### PR TITLE
Json maps as pairlists

### DIFF
--- a/Common/Json.hs
+++ b/Common/Json.hs
@@ -27,18 +27,25 @@ module Common.Json
   , rangedToJson
   , anToJson
   , tagJson
+  , pJson
   ) where
 
 import Common.AS_Annotation
-import Common.Doc
+import Common.Doc as Doc
 import Common.DocUtils
 import Common.GlobalAnnotations
 import Common.Id
+import Common.Parsec
 import Common.Result
 
 import Data.Char
 import Data.List
+import Data.Maybe
 import Data.Ratio
+
+import Numeric
+
+import Text.ParserCombinators.Parsec
 
 data Json
   = JString String
@@ -65,19 +72,38 @@ instance Show Json where
     JArray js -> show js
     JObject m -> '{'
       : intercalate ","
-        (map (\ (k, v) -> show k ++ ":" ++ show v)
-        m)
+        (map (\ (k, v) -> show k ++ ":" ++ show v) m)
       ++ "}"
 
 ppJson :: Json -> String
-ppJson = show . pJ
+ppJson = show . pJ False
 
-pJ :: Json -> Doc
-pJ j = case j of
-  JArray js -> brackets . sep . punctuate comma $ map pJ js
-  JObject m -> specBraces . sep . punctuate comma
-    $ map (\ (k, v) -> sep [text (show k), colon <+> pJ v]) m
+getOpBr :: Json -> Maybe Doc
+getOpBr j = case j of
+  JArray (j1 : _) -> Just $ lbrack <> fromMaybe empty (getOpBr j1)
+  JObject _ -> Just lbrace
+  _ -> Nothing
+
+pJ :: Bool -> Json -> Doc
+pJ omitOpBr j = case j of
+  JArray js@(j1 : _) -> let md = getOpBr j1 in
+    cat [ if omitOpBr then empty else lbrack <> fromMaybe empty md
+        , sep (pJA (isJust md) js) ]
+  JObject m -> sep [ if omitOpBr then empty else lbrace
+    , sep . punctuate comma
+      $ map (\ (k, v) -> let md = getOpBr v in
+        cat [ text (show k) <> colon <+> fromMaybe empty md
+            , Doc.space <> pJ (isJust md) v]) m
+    , rbrace ]
   _ -> text (show j)
+
+pJA :: Bool -> [Json] -> [Doc]
+pJA omitOpBr l = case l of
+  j1 : r@(j2 : _) -> let md = getOpBr j2 in
+      (pJ omitOpBr j1 <> comma <+> fromMaybe empty md)
+      : pJA (isJust md) r
+  [j] -> [pJ omitOpBr j <> rbrack]
+  [] -> []
 
 mkJStr :: String -> Json
 mkJStr = JString
@@ -116,3 +142,46 @@ anToJson ga = mkJObj . rangedToJson "annotation" ga
 
 tagJson :: String -> Json -> Json
 tagJson s j = mkJObj [(s, j)]
+
+pStr :: CharParser st String
+pStr = do
+  s <- getInput
+  case reads s of
+    [(s0, s1)] -> setInput s1 >> return s0
+    _ -> pzero
+
+pJBool :: CharParser st Json
+pJBool = choice
+  $ map (\ b -> let j = mkJBool b in string (show j) >> return j)
+    [False, True]
+
+pJNull :: CharParser st Json
+pJNull = string (show JNull) >> return JNull
+
+pJNumber :: CharParser st Json
+pJNumber = do
+  s <- getInput
+  case readSigned readFloat s of
+    [(n, s1)] -> setInput s1 >> return (JNumber n)
+    _ -> pzero
+
+pJson :: CharParser st Json
+pJson = tok $ choice [fmap mkJStr pStr, pJBool, pJNull, pJNumber, pJArr, pJObj]
+
+tok :: CharParser st a -> CharParser st a
+tok p = p << spaces
+
+cTok :: Char -> CharParser st ()
+cTok = forget . tok . char
+
+commaTok :: CharParser st ()
+commaTok = cTok ','
+
+pJArr :: CharParser st Json
+pJArr = cTok '[' >> fmap JArray (sepBy1 pJson commaTok) << cTok ']'
+
+pJObj :: CharParser st Json
+pJObj = cTok '{' >> fmap JObject (sepBy1 pJPair commaTok) << cTok '}'
+
+pJPair :: CharParser st JPair
+pJPair = pair (tok pStr << cTok ':') pJson

--- a/Common/testjson.hs
+++ b/Common/testjson.hs
@@ -1,0 +1,9 @@
+import Common.Json
+import Common.Parsec
+import Text.ParserCombinators.Parsec
+
+main = do
+  str <- getContents
+  case parse (spaces >> pJson << eof) "" str of
+    Right e -> putStr $ ppJson e
+    Left e -> print e


### PR DESCRIPTION
pair lists have the advantage that the order of labels is not sorted. 
I tried to create compact (and still readable) output. Maybe longer output is fine, too.
Because I was not sure if brackets still match I wrote a parser and tested that the .json output for the basic libraries can be parsed and printed again with the same result. 

I've also looked into http://hackage.haskell.org/package/json
