### PR TITLE
Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_install:
  - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
  - travis_retry sudo apt-get update
  - travis_retry sudo apt-get install cabal-install-$CABALVER ghc-$GHCVER happy-1.19.4 alex-3.1.3
- - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:/opt/alex/3.1.3/bin:/opt/happy/1.19.4/bin:$PATH
+ - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:/opt/alex/3.1.3/bin:/opt/happy/1.19.4/bin:$HOME/.cabal/bin:$PATH
  - sudo apt-get update -qq
  - sudo apt-get install -qq zlib1g-dev libncurses-dev libcairo2-dev libglib2.0-dev libpango1.0-dev libgtk2.0-dev libglade2-dev
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,11 @@ before_install:
 install:
  - travis_retry cabal update
  - cabal install gtk2hs-buildtools
- - cabal install glade
+ - cabal install glade parsec1
  - cabal install -v --only-dependencies
 script:
- - make compile_in_steps
+ - make
  - ./hets -V
  - export HETS_MAGIC=$PWD/magic/hets.magic
  - make check
-cache:
-  directories:
-  - .objs
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ env:
 before_install:
  - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
  - travis_retry sudo apt-get update
- - travis_retry sudo apt-get install cabal-install-$CABALVER ghc-$GHCVER
- - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
+ - travis_retry sudo apt-get install cabal-install-$CABALVER ghc-$GHCVER alex-3.1.3
+ - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:/opt/alex/3.1.3/bin:$PATH
  - sudo apt-get update -qq
  - sudo apt-get install -qq zlib1g-dev libncurses-dev libcairo2-dev libglib2.0-dev libpango1.0-dev libgtk2.0-dev libglade2-dev
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ env:
 before_install:
  - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
  - travis_retry sudo apt-get update
- - travis_retry sudo apt-get install cabal-install-$CABALVER ghc-$GHCVER alex-3.1.3
- - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:/opt/alex/3.1.3/bin:$PATH
+ - travis_retry sudo apt-get install cabal-install-$CABALVER ghc-$GHCVER happy-1.19.4 alex-3.1.3
+ - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:/opt/alex/3.1.3/bin:/opt/happy/1.19.4/bin:$PATH
  - sudo apt-get update -qq
  - sudo apt-get install -qq zlib1g-dev libncurses-dev libcairo2-dev libglib2.0-dev libpango1.0-dev libgtk2.0-dev libglade2-dev
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,14 @@
-language: haskell
+env:
+ - GHCVER=7.8.3 CABALVER=1.18
 before_install:
+ - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
+ - travis_retry sudo apt-get update
+ - travis_retry sudo apt-get install cabal-install-$CABALVER ghc-$GHCVER
+ - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
  - sudo apt-get update -qq
  - sudo apt-get install -qq zlib1g-dev libncurses-dev libcairo2-dev libglib2.0-dev libpango1.0-dev libgtk2.0-dev libglade2-dev
 install:
+ - travis_retry cabal update
  - cabal install gtk2hs-buildtools
  - cabal install http://www.dfki.de/cps/hets/src-distribution/programatica-1.0.0.5.tar.gz
  - cabal install --only-dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 env:
- - GHCVER=7.8.3 CABALVER=1.18
+ - GHCVER=7.8.4 CABALVER=1.20
 before_install:
  - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
  - travis_retry sudo apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
  - travis_retry cabal update
  - cabal install gtk2hs-buildtools
  - cabal install glade parsec1
- - cabal install -v --only-dependencies
+ - cabal install --only-dependencies
 script:
  - make
  - ./hets -V

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,7 @@ before_install:
 install:
  - travis_retry cabal update
  - cabal install gtk2hs-buildtools
- - cabal install http://www.dfki.de/cps/hets/src-distribution/programatica-1.0.0.5.tar.gz
  - cabal install --only-dependencies
- - ghc-pkg hide programatica
- - rm -f programatica
- - mkdir -p programatica
- - wget http://www.dfki.de/cps/hets/src-distribution/programatica-1.0.0.5.tar.gz
- - tar -xf programatica-1.0.0.5.tar.gz
- - mv programatica-1.0.0.5 programatica/tools
 script:
  - make compile_in_steps
  - ./hets -V

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
 install:
  - travis_retry cabal update
  - cabal install gtk2hs-buildtools
- - cabal install --only-dependencies
+ - cabal install -v --only-dependencies
 script:
  - make compile_in_steps
  - ./hets -V

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ before_install:
 install:
  - travis_retry cabal update
  - cabal install gtk2hs-buildtools
+ - cabal install glade
  - cabal install -v --only-dependencies
 script:
  - make compile_in_steps


### PR DESCRIPTION
I've looked up https://github.com/hvr/multi-ghc-travis to get travis working again (but currently only use one configuration).

The problem was that "cabal install --only-dependencies" tried to install older versions of gtk, that did not work. Installing "glade" separately solved this problem. (I think this is a cabal bug that needs further investigations.)

The next problem was that "ghc -M" changed between ghc-7.6 and ghc-7.8 and therefore "compile_in_steps" no longer worked.  compile_in_steps was needed to reduce memory consumption that lead to failures.