### PR TITLE
added header argument to wget call for #1351

### DIFF
--- a/Common/Http.hs
+++ b/Common/Http.hs
@@ -19,7 +19,8 @@ import System.Exit
 loadFromUri :: String -> IO (Either String String)
 loadFromUri str = do
   (code, out, err) <- executeProcess "wget"
-     ["--no-check-certificate", "-O", "-", str] ""
+     ["--header=\"Accept: */*; q=0.1, text/plain\"",
+      "--no-check-certificate", "-O", "-", str] ""
   return $ case code of
     ExitSuccess -> Right out
     _ -> Left err


### PR DESCRIPTION
fixes #1351. @0robustus1 there is not much to review. Can you do it?

However, a major problem could be that OWL ontologies are loaded by the OWL-API, where loading (of imports) is not in our hands.  Does this explain #1340?
