### PR TITLE
Add missing proofLines definitions.

### DIFF
--- a/OWL2/ProveFact.hs
+++ b/OWL2/ProveFact.hs
@@ -240,11 +240,6 @@ runFact sps cfg saveFact thName nGoal = do
         { tacticScript = tScript }
     disProvedStatus = defaultProofStatus {goalStatus = Disproved}
     provedStatus ut =
-      ProofStatus { goalName = senAttr nGoal
-                  , goalStatus = Proved True
-                  , usedAxioms = []
-                  , usedProver = proverName factProver
-                  , proofTree = emptyProofTree
-                  , usedTime = ut
-                  , tacticScript = tScript
-                  , proofLines = [] }
+      defaultProofStatus { goalStatus = Proved True
+                         , usedTime = ut
+                         , tacticScript = tScript }

--- a/OWL2/ProveFact.hs
+++ b/OWL2/ProveFact.hs
@@ -246,4 +246,5 @@ runFact sps cfg saveFact thName nGoal = do
                   , usedProver = proverName factProver
                   , proofTree = emptyProofTree
                   , usedTime = ut
-                  , tacticScript = tScript }
+                  , tacticScript = tScript
+                  , proofLines = [] }

--- a/QBF/ProveDepQBF.hs
+++ b/QBF/ProveDepQBF.hs
@@ -159,7 +159,8 @@ examineProof ps _ stdoutC _ exitCode nGoal tUsed _ =
                         , usedProver = proverName depQBFProver
                         , proofTree = emptyProofTree
                         , usedTime = tUsed
-                        , tacticScript = TacticScript "" }
+                        , tacticScript = TacticScript ""
+                        , proofLines = [] }
         getAxioms = map AS_Anno.senAttr (initialAxioms ps)
     in case getDepQBFResult exitCode stdoutC of
                DepQBFProved -> return (ATPSuccess, defaultStatus

--- a/QBF/ProveDepQBF.hs
+++ b/QBF/ProveDepQBF.hs
@@ -152,15 +152,10 @@ examineProof :: QBFProverState
              -> IO (ATPRetval, ProofStatus ProofTree)
 examineProof ps _ stdoutC _ exitCode nGoal tUsed _ =
     let
-        defaultStatus =
-            ProofStatus { goalName = senAttr nGoal
-                        , goalStatus = openGoalStatus
-                        , usedAxioms = []
-                        , usedProver = proverName depQBFProver
-                        , proofTree = emptyProofTree
-                        , usedTime = tUsed
-                        , tacticScript = TacticScript ""
-                        , proofLines = [] }
+        defaultStatus = (openProofStatus
+          (senAttr nGoal)
+          (proverName depQBFProver)
+          (emptyProofTree)) { usedTime = tUsed }
         getAxioms = map AS_Anno.senAttr (initialAxioms ps)
     in case getDepQBFResult exitCode stdoutC of
                DepQBFProved -> return (ATPSuccess, defaultStatus

--- a/SoftFOL/ProveHyperHyper.hs
+++ b/SoftFOL/ProveHyperHyper.hs
@@ -175,14 +175,10 @@ runHyper sps cfg saveTPTP thName nGoal =
           { tsTimeLimit = tl
           , tsExtraOpts = filter (isPrefixOf "#")
               $ lines $ prelTxt (show tl) ++ runTxt }
-        defProofStat = ProofStatus
-          { goalName = senAttr nGoal
-          , goalStatus = openGoalStatus
-          , usedAxioms = []
-          , usedProver = hyperS
-          , proofTree = emptyProofTree
-          , usedTime = midnight
-          , tacticScript = tScript }
+        defProofStat = (openProofStatus
+          (senAttr nGoal)
+          hyperS
+          emptyProofTree) { tacticScript = tScript }
     in
         if all checkOption simpleOptions
          then


### PR DESCRIPTION
In #1439 I forgot to set the `proofLines` in two files because the compiler didn't complain (I already had up to date object files for them). Now the compiler shouldn't complain about any missing `proofLines`.