### PR TITLE
conditional compilation for warp version 1 (precise), 2 (trusty) and 3

### DIFF
--- a/Hets.cabal
+++ b/Hets.cabal
@@ -135,9 +135,9 @@ Executable hets
 
   if flag(server)
     build-depends:
-        wai-extra >= 0.4
-      , wai >= 0.4
-      , warp >= 0.4
+        wai-extra >= 2.0 && < 3.0
+      , wai >= 2.0 && < 3.0
+      , warp >= 2.0 && < 3.0
       , http-types >= 0.6 && < 0.9
       , text >= 0.5 && < 2.0
       , bytestring >= 0.9

--- a/var.mk
+++ b/var.mk
@@ -82,16 +82,22 @@ endif
 
 WAIEXTVERSION = $(shell $(HCPKG) latest wai-extra)
 WARPVERSION = $(shell $(HCPKG) latest warp)
-ifneq ($(findstring 1., $(WARPVERSION)),)
-  ifneq ($(findstring 1., $(WAIEXTVERSION)),)
+ifneq ($(findstring -1., $(WARPVERSION)),)
+  ifneq ($(findstring -1., $(WAIEXTVERSION)),)
+  SERVER_FLAG = -DSERVER -DWARP1
+  endif
+endif
+ifneq ($(findstring -2., $(WARPVERSION)),)
+  ifneq ($(findstring -2., $(WAIEXTVERSION)),)
   SERVER_FLAG = -DSERVER
   endif
 endif
-ifneq ($(findstring 2., $(WARPVERSION)),)
-  ifneq ($(findstring 2., $(WAIEXTVERSION)),)
-  SERVER_FLAG = -DSERVER
+ifneq ($(findstring -3., $(WARPVERSION)),)
+  ifneq ($(findstring -3., $(WAIEXTVERSION)),)
+  SERVER_FLAG = -DSERVER -DWARP3
   endif
 endif
+
 
 PARSEC1VERSION = $(shell $(HCPKG) latest parsec1)
 ifneq ($(findstring 1.0., $(PARSEC1VERSION)),)


### PR DESCRIPTION
liftIO is/was only needed for warp-1 but is identity for warp-2. New installations will get warp-3 (by utils/installHetsPkgs.sh). Therefore these adjustments are necessary. Hets.cabal only supports the current warp-2 (for travis).
