### PR TITLE
1405 output proof details

### DIFF
--- a/CMDL/ProcessScript.hs
+++ b/CMDL/ProcessScript.hs
@@ -43,7 +43,7 @@ isNotDisproved G_theory {gTheorySens = el} =
 checkList :: [BasicProof] -> Bool
 checkList [] = False
 checkList (l : ls) = case l of
-            BasicProof _ (ProofStatus _ b _ _ _ _ _) -> case b of
+            BasicProof _ (ProofStatus _ b _ _ _ _ _ _) -> case b of
               Disproved -> True
               _ -> checkList ls
             _ -> checkList ls

--- a/CSL/Reduce_Interface.hs
+++ b/CSL/Reduce_Interface.hs
@@ -124,7 +124,8 @@ closedReduceProofStatus goalname proof_tree =
     , usedProver = reduceS
     , proofTree = proof_tree
     , usedTime = midnight
-    , tacticScript = TacticScript "" }
+    , tacticScript = TacticScript ""
+    , proofLines = [] }
 
 {-
 For Quantifier Elimination:

--- a/Logic/Prover.hs
+++ b/Logic/Prover.hs
@@ -179,7 +179,8 @@ data ProofStatus proof_tree = ProofStatus
     , usedProver :: String -- ^ name of prover
     , proofTree :: proof_tree
     , usedTime :: TimeOfDay
-    , tacticScript :: TacticScript }
+    , tacticScript :: TacticScript
+    , proofLines :: [String] }
     deriving (Show, Eq, Ord, Typeable)
 
 {- | constructs an open proof status with basic information filled in;
@@ -194,7 +195,8 @@ openProofStatus goalname provername proof_tree = ProofStatus
    , usedProver = provername
    , proofTree = proof_tree
    , usedTime = midnight
-   , tacticScript = TacticScript "" }
+   , tacticScript = TacticScript ""
+   , proofLines = [] }
 
 isProvedStat :: ProofStatus proof_tree -> Bool
 isProvedStat = isProvedGStat . goalStatus

--- a/PGIP/Server.hs
+++ b/PGIP/Server.hs
@@ -932,7 +932,15 @@ formatProofStatus ps =
   , unode "proofTree" $ show $ proofTree ps
   , unode "usedTime" $ formatUsedTime $ usedTime ps
   , unode "usedAxioms" $ formatUsedAxioms $ usedAxioms ps
+  , unode "proverOutput" $ formatProverOutput $ proofLines ps
   ]
+
+formatProverOutput :: [String] -> CData
+formatProverOutput ls =
+  CData { cdVerbatim = CDataVerbatim
+        , cdData = unlines ls
+        , cdLine = Nothing
+        }
 
 formatTacticScript :: ATPTacticScript -> [Element]
 formatTacticScript ts =

--- a/Proofs/AbstractState.hs
+++ b/Proofs/AbstractState.hs
@@ -16,6 +16,7 @@ It is also used by the CMDL interface.
 
 module Proofs.AbstractState
     ( G_prover (..)
+    , G_proof_tree (..)
     , getProverName
     , getCcName
     , getCcBatch

--- a/Proofs/BatchProcessing.hs
+++ b/Proofs/BatchProcessing.hs
@@ -219,8 +219,8 @@ genericProveBatch useStOpt tLimit extraOptions inclProvedThs saveProblem_batch
         recursion in that case
         add proved goals as axioms -}
         let res0 = proofStatus res_cfg
-            res = res0 { goalStatus =
-              case goalStatus res0 of
+            res = res0 { proofLines = resultOutput res_cfg,
+              goalStatus = case goalStatus res0 of
                 Open (Reason l) | err == ATPTLimitExceeded ->
                   Open (Reason $ "Timeout" : l)
                 r -> r }


### PR DESCRIPTION
Shall fix #1405.
## Example

Running
```
curl http://localhost:8000/prove/file%3A%2F%2F%2Ftmp%2FGroups.casl
```
with this `/tmp/Groups.casl`
```
spec Group =
  sort s
  ops 0:s;
      -__ :s->s;
      __+__ :s*s->s, assoc
  forall x,y:s
  . x+(-x) = 0
  . x+0=x %(leftunit)%
  . 0+x=x %(rightunit)% %implied
  . 0+0=0 %(zero_plus)% %implied
end

spec Empty =
  sort t
end
```
results in the following xml response
```xml
<?xml version='1.0' ?>
<Results>
  <Group>
    <results>
      <goal>
        <name>rightunit</name>
        <result>Proved</result>
        <details></details>
        <usedProver>SPASS</usedProver>
        <tacticScript>
          <timeLimit>1</timeLimit>
          <extraOpts>
            <option>-DocProof</option>
          </extraOpts>
        </tacticScript>
        <proofTree></proofTree>
        <usedTime>
          <seconds>0</seconds>
          <components>
            <hours>0</hours>
            <minutes>0</minutes>
            <seconds>0.000000000000</seconds>
          </components>
        </usedTime>
        <usedAxioms>
          <axiom>leftunit</axiom>
          <axiom>Ax2</axiom>
          <axiom>ga_assoc___+__</axiom>
        </usedAxioms>
        <proverOutput><![CDATA[
--------------------------SPASS-START-----------------------------
Input Problem:
1[0:Inp] ||  -> equal(o__Plus__(U,zero),U)**.
2[0:Inp] || equal(o__Plus__(zero,skc1),skc1)** -> .
3[0:Inp] ||  -> equal(o__Plus__(U,minus__(U)),zero)**.
4[0:Inp] ||  -> equal(o__Plus__(o__Plus__(U,V),W),o__Plus__(U,o__Plus__(V,W)))**.
 This is a unit equality problem.
 This is a problem that has, if any, a non-trivial domain model.
 The conjecture is ground.
 Axiom clauses: 3 Conjecture clauses: 1
 Inferences: IEqR=1 ISpR=1 ISpL=1
 Reductions: RFRew=1 RBRew=1 RFMRR=1 RBMRR=1 RObv=1 RUnC=1 RTaut=1 RFSub=1 RBSub=1
 Extras    : Input Saturation, No Selection, No Splitting, Full Reduction,  Ratio: 5, FuncWeight: 1, VarWeight: 1
 Precedence: o__Plus__ > minus__ > skc1 > skc0 > zero
 Ordering  : KBO
Processed Problem:

Worked Off Clauses:

Usable Clauses:
1[0:Inp] ||  -> equal(o__Plus__(U,zero),U)**.
2[0:Inp] || equal(o__Plus__(zero,skc1),skc1)** -> .
3[0:Inp] ||  -> equal(o__Plus__(U,minus__(U)),zero)**.
4[0:Inp] ||  -> equal(o__Plus__(o__Plus__(U,V),W),o__Plus__(U,o__Plus__(V,W)))**.
	Given clause: 1[0:Inp] ||  -> equal(o__Plus__(U,zero),U)**.
	Given clause: 2[0:Inp] || equal(o__Plus__(zero,skc1),skc1)** -> .
	Given clause: 3[0:Inp] ||  -> equal(o__Plus__(U,minus__(U)),zero)**.
	Given clause: 4[0:Inp] ||  -> equal(o__Plus__(o__Plus__(U,V),W),o__Plus__(U,o__Plus__(V,W)))**.
	Given clause: 11[0:SpR:1.0,4.0] ||  -> equal(o__Plus__(U,o__Plus__(zero,V)),o__Plus__(U,V))**.
	Given clause: 21[0:Rew:1.0,20.0] ||  -> equal(o__Plus__(U,minus__(zero)),U)**.
	Given clause: 8[0:SpR:4.0,3.0] ||  -> equal(o__Plus__(U,o__Plus__(V,minus__(o__Plus__(U,V)))),zero)**.
	Given clause: 12[0:SpR:3.0,4.0] ||  -> equal(o__Plus__(U,o__Plus__(minus__(U),V)),o__Plus__(zero,V))**.
	Given clause: 67[0:Rew:1.0,61.0] ||  -> equal(o__Plus__(zero,minus__(minus__(U))),U)**.
SPASS V 3.7
SPASS beiseite: Proof found.
Problem: Read from stdin.
SPASS derived 48 clauses, backtracked 0 clauses, performed 0 splits and kept 17 clauses.
SPASS allocated 46026 KBytes.
SPASS spent	0:00:00.02 on the problem.
		0:00:00.01 for the input.
		0:00:00.01 for the FLOTTER CNF translation.
		0:00:00.00 for inferences.
		0:00:00.00 for the backtracking.
		0:00:00.00 for the reduction.


Here is a proof with depth 3, length 11 :
1[0:Inp] ||  -> equal(o__Plus__(U,zero),U)**.
2[0:Inp] || equal(o__Plus__(zero,skc1),skc1)** -> .
3[0:Inp] ||  -> equal(o__Plus__(U,minus__(U)),zero)**.
4[0:Inp] ||  -> equal(o__Plus__(o__Plus__(U,V),W),o__Plus__(U,o__Plus__(V,W)))**.
11[0:SpR:1.0,4.0] ||  -> equal(o__Plus__(U,o__Plus__(zero,V)),o__Plus__(U,V))**.
12[0:SpR:3.0,4.0] ||  -> equal(o__Plus__(U,o__Plus__(minus__(U),V)),o__Plus__(zero,V))**.
61[0:SpR:3.0,12.0] ||  -> equal(o__Plus__(zero,minus__(minus__(U))),o__Plus__(U,zero))**.
67[0:Rew:1.0,61.0] ||  -> equal(o__Plus__(zero,minus__(minus__(U))),U)**.
77[0:SpR:67.0,11.0] ||  -> equal(o__Plus__(U,minus__(minus__(V))),o__Plus__(U,V))**.
79[0:Rew:77.0,67.0] ||  -> equal(o__Plus__(zero,U),U)**.
80[0:UnC:79.0,2.0] ||  -> .
Formulae used in the proof : leftunit rightunit ax2 ga_assoc___Plus__

--------------------------SPASS-STOP------------------------------
]]></proverOutput>
      </goal>
      <goal>
        <name>zero_plus</name>
        <result>Proved</result>
        <details></details>
        <usedProver>SPASS</usedProver>
        <tacticScript>
          <timeLimit>1</timeLimit>
          <extraOpts>
            <option>-DocProof</option>
          </extraOpts>
        </tacticScript>
        <proofTree></proofTree>
        <usedTime>
          <seconds>0</seconds>
          <components>
            <hours>0</hours>
            <minutes>0</minutes>
            <seconds>0.000000000000</seconds>
          </components>
        </usedTime>
        <usedAxioms>
          <axiom>rightunit</axiom>
        </usedAxioms>
        <proverOutput><![CDATA[
--------------------------SPASS-START-----------------------------
Input Problem:
1[0:Inp] ||  -> equal(o__Plus__(zero,U),U)**.
2[0:Inp] ||  -> equal(o__Plus__(U,zero),U)**.
3[0:Inp] || equal(o__Plus__(zero,zero),zero)** -> .
4[0:Inp] ||  -> equal(o__Plus__(U,minus__(U)),zero)**.
5[0:Inp] ||  -> equal(o__Plus__(o__Plus__(U,V),W),o__Plus__(U,o__Plus__(V,W)))**.
 This is a unit equality problem.
 This is a problem that has, if any, a non-trivial domain model.
 The conjecture is ground.
 Axiom clauses: 4 Conjecture clauses: 1
 Inferences: IEqR=1 ISpR=1 ISpL=1
 Reductions: RFRew=1 RBRew=1 RFMRR=1 RBMRR=1 RObv=1 RUnC=1 RTaut=1 RFSub=1 RBSub=1
 Extras    : Input Saturation, No Selection, No Splitting, Full Reduction,  Ratio: 5, FuncWeight: 1, VarWeight: 1
 Precedence: o__Plus__ > minus__ > zero
 Ordering  : KBO
Processed Problem:

Worked Off Clauses:

Usable Clauses:
1[0:Inp] ||  -> equal(o__Plus__(zero,U),U)**.
2[0:Inp] ||  -> equal(o__Plus__(U,zero),U)**.
4[0:Inp] ||  -> equal(o__Plus__(U,minus__(U)),zero)**.
5[0:Inp] ||  -> equal(o__Plus__(o__Plus__(U,V),W),o__Plus__(U,o__Plus__(V,W)))**.
SPASS V 3.7
SPASS beiseite: Proof found.
Problem: Read from stdin.
SPASS derived 0 clauses, backtracked 0 clauses, performed 0 splits and kept 4 clauses.
SPASS allocated 45941 KBytes.
SPASS spent	0:00:00.02 on the problem.
		0:00:00.01 for the input.
		0:00:00.01 for the FLOTTER CNF translation.
		0:00:00.00 for inferences.
		0:00:00.00 for the backtracking.
		0:00:00.00 for the reduction.


Here is a proof with depth 0, length 4 :
1[0:Inp] ||  -> equal(o__Plus__(zero,U),U)**.
3[0:Inp] || equal(o__Plus__(zero,zero),zero)** -> .
6[0:Rew:1.0,3.0] || equal(zero,zero)* -> .
7[0:Obv:6.0] ||  -> .
Formulae used in the proof : rightunit zero_plus

--------------------------SPASS-STOP------------------------------
]]></proverOutput>
      </goal>
    </results>
  </Group>
</Results>
```