### PR TITLE
let hets filetype report mimetypes

### DIFF
--- a/Common/FileType.hs
+++ b/Common/FileType.hs
@@ -64,7 +64,7 @@ getFileType :: Maybe FilePath -> Maybe String -> FilePath -> ResultT IO String
 getFileType mmf mp fn = ResultT $ do
   (ex, out, err) <- executeProcess "file"
     (maybe [] (\ mf -> ["-m", mf]) mmf
-    ++ maybeToList mp ++ ["-b", fn]) ""
+    ++ maybeToList mp ++ ["-b", fn] ++ ["--mime-type"]) ""
   let unexp = "unexpected file type "
   return $ case (ex, lines out) of
     (ExitSuccess, ls) -> if null err then case ls of


### PR DESCRIPTION
Shall close #1418.

---

Hets' filetype determination mechanic (via the MAGIC file) should
produce mime-type responses instead of the (arbitrary) text type
responses.
