### PR TITLE
adjust Hets-lib and (possibly) change Isabelle dependency

### DIFF
--- a/utils/debian/auto-package/debian-common/control
+++ b/utils/debian/auto-package/debian-common/control
@@ -3,7 +3,7 @@ Section: misc
 Priority: extra
 Maintainer: Corneliu-Claudiu Prodescu <cprodescu@googlemail.com>
 Build-Depends:
- debhelper (>=7.4.15),
+ debhelper(>=7.4.15),
  ghc,
  happy,
  ghc-haddock,
@@ -59,6 +59,6 @@ Description: Package containing the documentation for Heterogeneous Tool Set.
 
 Package: hets
 Architecture: all
-Depends: hets-core, hets-ontology, hets-doc, isabelle-installer, ${misc:Depends}
+Depends: hets-core, hets-ontology, hets-doc, isabelle, ${misc:Depends}
 Description: Package containing the full Hets - the Heterogeneous Tool Set.
  This is a meta-package containing the full Hets system.


### PR DESCRIPTION
@sternk I intend to make a last hets release that depends on Isabelle 2012 so that there is no conflict when packaging Isabelle 2014. I'm not sure if the version selection "(==2012)" will work, though
