### PR TITLE
1384 json output for provers and translations

### DIFF
--- a/PGIP/Output/Formatting.hs
+++ b/PGIP/Output/Formatting.hs
@@ -1,8 +1,11 @@
 module PGIP.Output.Formatting
-  ( showComorph
-  , getWebProverName
+  ( getWebProverName
+  , showComorph
+  , showProversOnly
   , removeFunnyChars
   ) where
+
+import Common.Utils
 
 import Logic.Logic
 import Logic.Comorphism
@@ -21,3 +24,6 @@ removeFunnyChars = filter (\ c -> isAlphaNum c || elem c "_.:-")
 
 getWebProverName :: G_prover -> String
 getWebProverName = removeFunnyChars . getProverName
+
+showProversOnly :: [(AnyComorphism, [String])] -> [String]
+showProversOnly = nubOrd . concatMap snd

--- a/PGIP/Output/Provers.hs
+++ b/PGIP/Output/Provers.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE CPP, TypeFamilies, DeriveDataTypeable #-}
+
+module PGIP.Output.Provers
+  ( formatProvers
+  ) where
+
+import PGIP.Output.Formatting
+import PGIP.Output.Mime
+
+import PGIP.Query (ProverMode (..))
+
+import Logic.Comorphism (AnyComorphism)
+
+import Common.Json (ppJson, asJson)
+import Common.ToXml (asXml)
+
+import Text.XML.Light (ppTopElement)
+
+import Data.Data
+
+type ProversFormatter = ProverMode ->
+                        [(AnyComorphism, [String])] -> (String, String)
+
+formatProvers :: Maybe String -> ProversFormatter
+formatProvers format proverMode availableProvers = case format of
+  Just "json" -> formatAsJSON
+  _ -> formatAsXML
+  where
+  computedProvers :: Provers
+  computedProvers =
+    let proverNames = showProversOnly availableProvers in
+    case proverMode of
+      GlProofs -> emptyProvers { provers = Just proverNames }
+      GlConsistency -> emptyProvers { consistencyCheckers = Just proverNames }
+
+  formatAsJSON :: (String, String)
+  formatAsJSON = (jsonC, ppJson $ asJson computedProvers)
+
+  formatAsXML :: (String, String)
+  formatAsXML = (xmlC, ppTopElement $ asXml computedProvers)
+
+data Provers = Provers
+  { provers :: Maybe [String]
+  , consistencyCheckers :: Maybe [String]
+  } deriving (Show, Typeable, Data)
+
+emptyProvers :: Provers
+emptyProvers = Provers { provers = Nothing, consistencyCheckers = Nothing }

--- a/PGIP/Output/Translations.hs
+++ b/PGIP/Output/Translations.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE CPP, TypeFamilies, DeriveDataTypeable #-}
+
+module PGIP.Output.Translations
+  ( formatTranslations
+  ) where
+
+import PGIP.Output.Formatting
+import PGIP.Output.Mime
+
+import Logic.Comorphism (AnyComorphism)
+import Proofs.AbstractState (G_prover)
+
+import Common.Json (ppJson, asJson)
+import Common.ToXml (asXml)
+import Common.Utils
+
+import Text.XML.Light (ppTopElement)
+
+import Data.Data
+
+type TranslationsFormatter = [(G_prover, AnyComorphism)] -> (String, String)
+
+formatTranslations :: Maybe String -> TranslationsFormatter
+formatTranslations format comorphisms = case format of
+  Just "json" -> formatAsJSON
+  _ -> formatAsXML
+  where
+  convertedTranslations :: Translations
+  convertedTranslations = Translations
+    { translations = nubOrd $ map (showComorph . snd) comorphisms }
+
+  formatAsJSON :: (String, String)
+  formatAsJSON = (jsonC, ppJson $ asJson convertedTranslations)
+
+  formatAsXML :: (String, String)
+  formatAsXML = (xmlC, ppTopElement $ asXml convertedTranslations)
+
+data Translations = Translations
+  { translations :: [String]
+  } deriving (Show, Typeable, Data)

--- a/PGIP/Server.hs
+++ b/PGIP/Server.hs
@@ -1340,9 +1340,6 @@ getFullProverList mp mt = fmap (formatProvers mp) . foldM
     . sublogicOfTh)
     $ maybeResult $ getGlobalTheory nd) [] . labNodesDG
 
-showProversOnly :: [(AnyComorphism, [String])] -> [String]
-showProversOnly = nubOrd . concatMap snd
-
 groupOnSnd :: Eq b => (a -> c) -> [(a, b)] -> [(b, [c])]
 groupOnSnd f =
   map (\ l@((_, b) : _) -> (b, map (f . fst) l)) . groupBy (on (==) snd)

--- a/PGIP/Server.hs
+++ b/PGIP/Server.hs
@@ -15,6 +15,7 @@ module PGIP.Server (hetsServer) where
 import PGIP.Output.Formatting
 import PGIP.Output.Mime
 import PGIP.Output.Proof
+import PGIP.Output.Translations
 import qualified PGIP.Output.Provers as OProvers
 
 import PGIP.Query as Query
@@ -916,7 +917,11 @@ getHetsResult opts updates sessRef (Query dgQ qk) format api pfOptions = do
                 RESTfulAPI -> OProvers.formatProvers format mp availableProvers
             GlTranslations -> do
               availableComorphisms <- liftIO $ getFullComorphList dg
-              return (xmlC, formatComorphs availableComorphisms)
+              return $ case api of
+                OldWebAPI ->
+                  (xmlC, formatComorphs availableComorphisms)
+                RESTfulAPI ->
+                  formatTranslations format availableComorphisms
             GlShowProverWindow prOrCons -> showAutoProofWindow dg k prOrCons
             GlAutoProve (ProveCmd prOrCons incl mp mt tl nds xForm axioms) -> do
               (newLib, nodesAndProofResults) <-
@@ -1011,7 +1016,11 @@ getHetsResult opts updates sessRef (Query dgQ qk) format api pfOptions = do
                             OProvers.formatProvers format mp availableProvers
                       NcTranslations mp -> do
                         availableComorphisms <- liftIO $ getComorphs mp subL
-                        return (xmlC, formatComorphs availableComorphisms)
+                        return $ case api of
+                          OldWebAPI ->
+                            (xmlC, formatComorphs availableComorphisms)
+                          RESTfulAPI ->
+                            formatTranslations format availableComorphisms
                       _ -> error "getHetsResult.NodeQuery."
             EdgeQuery i _ ->
               case getDGLinksById (EdgeId i) dg of

--- a/PGIP/Server.hs
+++ b/PGIP/Server.hs
@@ -1332,6 +1332,12 @@ getProverAndComorph mp mc subL = do
         Nothing -> spps
         _ -> filterByProver mp ps
 
+getProverList :: ProverMode -> Maybe String -> G_sublogics
+              -> IO [(AnyComorphism, [String])]
+getProverList mp mt subL = case mp of
+  GlProofs -> getProversAux mt subL
+  GlConsistency -> getConsCheckersAux mt subL
+
 getFullProverList :: ProverMode -> Maybe String -> DGraph -> IO String
 getFullProverList mp mt = fmap (formatProvers mp) . foldM
   (\ ls (_, nd) -> maybe (return ls) (fmap (++ ls) . case mp of


### PR DESCRIPTION
This adds JSON output and modifies XML output for `provers`, `consistency-checkers` and `translations` in the RESTful API. You can try it with the following commands:

```bash
# consistency-checkers with node
curl -X GET -H "Content-Type: application/json" http://localhost:8000/consistency-checkers/http%3A%2F%2Fdevelop.ontohub.org%2Fdefault%2Fpartial_order%3Fstrict_partial_order?format=json;node=strict_partial_order
curl -X GET -H "Content-Type: application/json" http://localhost:8000/consistency-checkers/http%3A%2F%2Fdevelop.ontohub.org%2Fdefault%2Fpartial_order%3Fstrict_partial_order?format=xml;node=strict_partial_order

# consistency-checkers without node
curl -X GET -H "Content-Type: application/json" http://localhost:8000/consistency-checkers/http%3A%2F%2Fdevelop.ontohub.org%2Fdefault%2Fpartial_order%3Fstrict_partial_order?format=json
curl -X GET -H "Content-Type: application/json" http://localhost:8000/consistency-checkers/http%3A%2F%2Fdevelop.ontohub.org%2Fdefault%2Fpartial_order%3Fstrict_partial_order?format=xml

# provers with node
curl -X GET -H "Content-Type: application/json" http://localhost:8000/provers/http%3A%2F%2Fdevelop.ontohub.org%2Fdefault%2Fpartial_order%3Fstrict_partial_order?format=json;node=strict_partial_order
curl -X GET -H "Content-Type: application/json" http://localhost:8000/provers/http%3A%2F%2Fdevelop.ontohub.org%2Fdefault%2Fpartial_order%3Fstrict_partial_order?format=xml;node=strict_partial_order

# provers without node
curl -X GET -H "Content-Type: application/json" http://localhost:8000/provers/http%3A%2F%2Fdevelop.ontohub.org%2Fdefault%2Fpartial_order%3Fstrict_partial_order?format=json
curl -X GET -H "Content-Type: application/json" http://localhost:8000/provers/http%3A%2F%2Fdevelop.ontohub.org%2Fdefault%2Fpartial_order%3Fstrict_partial_order?format=xml

# translations
curl -X GET -H "Content-Type: application/json" http://localhost:8000/translations/http%3A%2F%2Fdevelop.ontohub.org%2Fdefault%2Fpartial_order%3Fstrict_partial_order?format=json
curl -X GET -H "Content-Type: application/json" http://localhost:8000/translations/http%3A%2F%2Fdevelop.ontohub.org%2Fdefault%2Fpartial_order%3Fstrict_partial_order?format=xml
```

For example the first two commands output:
```json
{
"consistencyCheckers": [
 "darwin-non-fd", "darwin", "eprover", "truth tables"]
}
```
```xml
<?xml version='1.0' ?>
<Provers>
  <consistencyCheckers>
    <li>darwin-non-fd</li>
    <li>darwin</li>
    <li>eprover</li>
    <li>truth tables</li>
  </consistencyCheckers>
</Provers>
```
The other ones are analogous.