### PR TITLE
Use POST data in non-GET requests for RESTful API

### DIFF
--- a/PGIP/Server.hs
+++ b/PGIP/Server.hs
@@ -333,10 +333,7 @@ parseRESTfull opts sessRef pathBits qOpts splitQuery postParams meth respond = l
   lookupParam :: String -> Maybe String
   lookupParam key = case meth of
     "GET" -> lookupGETParam key
-    -- For POST and others first check query string and then post data.
-    _ -> case lookupGETParam key of
-      Nothing -> lookup key postParams
-      justValue ->  justValue
+    _ -> lookup key postParams
   session = lookupParam "session" >>= readMaybe
   library = lookupParam "library"
   format = lookupParam "format"


### PR DESCRIPTION
This pull request fixes the second part of #1424: Previously, only parameters from the query string were used in the RESTful server. In this branch, it actually uses POST data, which allows for much more data to be received in a request.

Still, the query string params are preferred if they are supplied in order to keep compatibility to the previous behavior.

That is, if you execute 

```
curl -F myKey=myValueInPOST http://localhost:8000/prove/file%3A%2F%2F%2Fpath%2Fto%2Ffile.casl?myKey=myValueInGET
```

the hets RESTful server actually uses the value `myValueInGET` instead of `myValueInPOST`.
Personally, I don't like this behavior. It should only use the POST data, even if there is something specified in the query string.

Please tell me if it is important to stay compatible to the old style of using the query string params. If it's not the case, I will add a commit to only use the POST params in POST requests.
