### PR TITLE
Rename REST API command translate to translations.

### DIFF
--- a/PGIP/Server.hs
+++ b/PGIP/Server.hs
@@ -309,7 +309,7 @@ nodeEdgeIdes = ["nodes", "edges"]
 
 newRESTIdes :: [String]
 newRESTIdes =
-  [ "dg", "translate", "provers", "consistency-checkers", "prove"
+  [ "dg", "translations", "provers", "consistency-checkers", "prove"
   , "consistency-check" ]
 
 queryFail :: String -> WebResponse
@@ -418,7 +418,7 @@ parseRESTfull opts sessRef pathBits qOpts splitQuery meth respond = let
         then getResponseAux newOpts . Query (NewDGQuery libIri $ cmdList
             ++ Set.toList (Set.fromList $ optFlags ++ qOpts))
          $ case newIde of
-           "translate" -> case nodeM of
+           "translations" -> case nodeM of
              Nothing -> GlTranslations
              Just n -> nodeQuery n $ NcTranslations Nothing
            _ | elem newIde ["provers", "consistency-checkers"] ->


### PR DESCRIPTION
This shall fix #1423.

Before renaming, I tested if the command `translations` was free by calling

```
http://localhost:8000/translations/file%3A%2F%2F%2Fprivate%2Ftmp%2FGroups.casl
```

which resulted in 

```
*** Error:
file does not exist: /var/folders/sq/9gmlj7991qq89myy2091r7vh0000gn/T/MyHetsLib/translations/file:///private/tmp/Groups.env
no input found for: translations/file:///private/tmp/Groups.casl
```

So I assume this command was really free.
