### PR TITLE
fix argument escaping for wget-Headers

### DIFF
--- a/Common/Http.hs
+++ b/Common/Http.hs
@@ -19,7 +19,7 @@ import System.Exit
 loadFromUri :: String -> IO (Either String String)
 loadFromUri str = do
   (code, out, err) <- executeProcess "wget"
-     ["--header=\"Accept: */*; q=0.1, text/plain\"",
+     ["--header=Accept: */*; q=0.1, text/plain",
       "--no-check-certificate", "-O", "-", str] ""
   return $ case code of
     ExitSuccess -> Right out


### PR DESCRIPTION
Since executeProcess seems to be similar to IO.popen with regards to
argument/parameter handling we can't actually escape arguments unless
the command requires us to do so. wget sends the headers without change
to the server which will result in an error since accept headers are not
to be grouped by quotation marks.
