### PR TITLE
check only if unexpanded IRIs are predefined

### DIFF
--- a/OWL2/AS.hs
+++ b/OWL2/AS.hs
@@ -294,9 +294,8 @@ preDefMaps sl pref = let
  in (sl, pref, sp)
 
 checkPredefAux :: PreDefMaps -> IRI -> Maybe (String, String)
-checkPredefAux (sl, pref, exPref) u = case expandedIRI u of
-  "" -> Nothing
-  _ -> let lp = localPart u in case namePrefix u of
+checkPredefAux (sl, pref, exPref) u =
+  let lp = localPart u in case namePrefix u of
     "http" -> case stripPrefix "//www." lp of
         Just q -> case stripPrefix "w3.org/" q of
             Just r -> case stripPrefix exPref r of
@@ -306,7 +305,8 @@ checkPredefAux (sl, pref, exPref) u = case expandedIRI u of
               Just s | elem s sl -> Just (pref, s)
               _ -> Nothing
         Nothing -> Nothing
-    pu | elem pu ["", pref] && elem lp sl -> Just (pref, lp)
+    pu | (null (expandedIRI u) && null pu || pu == pref) && elem lp sl
+      -> Just (pref, lp)
     _ -> Nothing
 
 checkPredef :: PreDefMaps -> IRI -> Bool

--- a/OWL2/AS.hs
+++ b/OWL2/AS.hs
@@ -294,8 +294,9 @@ preDefMaps sl pref = let
  in (sl, pref, sp)
 
 checkPredefAux :: PreDefMaps -> IRI -> Maybe (String, String)
-checkPredefAux (sl, pref, exPref) u = let lp = localPart u in
-  case namePrefix u of
+checkPredefAux (sl, pref, exPref) u = case expandedIRI u of
+  "" -> Nothing
+  _ -> let lp = localPart u in case namePrefix u of
     "http" -> case stripPrefix "//www." lp of
         Just q -> case stripPrefix "w3.org/" q of
             Just r -> case stripPrefix exPref r of
@@ -322,12 +323,13 @@ setDatatypePrefix iri = case isDatatypeKeyAux iri of
 
 -- | checks if the IRI is part of the built-in ones and puts the correct prefix
 setReservedPrefix :: IRI -> IRI
-setReservedPrefix iri
-    | isDatatypeKey iri && null (namePrefix iri) = setDatatypePrefix iri
-    | (isThing iri || isPredefDataProp iri || isPredefOWLAnnoProp iri
-        || isPredefObjProp iri) && null (namePrefix iri) = setPrefix "owl" iri
-    | isPredefRDFSAnnoProp iri = setPrefix "rdfs" iri
-    | otherwise = iri
+setReservedPrefix iri = case namePrefix iri of
+  ""
+    | isDatatypeKey iri -> setDatatypePrefix iri
+    | isThing iri || isPredefDataProp iri || isPredefOWLAnnoProp iri
+        || isPredefObjProp iri -> setPrefix "owl" iri
+    | isPredefRDFSAnnoProp iri -> setPrefix "rdfs" iri
+  _ -> iri
 
 stripReservedPrefix :: IRI -> IRI
 stripReservedPrefix = mkQName . getPredefName


### PR DESCRIPTION
This is supposed to fix #1431. Some tests should be made if other OWL examples are uneffected by this change. Could someone review this? 

XML creates expanded IRIs without a prefix.
"function Expand" checked for a predefined local part
(and a missing or matching prefix) and inserted a missing
prefix (which caused the problem of #1431).

This patch now only considers unexpanded IRIs as predefined.

Another minor change ensures that a prefix is always only set,
when it was empty before.
This was not case for the rdfs annotation properties:
label, comment, seeAlso, isDefinedBy