### PR TITLE
Allow to pass `theorems` in prove-request

### DIFF
--- a/PGIP/Server.hs
+++ b/PGIP/Server.hs
@@ -330,6 +330,7 @@ parseRESTfull opts sessRef pathBits qOpts splitQuery meth respond = let
   library = lookup2 "library"
   format = lookup2 "format"
   nodeM = lookup2 "node"
+  theoremsM = parseTheorems $ lookup2 "theorems"
   transM = lookup2 "translation"
   proverM = lookup2 "prover"
   consM = lookup2 "consistency-checker"
@@ -431,7 +432,7 @@ parseRESTfull opts sessRef pathBits qOpts splitQuery meth respond = let
                  pm = if isProve then GlProofs else GlConsistency
                  pc = ProveCmd pm
                    (not (isProve && isJust inclM) || incl)
-                   (if isProve then proverM else consM) transM timeout [] True
+                   (if isProve then proverM else consM) transM timeout theoremsM True
              in case nodeM of
              Nothing -> GlAutoProve pc
              Just n -> nodeQuery n $ ProveNode pc
@@ -487,6 +488,11 @@ parseRESTfull opts sessRef pathBits qOpts splitQuery meth respond = let
     {- create failure response if request method is not known
     (should never happen) -}
     _ -> respond $ mkResponse "" status400 ""
+
+parseTheorems :: Maybe String -> [String]
+parseTheorems mstr = case mstr of
+  Nothing -> []
+  Just str -> splitOn ',' str
 
 mkMenuResponse :: WebResponse
 mkMenuResponse respond =


### PR DESCRIPTION
There already was a `theorems` command, which was not used in the
RESTful API. It can now be passed to select theorems to be proven. If
it is empty or omitted, all theorems in the node/theory will be proven.

This shall fix #1425. Other than stated in the issue, instead of the key `goals`, I chose the key `theorems` because the availability of that one was already implemented and it suits to the situation.

This does not yet accept the options via POST. This shall be done in a new issue.

To try this, simply start the hets server and call

```
http://localhost:8000/prove/file%3A%2F%2F%2Ftmp%2FGroups.casl?node=Group;theorems=zero_plus
```

in your browser while having the following `/tmp/Group.casl`:

```
spec Group =
  sort s
  ops 0:s;
      -__ :s->s;
      __+__ :s*s->s, assoc
  forall x,y:s
  . x+(-x) = 0
  . x+0=x %(leftunit)%
  . 0+x=x %(rightunit)% %implied
  . 0+0=0 %(zero_plus)% %implied
end

spec Empty =
  sort t
end
```
