### PR TITLE
Percent encode

### DIFF
--- a/Common/LibName.hs
+++ b/Common/LibName.hs
@@ -37,6 +37,7 @@ import Common.DocUtils
 import Common.Id
 import Common.IRI
 import Common.Keywords
+import Common.Percent
 import Common.Utils
 
 import Data.Char
@@ -91,7 +92,7 @@ emptyLibName s = iriLibName .
 
 filePathToIri :: FilePath -> IRI
 filePathToIri fp = fromMaybe (error $ "filePathToIri: " ++ fp)
-  . parseIRIReference $ escapeIRIString isUnescapedInIRI fp
+  . parseIRIReference $ encodeBut (\ c -> isUnreserved c || isReserved c) fp
 
 filePathToLibId :: FilePath -> IRI
 filePathToLibId = setAngles True . filePathToIri

--- a/OMDoc/DataTypes.hs
+++ b/OMDoc/DataTypes.hs
@@ -20,7 +20,7 @@ import Common.Amalgamate (readShow)
 import Common.Id
 import Common.Lexer
 import Common.AnnoParser
-import Common.IRI (escapeIRIString)
+import Common.Percent (encodeBut)
 
 import Data.List
 import Data.Typeable
@@ -297,7 +297,7 @@ nameDecode s =
 
 nameToString :: UniqName -> String
 nameToString (s, i) =
-    let s' = escapeIRIString (`notElem` "/?%#") s
+    let s' = encodeBut (`notElem` "/?%#") s
     in if i > 0 then nameEncode ("over_" ++ show i) [s'] else s'
 
 -- * Constructing/Extracting Values

--- a/OMDoc/XmlInterface.hs
+++ b/OMDoc/XmlInterface.hs
@@ -25,7 +25,7 @@ import OMDoc.DataTypes
 
 import Common.Utils (splitBy)
 import Common.Result
-import Common.IRI (isUnescapedInIRI, escapeIRIString, unEscapeString)
+import Common.Percent
 
 import Data.Maybe
 import Data.List
@@ -170,10 +170,10 @@ toOmobj c = inAContent el_omobj [attr_om] $ Just c
 {- url escaping and unescaping.
 We use ? and / as special characters, so we need them to be encoded in names -}
 urlEscape :: String -> String
-urlEscape = escapeIRIString isUnescapedInIRI
+urlEscape = encodeBut (`notElem` "%/?")
 
 urlUnescape :: String -> String
-urlUnescape = unEscapeString
+urlUnescape = decode
 
 
 -- to- and from-string functions


### PR DESCRIPTION
The old encoding was wrong because unicode characters cannot be encoded by two hex-digits. Latin1 characters have been encoded differently. The standard is to go via a UTF8 encoded byte string.

(In query strings of the hets-api "+" may still be used instead of a blank, i.e. "?theorems=ax1+ax2".
A "+" in a theorem name should be written "XP", "X" as "XX" and " " (blank) as "XB".)

@sternk please review 
