### PR TITLE
1452 add used translation to prove output of restful api

### DIFF
--- a/PGIP/Output/Formatting.hs
+++ b/PGIP/Output/Formatting.hs
@@ -1,0 +1,23 @@
+module PGIP.Output.Formatting
+  ( showComorph
+  , getWebProverName
+  , removeFunnyChars
+  ) where
+
+import Logic.Logic
+import Logic.Comorphism
+
+import Proofs.AbstractState
+
+import Data.Char
+
+showComorph :: AnyComorphism -> String
+showComorph (Comorphism cid) = removeFunnyChars . drop 1 . dropWhile (/= ':')
+  . map (\ c -> if c == ';' then ':' else c)
+  $ language_name cid
+
+removeFunnyChars :: String -> String
+removeFunnyChars = filter (\ c -> isAlphaNum c || elem c "_.:-")
+
+getWebProverName :: G_prover -> String
+getWebProverName = removeFunnyChars . getProverName

--- a/PGIP/Output/Proof.hs
+++ b/PGIP/Output/Proof.hs
@@ -10,6 +10,7 @@ module PGIP.Output.Proof
   , formatProofs
   ) where
 
+import PGIP.Output.Formatting
 import PGIP.Output.Mime
 
 import Interfaces.GenericATPState (tsTimeLimit, tsExtraOpts)
@@ -78,7 +79,7 @@ formatProofs format options proofs = case format of
           then Just goalDetails
           else Nothing
       , usedProver = fmap LP.usedProver proofStatusM
-      , usedTranslation = show translation --FIXME
+      , usedTranslation = showComorph translation
       , tacticScript = fmap convertTacticScript proofStatusM
       , proofTree = fmap (show . LP.proofTree) proofStatusM
       , usedTime = fmap (convertTime . LP.usedTime) proofStatusM

--- a/PGIP/Server.hs
+++ b/PGIP/Server.hs
@@ -12,6 +12,7 @@ Portability :  non-portable (via imports)
 
 module PGIP.Server (hetsServer) where
 
+import PGIP.Output.Formatting
 import PGIP.Output.Mime
 import PGIP.Output.Proof
 
@@ -1330,17 +1331,6 @@ getProverAndComorph mp mc subL = do
    return $ case mp of
         Nothing -> spps
         _ -> filterByProver mp ps
-
-showComorph :: AnyComorphism -> String
-showComorph (Comorphism cid) = removeFunnyChars . drop 1 . dropWhile (/= ':')
-  . map (\ c -> if c == ';' then ':' else c)
-  $ language_name cid
-
-removeFunnyChars :: String -> String
-removeFunnyChars = filter (\ c -> isAlphaNum c || elem c "_.:-")
-
-getWebProverName :: G_prover -> String
-getWebProverName = removeFunnyChars . getProverName
 
 getFullProverList :: ProverMode -> Maybe String -> DGraph -> IO String
 getFullProverList mp mt = fmap (formatProvers mp) . foldM


### PR DESCRIPTION
This shall fix #1452.
The new prove-output looks like this (truncated):
```bash
curl -X POST -H "Content-Type: application/json" -d '{"format": "json", "translation": "CASL2SubCFOLNoMembershipOrCast:CASL2SoftFOL"}' http://localhost:8000/prove/file%3A%2F%2F%2Fpath%2Fto%2FSimple_Implications.casl
```
```json
[{
"node": "Empty",
"goals": [{
 "name": "Ax1",
 "result": "Proved",
 "details": "",
 "usedProver": "SPASS",
 "usedTranslation": "CASL2SubCFOLNoMembershipOrCast:CASL2SoftFOL",
 ...
 }]
}, ...]
}]
```