### PR TITLE
removed taxonomy tool

### DIFF
--- a/var.mk
+++ b/var.mk
@@ -105,7 +105,6 @@ PARSEC_FLAG = -hide-package parsec -package parsec1
 endif
 
 ifneq ($(strip $(UNI_PACKAGE)),)
-TESTTARGETFILES += Taxonomy/taxonomyTool.hs
   ifeq ($(strip $(HTTP_PACKAGE)),)
   TESTTARGETFILES += SoftFOL/tests/CMDL_tests.hs
   endif


### PR DESCRIPTION
because in fgl 5.5. Data.Graph.Inductive.Graphviz was moved to graphviz
