### PR TITLE
Allow selection of axioms.

### DIFF
--- a/GUI/GtkAutomaticProofs.hs
+++ b/GUI/GtkAutomaticProofs.hs
@@ -253,7 +253,7 @@ performAutoProof gi inclThms timeout update (Finder _ pr cs i) listNodes nodes =
            res <- maybe (return Nothing) (\ g_th -> do
                     Result ds ms <- runResultT
                         (do
-                          (a, b) <- autoProofAtNode inclThms timeout [] g_th
+                          (a, b) <- autoProofAtNode inclThms timeout [] [] g_th
                             (pr, c)
                           liftIO $ addCommandHistoryToState (intState gi)
                             (fst b) (Just (pr, c)) (snd b) (name fn)

--- a/PGIP/Query.hs
+++ b/PGIP/Query.hs
@@ -87,7 +87,7 @@ nodeCommands :: [String]
 nodeCommands = map showNodeCmd nodeCmds ++ comorphs ++ ["prove"]
 
 proveParams :: [String]
-proveParams = ["timeout", "include", "prover", "translation", "theorems"]
+proveParams = ["timeout", "include", "prover", "translation", "theorems", "axioms"]
 
 edgeCommands :: [String]
 edgeCommands = ["edge"]
@@ -133,9 +133,9 @@ data QueryKind =
   | GlShowProverWindow ProverMode
   | GlAutoProve ProveCmd
   | NodeQuery NodeIdOrName NodeCommand
-  | EdgeQuery Int String
+  | EdgeQuery Int String deriving (Show, Eq)
 
-data ProverMode = GlProofs | GlConsistency
+data ProverMode = GlProofs | GlConsistency deriving (Show, Eq)
 
 data ProveCmd = ProveCmd
   { pcProverMode :: ProverMode
@@ -144,13 +144,14 @@ data ProveCmd = ProveCmd
   , pcTranslation :: Maybe String
   , pcTimeout :: Maybe Int
   , pcTheoremsOrNodes :: [String]
-  , pcXmlResult :: Bool }
+  , pcXmlResult :: Bool
+  , pcAxioms :: [String] } deriving (Show, Eq)
 
 data NodeCommand =
     NcCmd NodeCmd
   | NcProvers ProverMode (Maybe String) -- optional comorphism
   | NcTranslations (Maybe String) -- optional prover name
-  | ProveNode ProveCmd
+  | ProveNode ProveCmd deriving (Show, Eq)
 
 -- | the path is not empty and leading slashes are removed
 anaUri :: [String] -> [QueryPair] -> [String] -> Either String Query
@@ -336,7 +337,7 @@ anaNodeQuery ans i moreTheorems incls pss =
       pp = ProveNode $ ProveCmd GlProofs (not (null incls) || case incl of
         Nothing -> True
         Just str -> map toLower str `notElem` ["f", "false"])
-        prover trans timeLimit theorems False
+        prover trans timeLimit theorems False []
       noPP = null incls && null pps
       noIncl = null incls && isNothing incl && isNothing timeLimit
       cmds = map (\ a -> (showNodeCmd a, a)) nodeCmds


### PR DESCRIPTION
This shall fix #1424. It adds the prove option `axioms`. `axioms` expects a comma separated list of axiom names which are supposed to be used in the proof attempt (white list).

To try this, simply start the hets server and call

```
http://localhost:8000/prove/file%3A%2F%2F%2Fprivate%2Ftmp%2FGroups.casl?node=Group;axioms=Ax2,leftunit,ga_assoc___%2B__
http://localhost:8000/prove/file%3A%2F%2F%2Fprivate%2Ftmp%2FGroups.casl?node=Group;axioms=Ax2,leftunit
```

in your browser while having the following /tmp/Group.casl:

```
library Examples/Groups

spec Group =
  sort s
  ops 0:s;
      -__ :s->s; %(inverse)%
      __+__ :s*s->s, assoc
  forall x,y:s
  . x+(-x) = 0
  . x+0=x %(leftunit)%
  . 0+x=x %(rightunit)% %implied
end
```

In another pull request (WIP) the options are expected as POST parameters because (a) the list of axioms can be very long and (b) using GET for a proof creation is not compliant to a RESTful API.
