### PR TITLE
1441 parse json data from request body

### DIFF
--- a/Common/Json.hs
+++ b/Common/Json.hs
@@ -13,7 +13,7 @@ inspired by Yuriy Iskra's json2-types hackage package
 -}
 
 module Common.Json
-  ( Json
+  ( Json (..)
   , ppJson
   , mkJStr
   , mkJBool


### PR DESCRIPTION
This shall fix #1441.

Form data is still supported, but not encouraged.
JSON request bodies are parsed with [aeson](http://hackage.haskell.org/package/aeson-0.8.0.2/docs/Data-Aeson.html), if the content type is set to `application/json`. Otherwise form data is assumed.

Now, aeson must be installed with cabal prior to compiling hets.

You can try the current behaviour with these calls:

* POST with Form data
```
curl -F theorems='["rightunit"]' -F axioms='["Ax2","ga_assoc___+__","leftunit"]' -F node=Group http://localhost:8000/prove/file%3A%2F%2F%2Fprivate%2Ftmp%2FGroups.casl
```
* POST with JSON
```
curl -X POST -H "Content-Type: application/json" -d '{"theorems": ["rightunit"], "axioms": ["Ax2","ga_assoc___+__","leftunit"], "node": "Group"}' http://localhost:8000/prove/file%3A%2F%2F%2Ftmp%2FGroups.casl
```
* GET with query string
```
curl http://localhost:8000/prove/file%3A%2F%2F%2Ftmp%2FGroups.casl\?theorems\=rightunit\;axioms\=Ax2,ga_assoc___%2B__,leftunit\;node\=Group
```
while having the `/tmp/Groups.casl`:
```casl
spec Group =
  sort s
  ops 0:s;
      -__ :s->s;
      __+__ :s*s->s, assoc
  forall x,y:s
  . x+(-x) = 0
  . x+0=x %(leftunit)%
  . 0+x=x %(rightunit)% %implied
  . 0+0=0 %(zero_plus)% %implied
end

spec Empty =
  sort t
end
```