### PR TITLE
1203 owl2casl translation

### DIFF
--- a/OWL2/OWL22CASL.hs
+++ b/OWL2/OWL22CASL.hs
@@ -115,17 +115,17 @@ uriToIdM = return . uriToCaslId
 
 -- | Extracts Id from URI
 uriToCaslId :: IRI -> Id
-uriToCaslId urI = let 
-  repl a = if isAlphaNum a then [a] else if a/=':' then "_u" else "" 
+uriToCaslId urI = let
+  repl a = if isAlphaNum a then [a] else if a/=':' then "_u" else ""
   getId = stringToId . (concatMap repl)
- in 
-  if (isDatatypeKey urI) && (isThing urI)  then 
+ in
+  if (isDatatypeKey urI) && (isThing urI)  then
         getId $ localPart urI
-   else 
+   else
     let
       ePart = expandedIRI urI
-    in 
-      if ePart /= "" then 
+    in
+      if ePart /= "" then
         getId $ expandedIRI urI
       else -- this catches the datatypes, e.g. xsd:time, weird
         getId $ localPart urI
@@ -779,7 +779,7 @@ mapAnnFrameBit cSig ex ans afb =
         (keys, s) <-
             mapKey cSig ce (ol ++ dl) (nol ++ ndl) tl (uptoOP ++ uptoDP) lo
         return ([keys], uniteCASLSign cSig s)
-    ObjectSubPropertyChain oplst -> 
+    ObjectSubPropertyChain oplst ->
       case ex of
        ObjectEntity oe -> do
         os <- mapSubObjPropChain cSig oplst oe
@@ -803,4 +803,3 @@ mapAxioms :: CASLSign -> Axiom -> Result ([CASLFORMULA], CASLSign)
 mapAxioms cSig (PlainAxiom ex fb) = case fb of
     ListFrameBit rel lfb -> mapListFrameBit cSig ex rel lfb
     AnnFrameBit ans afb -> mapAnnFrameBit cSig ex ans afb
-

--- a/OWL2/OWL22CASL.hs
+++ b/OWL2/OWL22CASL.hs
@@ -113,14 +113,14 @@ indiConst :: OpType
 indiConst = OpType Total [] thing
 
 uriToIdM :: OS.Sign -> IRI -> Result Id
-uriToIdM s i = return $ uriToCaslId s i 
+uriToIdM s i = return $ uriToCaslId s i
 
 -- | Extracts Id from URI
 uriToCaslId :: OS.Sign -> IRI -> Id
 uriToCaslId sig urI =
     let l = localPart urI
         ur = if isThing urI then mkQName l else urI
-        repl a = if isAlphaNum a then [a] else if a/=':' then "_u" else "" 
+        repl a = if isAlphaNum a then [a] else if a/=':' then "_u" else ""
         p = namePrefix ur
         nP = concatMap repl $ Map.findWithDefault p p $ OS.prefixMap sig   --this should be expanded always
         lP = concatMap repl l
@@ -208,8 +208,8 @@ mapMorphism :: OWLMorphism -> Result CASLMor
 mapMorphism oMor = do
       let oSig1 = osource oMor
           oSig2 = otarget oMor
-      cdm <- mapSign oSig1 
-      ccd <- mapSign oSig2 
+      cdm <- mapSign oSig1
+      ccd <- mapSign oSig2
       let emap = mmaps oMor
           preds = Map.foldWithKey (\ (Entity _ ty u1) u2 -> let
               i1 = uriToCaslId oSig1 u1
@@ -595,7 +595,7 @@ mapCharact oSig cSig ope c = case c of
 mapSubObjPropChain :: OS.Sign -> CASLSign -> [ObjectPropertyExpression]
     -> ObjectPropertyExpression -> Result CASLFORMULA
 mapSubObjPropChain oSig cSig props oP = do
-    let (_, vars) = unzip $ zip (oP:props) [1 ..] 
+    let (_, vars) = unzip $ zip (oP:props) [1 ..]
     -- because we need n+1 vars for a chain of n roles
     oProps <- mapM (\ (z, x) -> mapObjProp oSig cSig z x (x+1)) $
                 zip props vars
@@ -657,13 +657,13 @@ mapListFrameBit oSig cSig ex rel lfb =
                     let vars = case r of
                                 ADomain -> (mkNName 1, mkNName 2)
                                 ARange -> (mkNName 2, mkNName 1)
-                    return (map (mkFI [tokDecl $ fst vars] [tokDecl $ snd vars] tobjP) tdsc, 
+                    return (map (mkFI [tokDecl $ fst vars] [tokDecl $ snd vars] tobjP) tdsc,
                             uniteL $ cSig : s)
                   _ -> err
           ClassEntity ce -> let cel = map snd cls in case rel of
               Nothing -> return ([], cSig)
               Just r -> case r of
-                EDRelation _ -> do 
+                EDRelation _ -> do
                     (decrsS, s) <- mapDescriptionListP oSig cSig 1 $ mkPairs ce cel
                     mkEDPairs (uniteCASLSign cSig s) [1] rel decrsS
                 SubClass -> do
@@ -706,7 +706,7 @@ mapListFrameBit oSig cSig ex rel lfb =
                     . mkImpl o2) os1, cSig)
             EDRelation _ -> do
                 pairs <- mapComDataPropsList oSig cSig (Just iri) dl 1 2
-                mkEDPairs cSig [1, 2] rel pairs 
+                mkEDPairs cSig [1, 2] rel pairs
             _ -> return ([], cSig)
         _ -> err
     IndividualSameOrDifferent al -> case rel of
@@ -778,8 +778,8 @@ mapAnnFrameBit oSig cSig ex ans afb =
         (keys, s) <-
             mapKey oSig cSig ce (ol ++ dl) (nol ++ ndl) tl (uptoOP ++ uptoDP) lo
         return ([keys], uniteCASLSign cSig s)
-    ObjectSubPropertyChain oplst -> 
-      case ex of 
+    ObjectSubPropertyChain oplst ->
+      case ex of
        ObjectEntity oe -> do
         os <- mapSubObjPropChain oSig cSig oplst oe
         return ([os], cSig)

--- a/OWL2/OWL22CASL.hs
+++ b/OWL2/OWL22CASL.hs
@@ -53,8 +53,6 @@ import Common.DocUtils
 import Data.Maybe
 import Text.ParserCombinators.Parsec
 
-import Debug.Trace
-
 data OWL22CASL = OWL22CASL deriving Show
 
 instance Language OWL22CASL
@@ -91,7 +89,7 @@ instance Comorphism
         { cons_features = emptyMapConsFeature }
       map_theory OWL22CASL = mapTheory
       map_morphism OWL22CASL = mapMorphism
-      map_symbol OWL22CASL = mapSymbol
+      map_symbol OWL22CASL _ = mapSymbol
       isInclusionComorphism OWL22CASL = True
       has_model_expansion OWL22CASL = True
 
@@ -112,19 +110,25 @@ dataPropPred = PredType [thing, dataS]
 indiConst :: OpType
 indiConst = OpType Total [] thing
 
-uriToIdM :: OS.Sign -> IRI -> Result Id
-uriToIdM s i = return $ uriToCaslId s i
+uriToIdM :: IRI -> Result Id
+uriToIdM = return . uriToCaslId
 
 -- | Extracts Id from URI
-uriToCaslId :: OS.Sign -> IRI -> Id
-uriToCaslId sig urI =
-    let l = localPart urI
-        ur = if isThing urI then mkQName l else urI
-        repl a = if isAlphaNum a then [a] else if a/=':' then "_u" else ""
-        p = namePrefix ur
-        nP = concatMap repl $ Map.findWithDefault p p $ OS.prefixMap sig   --this should be expanded always
-        lP = concatMap repl l
-    in stringToId $ (if isDatatypeKey urI then "" else nP) ++ lP
+uriToCaslId :: IRI -> Id
+uriToCaslId urI = let 
+  repl a = if isAlphaNum a then [a] else if a/=':' then "_u" else "" 
+  getId = stringToId . (concatMap repl)
+ in 
+  if (isDatatypeKey urI) && (isThing urI)  then 
+        getId $ localPart urI
+   else 
+    let
+      ePart = expandedIRI urI
+    in 
+      if ePart /= "" then 
+        getId $ expandedIRI urI
+      else -- this catches the datatypes, e.g. xsd:time, weird
+        getId $ localPart urI
 
 tokDecl :: Token -> VAR_DECL
 tokDecl = flip mkVarDecl thing
@@ -159,12 +163,11 @@ mkEqVar = mkStEq . toQualVar
 mkFEI :: [VAR_DECL] -> [VAR_DECL] -> FORMULA f -> FORMULA f -> FORMULA f
 mkFEI l1 l2 f = mkForall l1 . mkExist l2 . mkImpl f
 
-mkFI :: [VAR_DECL] -> [VAR_DECL] -> FORMULA f -> FORMULA f -> FORMULA f
-mkFI l1 l2 f1 f2 = mkForall l1 $ mkImpl (mkExist l2 f1) f2
-
-
 mkFIE :: [Int] -> [FORMULA f] -> Int -> Int -> FORMULA f
 mkFIE l1 l2 x y = mkVDecl l1 $ implConj l2 $ mkEqVar (thingDecl x) $ qualThing y
+
+mkFI :: [VAR_DECL] -> [VAR_DECL] -> FORMULA f -> FORMULA f -> FORMULA f
+mkFI l1 l2 f1 = (mkForall l1) . (mkImpl (mkExist l2 f1))
 
 mkRI :: [Int] -> Int -> FORMULA f -> FORMULA f
 mkRI l x so = mkVDecl l $ mkImpl (mkMember (qualThing x) thing) so
@@ -206,30 +209,28 @@ data VarOrIndi = OVar Int | OIndi IRI
 -- | Mapping of OWL morphisms to CASL morphisms
 mapMorphism :: OWLMorphism -> Result CASLMor
 mapMorphism oMor = do
-      let oSig1 = osource oMor
-          oSig2 = otarget oMor
-      cdm <- mapSign oSig1
-      ccd <- mapSign oSig2
+      cdm <- mapSign $ osource oMor
+      ccd <- mapSign $ otarget oMor
       let emap = mmaps oMor
           preds = Map.foldWithKey (\ (Entity _ ty u1) u2 -> let
-              i1 = uriToCaslId oSig1 u1
-              i2 = uriToCaslId oSig2 u2
+              i1 = uriToCaslId u1
+              i2 = uriToCaslId u2
               in case ty of
                 Class -> Map.insert (i1, conceptPred) i2
                 ObjectProperty -> Map.insert (i1, objectPropPred) i2
                 DataProperty -> Map.insert (i1, dataPropPred) i2
                 _ -> id) Map.empty emap
           ops = Map.foldWithKey (\ (Entity _ ty u1) u2 -> case ty of
-                NamedIndividual -> Map.insert (uriToCaslId oSig1 u1, indiConst)
-                  (uriToCaslId oSig2 u2, Total)
+                NamedIndividual -> Map.insert (uriToCaslId u1, indiConst)
+                  (uriToCaslId u2, Total)
                 _ -> id) Map.empty emap
       return (embedMorphism () cdm ccd)
                  { op_map = ops
                  , pred_map = preds }
 
-mapSymbol :: OS.Sign -> Entity -> Set.Set Symbol
-mapSymbol oSig (Entity _ ty iri) = let
-  syN = Set.singleton . Symbol (uriToCaslId oSig iri)
+mapSymbol :: Entity -> Set.Set Symbol
+mapSymbol (Entity _ ty iri) = let
+  syN = Set.singleton . Symbol (uriToCaslId iri)
   in case ty of
     Class -> syN $ PredAsItemType conceptPred
     ObjectProperty -> syN $ PredAsItemType objectPropPred
@@ -241,7 +242,7 @@ mapSymbol oSig (Entity _ ty iri) = let
 mapSign :: OS.Sign -> Result CASLSign
 mapSign sig =
       let conc = OS.concepts sig
-          cvrt = map (uriToCaslId sig) . Set.toList
+          cvrt = map uriToCaslId . Set.toList
           tMp k = MapSet.fromList . map (\ u -> (u, [k]))
           cPreds = thing : nothing : cvrt conc
           oPreds = cvrt $ OS.objectProperties sig
@@ -264,33 +265,33 @@ mapTheory (owlSig, owlSens) = let sl = topS in do
     cSig <- mapSign owlSig
     let pSig = loadDataInformation sl
         dTypes = (emptySign ()) {sortRel = Rel.transClosure . Rel.fromSet
-                    . Set.map (\ d -> (uriToCaslId owlSig d, dataS))
+                    . Set.map (\ d -> (uriToCaslId d, dataS))
                     . Set.union predefIRIs $ OS.datatypes owlSig}
     (cSens, nSig) <- foldM (\ (x, y) z -> do
-            (sen, sig) <- mapSentence owlSig y z
+            (sen, sig) <- mapSentence y z
             return (sen ++ x, uniteCASLSign sig y)) ([], cSig) owlSens
     return (foldl1 uniteCASLSign [nSig, pSig, dTypes],
                 predefinedAxioms ++ cSens)
 
 -- | mapping of OWL to CASL_DL formulae
-mapSentence :: OS.Sign -> CASLSign -> Named Axiom -> Result ([Named CASLFORMULA], CASLSign)
-mapSentence oSig cSig inSen = do
-    (outAx, outSig) <- mapAxioms oSig cSig $ sentence inSen
+mapSentence :: CASLSign -> Named Axiom -> Result ([Named CASLFORMULA], CASLSign)
+mapSentence cSig inSen = do
+    (outAx, outSig) <- mapAxioms cSig $ sentence inSen
     return (map (flip mapNamed inSen . const) outAx, outSig)
 
-mapVar :: OS.Sign -> CASLSign -> VarOrIndi -> Result (TERM ())
-mapVar oSig cSig v = case v of
+mapVar :: CASLSign -> VarOrIndi -> Result (TERM ())
+mapVar cSig v = case v of
     OVar n -> return $ qualThing n
-    OIndi i -> mapIndivURI oSig cSig i
+    OIndi i -> mapIndivURI cSig i
 
 -- | Mapping of Class URIs
-mapClassURI :: OS.Sign -> CASLSign -> Class -> Token -> Result CASLFORMULA
-mapClassURI oSig _ c t = fmap (mkPred conceptPred [mkThingVar t]) $ uriToIdM oSig c
+mapClassURI :: CASLSign -> Class -> Token -> Result CASLFORMULA
+mapClassURI _ c t = fmap (mkPred conceptPred [mkThingVar t]) $ uriToIdM c
 
 -- | Mapping of Individual URIs
-mapIndivURI :: OS.Sign -> CASLSign -> Individual -> Result (TERM ())
-mapIndivURI oSig _ uriI = do
-    ur <- uriToIdM oSig uriI
+mapIndivURI :: CASLSign -> Individual -> Result (TERM ())
+mapIndivURI _ uriI = do
+    ur <- uriToIdM uriI
     return $ mkAppl (mkQualOp ur (Op_type Total [] thing nullRange)) []
 
 mapNNInt :: NNInt -> TERM ()
@@ -339,38 +340,38 @@ mapLiteral lit = return $ case lit of
     _ -> mapNrLit lit
 
 -- | Mapping of data properties
-mapDataProp :: OS.Sign -> CASLSign -> DataPropertyExpression -> Int -> Int
+mapDataProp :: CASLSign -> DataPropertyExpression -> Int -> Int
             -> Result CASLFORMULA
-mapDataProp oSig _ dp a b = fmap (mkPred dataPropPred [qualThing a, qualData b])
-    $ uriToIdM oSig dp
+mapDataProp _ dp a b = fmap (mkPred dataPropPred [qualThing a, qualData b])
+    $ uriToIdM dp
 
 -- | Mapping of obj props
-mapObjProp :: OS.Sign -> CASLSign -> ObjectPropertyExpression -> Int -> Int
+mapObjProp :: CASLSign -> ObjectPropertyExpression -> Int -> Int
         -> Result CASLFORMULA
-mapObjProp oSig cSig ob a b = case ob of
+mapObjProp cSig ob a b = case ob of
       ObjectProp u -> fmap (mkPred objectPropPred $ map qualThing [a, b])
-            $ uriToIdM oSig u
-      ObjectInverseOf u -> mapObjProp oSig cSig u b a
+            $ uriToIdM u
+      ObjectInverseOf u -> mapObjProp cSig u b a
 
 -- | Mapping of obj props with Individuals
-mapObjPropI :: OS.Sign -> CASLSign -> ObjectPropertyExpression -> VarOrIndi -> VarOrIndi
+mapObjPropI :: CASLSign -> ObjectPropertyExpression -> VarOrIndi -> VarOrIndi
               -> Result CASLFORMULA
-mapObjPropI oSig cSig ob lP rP = case ob of
+mapObjPropI cSig ob lP rP = case ob of
     ObjectProp u -> do
-        l <- mapVar oSig cSig lP
-        r <- mapVar oSig cSig rP
-        fmap (mkPred objectPropPred [l, r]) $ uriToIdM oSig u
-    ObjectInverseOf u -> mapObjPropI oSig cSig u rP lP
+        l <- mapVar cSig lP
+        r <- mapVar cSig rP
+        fmap (mkPred objectPropPred [l, r]) $ uriToIdM u
+    ObjectInverseOf u -> mapObjPropI cSig u rP lP
 
 -- | mapping of individual list
-mapComIndivList :: OS.Sign -> CASLSign -> SameOrDifferent -> Maybe Individual
+mapComIndivList :: CASLSign -> SameOrDifferent -> Maybe Individual
     -> [Individual] -> Result [CASLFORMULA]
-mapComIndivList oSig cSig sod mol inds = do
-    fs <- mapM (mapIndivURI oSig cSig) inds
+mapComIndivList cSig sod mol inds = do
+    fs <- mapM (mapIndivURI cSig) inds
     tps <- case mol of
         Nothing -> return $ comPairs fs fs
         Just ol -> do
-            f <- mapIndivURI oSig cSig ol
+            f <- mapIndivURI cSig ol
             return $ mkPairs f fs
     return $ map (\ (x, y) -> case sod of
         Same -> mkStEq x y
@@ -378,38 +379,38 @@ mapComIndivList oSig cSig sod mol inds = do
 
 {- | Mapping along DataPropsList for creation of pairs for commutative
 operations. -}
-mapComDataPropsList :: OS.Sign -> CASLSign -> Maybe DataPropertyExpression
+mapComDataPropsList :: CASLSign -> Maybe DataPropertyExpression
     -> [DataPropertyExpression] -> Int -> Int
     -> Result [(CASLFORMULA, CASLFORMULA)]
-mapComDataPropsList oSig cSig md props a b = do
-    fs <- mapM (\ x -> mapDataProp oSig cSig x a b) props
+mapComDataPropsList cSig md props a b = do
+    fs <- mapM (\ x -> mapDataProp cSig x a b) props
     case md of
         Nothing -> return $ comPairs fs fs
-        Just dp -> fmap (`mkPairs` fs) $ mapDataProp oSig cSig dp a b
+        Just dp -> fmap (`mkPairs` fs) $ mapDataProp cSig dp a b
 
 {- | Mapping along ObjectPropsList for creation of pairs for commutative
 operations. -}
-mapComObjectPropsList :: OS.Sign -> CASLSign -> Maybe ObjectPropertyExpression
+mapComObjectPropsList :: CASLSign -> Maybe ObjectPropertyExpression
     -> [ObjectPropertyExpression] -> Int -> Int
     -> Result [(CASLFORMULA, CASLFORMULA)]
-mapComObjectPropsList oSig cSig mol props a b = do
-    fs <- mapM (\ x -> mapObjProp oSig cSig x a b) props
+mapComObjectPropsList cSig mol props a b = do
+    fs <- mapM (\ x -> mapObjProp cSig x a b) props
     case mol of
         Nothing -> return $ comPairs fs fs
-        Just ol -> fmap (`mkPairs` fs) $ mapObjProp oSig cSig ol a b
+        Just ol -> fmap (`mkPairs` fs) $ mapObjProp cSig ol a b
 
 -- | mapping of Data Range
-mapDataRange :: OS.Sign -> CASLSign -> DataRange -> Int -> Result (CASLFORMULA, CASLSign)
-mapDataRange oSig cSig dr i = case dr of
+mapDataRange :: CASLSign -> DataRange -> Int -> Result (CASLFORMULA, CASLSign)
+mapDataRange cSig dr i = case dr of
     DataType d fl -> do
-        let dt = mkMember (qualData i) $ uriToCaslId oSig d
+        let dt = mkMember (qualData i) $ uriToCaslId d
         (sens, s) <- mapAndUnzipM (mapFacet cSig i) fl
         return (conjunct $ dt : sens, uniteL $ cSig : s)
     DataComplementOf drc -> do
-        (sens, s) <- mapDataRange oSig cSig drc i
+        (sens, s) <- mapDataRange cSig drc i
         return (mkNeg sens, uniteCASLSign cSig s)
     DataJunction jt drl -> do
-        (jl, sl) <- mapAndUnzipM ((\ s v r -> mapDataRange oSig s r v) cSig i) drl
+        (jl, sl) <- mapAndUnzipM ((\ s v r -> mapDataRange s r v) cSig i) drl
         let usig = uniteL sl
         return $ case jt of
                 IntersectionOf -> (conjunct jl, usig)
@@ -431,34 +432,34 @@ mapFacet sig var (f, r) = do
     return (fp, uniteCASLSign sig $ (emptySign ())
             {predMap = MapSet.fromList [(cf, [dataPred])]})
 
-cardProps :: Bool -> OS.Sign -> CASLSign
+cardProps :: Bool -> CASLSign
     -> Either ObjectPropertyExpression DataPropertyExpression -> Int
     -> [Int] -> Result [CASLFORMULA]
-cardProps b oSig cSig prop var vLst =
-    if b then let Left ope = prop in mapM (mapObjProp oSig cSig ope var) vLst
-     else let Right dpe = prop in mapM (mapDataProp oSig cSig dpe var) vLst
+cardProps b cSig prop var vLst =
+    if b then let Left ope = prop in mapM (mapObjProp cSig ope var) vLst
+     else let Right dpe = prop in mapM (mapDataProp cSig dpe var) vLst
 
-mapCard :: Bool -> OS.Sign -> CASLSign -> CardinalityType -> Int
+mapCard :: Bool -> CASLSign -> CardinalityType -> Int
     -> Either ObjectPropertyExpression DataPropertyExpression
     -> Maybe (Either ClassExpression DataRange) -> Int
     -> Result (FORMULA (), CASLSign)
-mapCard b oSig cSig ct n prop d var = do
+mapCard b cSig ct n prop d var = do
     let vlst = map (var +) [1 .. n]
         vlstM = vlst ++ [n + var + 1]
     (dOut, s) <- case d of
         Nothing -> return ([], [emptySign ()])
         Just y ->
            if b then let Left ce = y in mapAndUnzipM
-                        (mapDescription oSig cSig ce) vlst
-           else let Right dr = y in mapAndUnzipM (mapDataRange oSig cSig dr) vlst
+                        (mapDescription cSig ce) vlst
+           else let Right dr = y in mapAndUnzipM (mapDataRange cSig dr) vlst
     let dlst = map (\ (x, y) -> mkNeg $ mkStEq (qualThing x) $ qualThing y)
                         $ comPairs vlst vlst
         dlstM = map (\ (x, y) -> mkStEq (qualThing x) $ qualThing y)
                         $ comPairs vlstM vlstM
         qVars = map thingDecl vlst
         qVarsM = map thingDecl vlstM
-    oProps <- cardProps b oSig cSig prop var vlst
-    oPropsM <- cardProps b oSig cSig prop var vlstM
+    oProps <- cardProps b cSig prop var vlst
+    oPropsM <- cardProps b cSig prop var vlstM
     let minLst = mkExist qVars $ conjunct $ dlst ++ dOut ++ oProps
         maxLst = mkForall qVarsM $ mkImpl (conjunct $ oPropsM ++ dOut)
                         $ disjunct dlstM
@@ -469,43 +470,43 @@ mapCard b oSig cSig ct n prop d var = do
             ExactCardinality -> (conjunct [minLst, maxLst], ts)
 
 -- | mapping of OWL2 Descriptions
-mapDescription :: OS.Sign -> CASLSign -> ClassExpression -> Int ->
+mapDescription :: CASLSign -> ClassExpression -> Int ->
     Result (CASLFORMULA, CASLSign)
-mapDescription oSig cSig desc var = case desc of
+mapDescription cSig desc var = case desc of
     Expression u -> do
-        c <- mapClassURI oSig cSig u $ mkNName var
+        c <- mapClassURI cSig u $ mkNName var
         return (c, cSig)
     ObjectJunction ty ds -> do
-        (els, s) <- mapAndUnzipM (flip (mapDescription oSig cSig) var) ds
+        (els, s) <- mapAndUnzipM (flip (mapDescription cSig) var) ds
         return ((case ty of
                 UnionOf -> disjunct
                 IntersectionOf -> conjunct)
             els, uniteL $ cSig : s)
     ObjectComplementOf d -> do
-        (els, s) <- mapDescription oSig cSig d var
+        (els, s) <- mapDescription cSig d var
         return (mkNeg els, uniteCASLSign cSig s)
     ObjectOneOf is -> do
-        il <- mapM (mapIndivURI oSig cSig) is
+        il <- mapM (mapIndivURI cSig) is
         return (disjunct $ map (mkStEq $ qualThing var) il, cSig)
     ObjectValuesFrom ty o d -> let n = var + 1 in do
-        oprop0 <- mapObjProp oSig cSig o var n
-        (desc0, s) <- mapDescription oSig cSig d n
+        oprop0 <- mapObjProp cSig o var n
+        (desc0, s) <- mapDescription cSig d n
         return $ case ty of
             SomeValuesFrom -> (mkExist [thingDecl n] $ conjunct [oprop0, desc0],
                     uniteCASLSign cSig s)
             AllValuesFrom -> (mkVDecl [n] $ mkImpl oprop0 desc0,
                     uniteCASLSign cSig s)
     ObjectHasSelf o -> do
-        op <- mapObjProp oSig cSig o var var
+        op <- mapObjProp cSig o var var
         return (op, cSig)
     ObjectHasValue o i -> do
-        op <- mapObjPropI oSig cSig o (OVar var) (OIndi i)
+        op <- mapObjPropI cSig o (OVar var) (OIndi i)
         return (op, cSig)
-    ObjectCardinality (Cardinality ct n oprop d) -> mapCard True oSig cSig ct n
+    ObjectCardinality (Cardinality ct n oprop d) -> mapCard True cSig ct n
         (Left oprop) (fmap Left d) var
     DataValuesFrom ty dpe dr -> let n = var + 1 in do
-        oprop0 <- mapDataProp oSig cSig dpe var n
-        (desc0, s) <- mapDataRange oSig cSig dr n
+        oprop0 <- mapDataProp cSig dpe var n
+        (desc0, s) <- mapDataRange cSig dr n
         let ts = uniteCASLSign cSig s
         return $ case ty of
             SomeValuesFrom -> (mkExist [dataDecl n] $ conjunct [oprop0, desc0],
@@ -514,31 +515,31 @@ mapDescription oSig cSig desc var = case desc of
     DataHasValue dpe c -> do
         con <- mapLiteral c
         return (mkPred dataPropPred [qualThing var, con]
-                           $ uriToCaslId oSig dpe, cSig)
-    DataCardinality (Cardinality ct n dpe dr) -> mapCard False oSig cSig ct n
+                           $ uriToCaslId dpe, cSig)
+    DataCardinality (Cardinality ct n dpe dr) -> mapCard False cSig ct n
         (Right dpe) (fmap Right dr) var
 
 -- | Mapping of a list of descriptions
-mapDescriptionList :: OS.Sign -> CASLSign -> Int -> [ClassExpression]
+mapDescriptionList :: CASLSign -> Int -> [ClassExpression]
         -> Result ([CASLFORMULA], CASLSign)
-mapDescriptionList oSig cSig n lst = do
-    (els, s) <- mapAndUnzipM (uncurry $ mapDescription oSig cSig)
+mapDescriptionList cSig n lst = do
+    (els, s) <- mapAndUnzipM (uncurry $ mapDescription cSig)
                     $ zip lst $ replicate (length lst) n
     return (els, uniteL $ cSig : s)
 
 -- | Mapping of a list of pairs of descriptions
-mapDescriptionListP :: OS.Sign -> CASLSign -> Int -> [(ClassExpression, ClassExpression)]
+mapDescriptionListP :: CASLSign -> Int -> [(ClassExpression, ClassExpression)]
                     -> Result ([(CASLFORMULA, CASLFORMULA)], CASLSign)
-mapDescriptionListP oSig cSig n lst = do
+mapDescriptionListP cSig n lst = do
     let (l, r) = unzip lst
-    ([lls, rls], s) <- mapAndUnzipM (mapDescriptionList oSig cSig n) [l, r]
+    ([lls, rls], s) <- mapAndUnzipM (mapDescriptionList cSig n) [l, r]
     return (zip lls rls, uniteL $ cSig : s)
 
-mapFact :: OS.Sign -> CASLSign -> Extended -> Fact -> Result CASLFORMULA
-mapFact oSig cSig ex f = case f of
+mapFact :: CASLSign -> Extended -> Fact -> Result CASLFORMULA
+mapFact cSig ex f = case f of
     ObjectPropertyFact posneg obe ind -> case ex of
         SimpleEntity (Entity _ NamedIndividual siri) -> do
-            oPropH <- mapObjPropI oSig cSig obe (OIndi ind) (OIndi siri)
+            oPropH <- mapObjPropI cSig obe (OIndi ind) (OIndi siri)
             let oProp = case posneg of
                     Positive -> oPropH
                     Negative -> Negation oPropH nullRange
@@ -546,9 +547,9 @@ mapFact oSig cSig ex f = case f of
         _ -> fail $ "ObjectPropertyFactsFacts Entity fail: " ++ show f
     DataPropertyFact posneg dpe lit -> case ex of
         SimpleEntity (Entity _ NamedIndividual iri) -> do
-            inS <- mapIndivURI oSig cSig iri
+            inS <- mapIndivURI cSig iri
             inT <- mapLiteral lit
-            oPropH <- mapDataProp oSig cSig dpe 1 2
+            oPropH <- mapDataProp cSig dpe 1 2
             let oProp = case posneg of
                     Positive -> oPropH
                     Negative -> Negation oPropH nullRange
@@ -556,59 +557,59 @@ mapFact oSig cSig ex f = case f of
                 [mkEqDecl 1 inS, mkEqVar (dataDecl 2) $ upcast inT dataS] oProp
         _ -> fail $ "DataPropertyFact Entity fail " ++ show f
 
-mapCharact :: OS.Sign -> CASLSign -> ObjectPropertyExpression -> Character
+mapCharact :: CASLSign -> ObjectPropertyExpression -> Character
             -> Result CASLFORMULA
-mapCharact oSig cSig ope c = case c of
+mapCharact cSig ope c = case c of
     Functional -> do
-        so1 <- mapObjProp oSig cSig ope 1 2
-        so2 <- mapObjProp oSig cSig ope 1 3
+        so1 <- mapObjProp cSig ope 1 2
+        so2 <- mapObjProp cSig ope 1 3
         return $ mkFIE [1, 2, 3] [so1, so2] 2 3
     InverseFunctional -> do
-        so1 <- mapObjProp oSig cSig ope 1 3
-        so2 <- mapObjProp oSig cSig ope 2 3
+        so1 <- mapObjProp cSig ope 1 3
+        so2 <- mapObjProp cSig ope 2 3
         return $ mkFIE [1, 2, 3] [so1, so2] 1 2
     Reflexive -> do
-        so <- mapObjProp oSig cSig ope 1 1
+        so <- mapObjProp cSig ope 1 1
         return $ mkRI [1] 1 so
     Irreflexive -> do
-        so <- mapObjProp oSig cSig ope 1 1
+        so <- mapObjProp cSig ope 1 1
         return $ mkRI [1] 1 $ mkNeg so
     Symmetric -> do
-        so1 <- mapObjProp oSig cSig ope 1 2
-        so2 <- mapObjProp oSig cSig ope 2 1
+        so1 <- mapObjProp cSig ope 1 2
+        so2 <- mapObjProp cSig ope 2 1
         return $ mkVDecl [1, 2] $ mkImpl so1 so2
     Asymmetric -> do
-        so1 <- mapObjProp oSig cSig ope 1 2
-        so2 <- mapObjProp oSig cSig ope 2 1
+        so1 <- mapObjProp cSig ope 1 2
+        so2 <- mapObjProp cSig ope 2 1
         return $ mkVDecl [1, 2] $ mkImpl so1 $ mkNeg so2
     Antisymmetric -> do
-        so1 <- mapObjProp oSig cSig ope 1 2
-        so2 <- mapObjProp oSig cSig ope 2 1
+        so1 <- mapObjProp cSig ope 1 2
+        so2 <- mapObjProp cSig ope 2 1
         return $ mkFIE [1, 2] [so1, so2] 1 2
     Transitive -> do
-        so1 <- mapObjProp oSig cSig ope 1 2
-        so2 <- mapObjProp oSig cSig ope 2 3
-        so3 <- mapObjProp oSig cSig ope 1 3
+        so1 <- mapObjProp cSig ope 1 2
+        so2 <- mapObjProp cSig ope 2 3
+        so3 <- mapObjProp cSig ope 1 3
         return $ mkVDecl [1, 2, 3] $ implConj [so1, so2] so3
 
 -- | Mapping of ObjectSubPropertyChain
-mapSubObjPropChain :: OS.Sign -> CASLSign -> [ObjectPropertyExpression]
+mapSubObjPropChain :: CASLSign -> [ObjectPropertyExpression]
     -> ObjectPropertyExpression -> Result CASLFORMULA
-mapSubObjPropChain oSig cSig props oP = do
-    let (_, vars) = unzip $ zip (oP:props) [1 ..]
-    -- because we need n+1 vars for a chain of n roles
-    oProps <- mapM (\ (z, x) -> mapObjProp oSig cSig z x (x+1)) $
-                zip props vars
-    ooP <- mapObjProp oSig cSig oP 1 (head $ reverse vars)
-    trace (show ooP) $ return $ mkVDecl vars $ implConj oProps ooP
+mapSubObjPropChain cSig props oP = do
+     let (_, vars) = unzip $ zip (oP:props) [1 ..]
+     -- because we need n+1 vars for a chain of n roles
+     oProps <- mapM (\ (z, x) -> mapObjProp cSig z x (x+1)) $
+                 zip props vars
+     ooP <- mapObjProp cSig oP 1 (head $ reverse vars)
+     return $ mkVDecl vars $ implConj oProps ooP
 
 -- | Mapping of subobj properties
-mapSubObjProp :: OS.Sign -> CASLSign -> ObjectPropertyExpression
+mapSubObjProp :: CASLSign -> ObjectPropertyExpression
     -> ObjectPropertyExpression -> Int -> Result CASLFORMULA
-mapSubObjProp oSig cSig e1 e2 a = do
+mapSubObjProp cSig e1 e2 a = do
     let b = a + 1
-    l <- mapObjProp oSig cSig e1 a b
-    r <- mapObjProp oSig cSig e2 a b
+    l <- mapObjProp cSig e1 a b
+    r <- mapObjProp cSig e2 a b
     return $ mkForallRange (map thingDecl [a, b]) (mkImpl l r) nullRange
 
 mkEDPairs :: CASLSign -> [Int] -> Maybe O.Relation -> [(FORMULA f, FORMULA f)]
@@ -622,25 +623,25 @@ mkEDPairs s il mr pairs = do
     return (ls, s)
 
 -- | Mapping of ListFrameBit
-mapListFrameBit :: OS.Sign -> CASLSign -> Extended -> Maybe O.Relation -> ListFrameBit
+mapListFrameBit :: CASLSign -> Extended -> Maybe O.Relation -> ListFrameBit
        -> Result ([CASLFORMULA], CASLSign)
-mapListFrameBit oSig cSig ex rel lfb =
+mapListFrameBit cSig ex rel lfb =
     let err = failMsg $ PlainAxiom ex $ ListFrameBit rel lfb
     in case lfb of
     AnnotationBit _ -> return ([], cSig)
     ExpressionBit cls -> case ex of
           Misc _ -> let cel = map snd cls in do
-            (els, s) <- mapDescriptionListP oSig cSig 1 $ comPairs cel cel
+            (els, s) <- mapDescriptionListP cSig 1 $ comPairs cel cel
             mkEDPairs (uniteCASLSign cSig s) [1] rel els
           SimpleEntity (Entity _ ty iri) -> do
-              (els, s) <- mapAndUnzipM (\ (_, c) -> mapDescription oSig cSig c 1) cls
+              (els, s) <- mapAndUnzipM (\ (_, c) -> mapDescription cSig c 1) cls
               case ty of
                 NamedIndividual | rel == Just Types -> do
-                  inD <- mapIndivURI oSig cSig iri
+                  inD <- mapIndivURI cSig iri
                   return (map (mk1VDecl . mkImpl (mkEqDecl 1 inD)) els,
                         uniteL $ cSig : s)
                 DataProperty | rel == (Just $ DRRelation ADomain) -> do
-                  oEx <- mapDataProp oSig cSig iri 1 2
+                  oEx <- mapDataProp cSig iri 1 2
                   let vars = (mkNName 1, mkNName 2)
                   return (map (mkFI [tokDecl $ fst vars]
                        [mkVarDecl (snd vars) dataS] oEx) els, uniteL $ cSig : s)
@@ -649,8 +650,8 @@ mapListFrameBit oSig cSig ex rel lfb =
               Nothing -> err
               Just re -> case re of
                   DRRelation r -> do
-                    tobjP <- mapObjProp oSig cSig oe 1 2
-                    (tdsc, s) <- mapAndUnzipM (\ (_, c) -> mapDescription oSig cSig c
+                    tobjP <- mapObjProp cSig oe 1 2
+                    (tdsc, s) <- mapAndUnzipM (\ (_, c) -> mapDescription cSig c
                         $ case r of
                                 ADomain -> 1
                                 ARange -> 2) cls
@@ -664,11 +665,11 @@ mapListFrameBit oSig cSig ex rel lfb =
               Nothing -> return ([], cSig)
               Just r -> case r of
                 EDRelation _ -> do
-                    (decrsS, s) <- mapDescriptionListP oSig cSig 1 $ mkPairs ce cel
+                    (decrsS, s) <- mapDescriptionListP cSig 1 $ mkPairs ce cel
                     mkEDPairs (uniteCASLSign cSig s) [1] rel decrsS
                 SubClass -> do
-                  (domT, s1) <- mapDescription oSig cSig ce 1
-                  (codT, s2) <- mapDescriptionList oSig cSig 1 cel
+                  (domT, s1) <- mapDescription cSig ce 1
+                  (codT, s2) <- mapDescriptionList cSig 1 cel
                   return (map (mk1VDecl . mkImpl domT) codT,
                         uniteL [cSig, s1, s2])
                 _ -> err
@@ -676,19 +677,19 @@ mapListFrameBit oSig cSig ex rel lfb =
       Nothing -> err
       Just r -> case ex of
         Misc _ -> do
-            pairs <- mapComObjectPropsList oSig cSig Nothing opl 1 2
+            pairs <- mapComObjectPropsList cSig Nothing opl 1 2
             mkEDPairs cSig [1, 2] rel pairs
         ObjectEntity op -> case r of
             EDRelation _ -> do
-                pairs <- mapComObjectPropsList oSig cSig (Just op) opl 1 2
+                pairs <- mapComObjectPropsList cSig (Just op) opl 1 2
                 mkEDPairs cSig [1, 2] rel pairs
             SubPropertyOf -> do
-                os <- mapM (\ (o1, o2) -> mapSubObjProp oSig cSig o1 o2 3)
+                os <- mapM (\ (o1, o2) -> mapSubObjProp cSig o1 o2 3)
                     $ mkPairs op opl
                 return (os, cSig)
             InverseOf -> do
-                os1 <- mapM (\ o1 -> mapObjProp oSig cSig o1 1 2) opl
-                o2 <- mapObjProp oSig cSig op 2 1
+                os1 <- mapM (\ o1 -> mapObjProp cSig o1 1 2) opl
+                o2 <- mapObjProp cSig op 2 1
                 return (map (mkVDecl [1, 2] . mkEqv o2) os1, cSig)
             _ -> err
         _ -> err
@@ -696,16 +697,16 @@ mapListFrameBit oSig cSig ex rel lfb =
       Nothing -> return ([], cSig)
       Just r -> case ex of
         Misc _ -> do
-            pairs <- mapComDataPropsList oSig cSig Nothing dl 1 2
+            pairs <- mapComDataPropsList cSig Nothing dl 1 2
             mkEDPairs cSig [1, 2] rel pairs
         SimpleEntity (Entity _ DataProperty iri) -> case r of
             SubPropertyOf -> do
-                os1 <- mapM (\ o1 -> mapDataProp oSig cSig o1 1 2) dl
-                o2 <- mapDataProp oSig cSig iri 2 1
+                os1 <- mapM (\ o1 -> mapDataProp cSig o1 1 2) dl
+                o2 <- mapDataProp cSig iri 2 1
                 return (map (mkForall [thingDecl 1, dataDecl 2]
                     . mkImpl o2) os1, cSig)
             EDRelation _ -> do
-                pairs <- mapComDataPropsList oSig cSig (Just iri) dl 1 2
+                pairs <- mapComDataPropsList cSig (Just iri) dl 1 2
                 mkEDPairs cSig [1, 2] rel pairs
             _ -> return ([], cSig)
         _ -> err
@@ -715,52 +716,52 @@ mapListFrameBit oSig cSig ex rel lfb =
             let mi = case ex of
                     SimpleEntity (Entity _ NamedIndividual iri) -> Just iri
                     _ -> Nothing
-            fs <- mapComIndivList oSig cSig re mi $ map snd al
+            fs <- mapComIndivList cSig re mi $ map snd al
             return (fs, cSig)
         _ -> err
     DataPropRange dpr -> case ex of
         SimpleEntity (Entity _ DataProperty iri) -> do
-            oEx <- mapDataProp oSig cSig iri 1 2
-            (odes, s) <- mapAndUnzipM (\ (_, c) -> mapDataRange oSig cSig c 2) dpr
+            oEx <- mapDataProp cSig iri 1 2
+            (odes, s) <- mapAndUnzipM (\ (_, c) -> mapDataRange cSig c 2) dpr
             let vars = (mkNName 1, mkNName 2)
             return (map (mkFEI [tokDecl $ fst vars]
                         [tokDataDecl $ snd vars] oEx) odes, uniteL $ cSig : s)
         _ -> err
     IndividualFacts indf -> do
-        fl <- mapM (mapFact oSig cSig ex . snd) indf
+        fl <- mapM (mapFact cSig ex . snd) indf
         return (fl, cSig)
     ObjectCharacteristics ace -> case ex of
         ObjectEntity ope -> do
-            cl <- mapM (mapCharact oSig cSig ope . snd) ace
+            cl <- mapM (mapCharact cSig ope . snd) ace
             return (cl, cSig)
         _ -> err
 
 -- | Mapping of AnnFrameBit
-mapAnnFrameBit :: OS.Sign -> CASLSign -> Extended -> Annotations -> AnnFrameBit
+mapAnnFrameBit :: CASLSign -> Extended -> Annotations -> AnnFrameBit
             -> Result ([CASLFORMULA], CASLSign)
-mapAnnFrameBit oSig cSig ex ans afb =
+mapAnnFrameBit cSig ex ans afb =
     let err = failMsg $ PlainAxiom ex $ AnnFrameBit ans afb
     in case afb of
     AnnotationFrameBit _ -> return ([], cSig)
     DataFunctional -> case ex of
         SimpleEntity (Entity _ _ iri) -> do
-            so1 <- mapDataProp oSig cSig iri 1 2
-            so2 <- mapDataProp oSig cSig iri 1 3
+            so1 <- mapDataProp cSig iri 1 2
+            so2 <- mapDataProp cSig iri 1 3
             return ([mkForall (thingDecl 1 : map dataDecl [2, 3]) $ implConj
                         [so1, so2] $ mkEqVar (dataDecl 2) $ qualData 3], cSig)
         _ -> err
     DatatypeBit dr -> case ex of
         SimpleEntity (Entity _ Datatype iri) -> do
-            (odes, s) <- mapDataRange oSig cSig dr 2
+            (odes, s) <- mapDataRange cSig dr 2
             return ([mkVDataDecl [2] $ mkEqv odes $ mkMember
-                    (qualData 2) $ uriToCaslId oSig iri], uniteCASLSign cSig s)
+                    (qualData 2) $ uriToCaslId iri], uniteCASLSign cSig s)
         _ -> err
     ClassDisjointUnion clsl -> case ex of
         ClassEntity (Expression iri) -> do
-            (decrs, s1) <- mapDescriptionList oSig cSig 1 clsl
-            (decrsS, s2) <- mapDescriptionListP oSig cSig 1 $ comPairs clsl clsl
+            (decrs, s1) <- mapDescriptionList cSig 1 clsl
+            (decrsS, s2) <- mapDescriptionListP cSig 1 $ comPairs clsl clsl
             let decrsP = map (\ (x, y) -> conjunct [x, y]) decrsS
-            mcls <- mapClassURI oSig cSig iri $ mkNName 1
+            mcls <- mapClassURI cSig iri $ mkNName 1
             return ([mk1VDecl $ mkEqv mcls $ conjunct
                     [disjunct decrs, mkNC decrsP]], uniteL [cSig, s1, s2])
         _ -> err
@@ -771,34 +772,35 @@ mapAnnFrameBit oSig cSig ex ans afb =
             uptoOP = [2 .. lo + 1]
             uptoDP = [lo + 2 .. lo + ld + 1]
             tl = lo + ld + 2
-        ol <- mapM (\ (n, o) -> mapObjProp oSig cSig o 1 n) $ zip uptoOP opl
-        nol <- mapM (\ (n, o) -> mapObjProp oSig cSig o tl n) $ zip uptoOP opl
-        dl <- mapM (\ (n, d) -> mapDataProp oSig cSig d 1 n) $ zip uptoDP dpl
-        ndl <- mapM (\ (n, d) -> mapDataProp oSig cSig d tl n) $ zip uptoDP dpl
+        ol <- mapM (\ (n, o) -> mapObjProp cSig o 1 n) $ zip uptoOP opl
+        nol <- mapM (\ (n, o) -> mapObjProp cSig o tl n) $ zip uptoOP opl
+        dl <- mapM (\ (n, d) -> mapDataProp cSig d 1 n) $ zip uptoDP dpl
+        ndl <- mapM (\ (n, d) -> mapDataProp cSig d tl n) $ zip uptoDP dpl
         (keys, s) <-
-            mapKey oSig cSig ce (ol ++ dl) (nol ++ ndl) tl (uptoOP ++ uptoDP) lo
+            mapKey cSig ce (ol ++ dl) (nol ++ ndl) tl (uptoOP ++ uptoDP) lo
         return ([keys], uniteCASLSign cSig s)
-    ObjectSubPropertyChain oplst ->
+    ObjectSubPropertyChain oplst -> 
       case ex of
        ObjectEntity oe -> do
-        os <- mapSubObjPropChain oSig cSig oplst oe
+        os <- mapSubObjPropChain cSig oplst oe
         return ([os], cSig)
        _ -> error "wrong annotation"
 
 keyDecl :: Int -> [Int] -> [VAR_DECL]
 keyDecl h il = map thingDecl (take h il) ++ map dataDecl (drop h il)
 
-mapKey :: OS.Sign -> CASLSign -> ClassExpression -> [FORMULA ()] -> [FORMULA ()]
+mapKey :: CASLSign -> ClassExpression -> [FORMULA ()] -> [FORMULA ()]
     -> Int -> [Int] -> Int -> Result (FORMULA (), CASLSign)
-mapKey oSig cSig ce pl npl p i h = do
-    (nce, s) <- mapDescription oSig cSig ce 1
-    (c3, _) <- mapDescription oSig cSig ce p
+mapKey cSig ce pl npl p i h = do
+    (nce, s) <- mapDescription cSig ce 1
+    (c3, _) <- mapDescription cSig ce p
     let un = mkForall [thingDecl p] $ implConj (c3 : npl)
                 $ mkStEq (qualThing p) $ qualThing 1
     return (mkForall [thingDecl 1] $ mkImpl nce
             $ mkExist (keyDecl h i) $ conjunct $ pl ++ [un], s)
 
-mapAxioms :: OS.Sign -> CASLSign -> Axiom -> Result ([CASLFORMULA], CASLSign)
-mapAxioms oSig cSig (PlainAxiom ex fb) = case fb of
-    ListFrameBit rel lfb -> mapListFrameBit oSig cSig ex rel lfb
-    AnnFrameBit ans afb -> mapAnnFrameBit oSig cSig ex ans afb
+mapAxioms :: CASLSign -> Axiom -> Result ([CASLFORMULA], CASLSign)
+mapAxioms cSig (PlainAxiom ex fb) = case fb of
+    ListFrameBit rel lfb -> mapListFrameBit cSig ex rel lfb
+    AnnFrameBit ans afb -> mapAnnFrameBit cSig ex ans afb
+

--- a/OWL2/OWL22CASL.hs
+++ b/OWL2/OWL22CASL.hs
@@ -53,6 +53,8 @@ import Common.DocUtils
 import Data.Maybe
 import Text.ParserCombinators.Parsec
 
+import Debug.Trace
+
 data OWL22CASL = OWL22CASL deriving Show
 
 instance Language OWL22CASL
@@ -89,7 +91,7 @@ instance Comorphism
         { cons_features = emptyMapConsFeature }
       map_theory OWL22CASL = mapTheory
       map_morphism OWL22CASL = mapMorphism
-      map_symbol OWL22CASL _ = mapSymbol
+      map_symbol OWL22CASL = mapSymbol
       isInclusionComorphism OWL22CASL = True
       has_model_expansion OWL22CASL = True
 
@@ -110,16 +112,17 @@ dataPropPred = PredType [thing, dataS]
 indiConst :: OpType
 indiConst = OpType Total [] thing
 
-uriToIdM :: IRI -> Result Id
-uriToIdM = return . uriToCaslId
+uriToIdM :: OS.Sign -> IRI -> Result Id
+uriToIdM s i = return $ uriToCaslId s i 
 
 -- | Extracts Id from URI
-uriToCaslId :: IRI -> Id
-uriToCaslId urI =
+uriToCaslId :: OS.Sign -> IRI -> Id
+uriToCaslId sig urI =
     let l = localPart urI
         ur = if isThing urI then mkQName l else urI
-        repl a = if isAlphaNum a then [a] else "_u"
-        nP = concatMap repl $ namePrefix ur
+        repl a = if isAlphaNum a then [a] else if a/=':' then "_u" else "" 
+        p = namePrefix ur
+        nP = concatMap repl $ Map.findWithDefault p p $ OS.prefixMap sig   --this should be expanded always
         lP = concatMap repl l
     in stringToId $ (if isDatatypeKey urI then "" else nP) ++ lP
 
@@ -155,6 +158,10 @@ mkEqVar = mkStEq . toQualVar
 
 mkFEI :: [VAR_DECL] -> [VAR_DECL] -> FORMULA f -> FORMULA f -> FORMULA f
 mkFEI l1 l2 f = mkForall l1 . mkExist l2 . mkImpl f
+
+mkFI :: [VAR_DECL] -> [VAR_DECL] -> FORMULA f -> FORMULA f -> FORMULA f
+mkFI l1 l2 f1 f2 = mkForall l1 $ mkImpl (mkExist l2 f1) f2
+
 
 mkFIE :: [Int] -> [FORMULA f] -> Int -> Int -> FORMULA f
 mkFIE l1 l2 x y = mkVDecl l1 $ implConj l2 $ mkEqVar (thingDecl x) $ qualThing y
@@ -199,28 +206,30 @@ data VarOrIndi = OVar Int | OIndi IRI
 -- | Mapping of OWL morphisms to CASL morphisms
 mapMorphism :: OWLMorphism -> Result CASLMor
 mapMorphism oMor = do
-      cdm <- mapSign $ osource oMor
-      ccd <- mapSign $ otarget oMor
+      let oSig1 = osource oMor
+          oSig2 = otarget oMor
+      cdm <- mapSign oSig1 
+      ccd <- mapSign oSig2 
       let emap = mmaps oMor
           preds = Map.foldWithKey (\ (Entity _ ty u1) u2 -> let
-              i1 = uriToCaslId u1
-              i2 = uriToCaslId u2
+              i1 = uriToCaslId oSig1 u1
+              i2 = uriToCaslId oSig2 u2
               in case ty of
                 Class -> Map.insert (i1, conceptPred) i2
                 ObjectProperty -> Map.insert (i1, objectPropPred) i2
                 DataProperty -> Map.insert (i1, dataPropPred) i2
                 _ -> id) Map.empty emap
           ops = Map.foldWithKey (\ (Entity _ ty u1) u2 -> case ty of
-                NamedIndividual -> Map.insert (uriToCaslId u1, indiConst)
-                  (uriToCaslId u2, Total)
+                NamedIndividual -> Map.insert (uriToCaslId oSig1 u1, indiConst)
+                  (uriToCaslId oSig2 u2, Total)
                 _ -> id) Map.empty emap
       return (embedMorphism () cdm ccd)
                  { op_map = ops
                  , pred_map = preds }
 
-mapSymbol :: Entity -> Set.Set Symbol
-mapSymbol (Entity _ ty iri) = let
-  syN = Set.singleton . Symbol (uriToCaslId iri)
+mapSymbol :: OS.Sign -> Entity -> Set.Set Symbol
+mapSymbol oSig (Entity _ ty iri) = let
+  syN = Set.singleton . Symbol (uriToCaslId oSig iri)
   in case ty of
     Class -> syN $ PredAsItemType conceptPred
     ObjectProperty -> syN $ PredAsItemType objectPropPred
@@ -232,7 +241,7 @@ mapSymbol (Entity _ ty iri) = let
 mapSign :: OS.Sign -> Result CASLSign
 mapSign sig =
       let conc = OS.concepts sig
-          cvrt = map uriToCaslId . Set.toList
+          cvrt = map (uriToCaslId sig) . Set.toList
           tMp k = MapSet.fromList . map (\ u -> (u, [k]))
           cPreds = thing : nothing : cvrt conc
           oPreds = cvrt $ OS.objectProperties sig
@@ -255,33 +264,33 @@ mapTheory (owlSig, owlSens) = let sl = topS in do
     cSig <- mapSign owlSig
     let pSig = loadDataInformation sl
         dTypes = (emptySign ()) {sortRel = Rel.transClosure . Rel.fromSet
-                    . Set.map (\ d -> (uriToCaslId d, dataS))
+                    . Set.map (\ d -> (uriToCaslId owlSig d, dataS))
                     . Set.union predefIRIs $ OS.datatypes owlSig}
     (cSens, nSig) <- foldM (\ (x, y) z -> do
-            (sen, sig) <- mapSentence y z
+            (sen, sig) <- mapSentence owlSig y z
             return (sen ++ x, uniteCASLSign sig y)) ([], cSig) owlSens
     return (foldl1 uniteCASLSign [nSig, pSig, dTypes],
                 predefinedAxioms ++ cSens)
 
 -- | mapping of OWL to CASL_DL formulae
-mapSentence :: CASLSign -> Named Axiom -> Result ([Named CASLFORMULA], CASLSign)
-mapSentence cSig inSen = do
-    (outAx, outSig) <- mapAxioms cSig $ sentence inSen
+mapSentence :: OS.Sign -> CASLSign -> Named Axiom -> Result ([Named CASLFORMULA], CASLSign)
+mapSentence oSig cSig inSen = do
+    (outAx, outSig) <- mapAxioms oSig cSig $ sentence inSen
     return (map (flip mapNamed inSen . const) outAx, outSig)
 
-mapVar :: CASLSign -> VarOrIndi -> Result (TERM ())
-mapVar cSig v = case v of
+mapVar :: OS.Sign -> CASLSign -> VarOrIndi -> Result (TERM ())
+mapVar oSig cSig v = case v of
     OVar n -> return $ qualThing n
-    OIndi i -> mapIndivURI cSig i
+    OIndi i -> mapIndivURI oSig cSig i
 
 -- | Mapping of Class URIs
-mapClassURI :: CASLSign -> Class -> Token -> Result CASLFORMULA
-mapClassURI _ c t = fmap (mkPred conceptPred [mkThingVar t]) $ uriToIdM c
+mapClassURI :: OS.Sign -> CASLSign -> Class -> Token -> Result CASLFORMULA
+mapClassURI oSig _ c t = fmap (mkPred conceptPred [mkThingVar t]) $ uriToIdM oSig c
 
 -- | Mapping of Individual URIs
-mapIndivURI :: CASLSign -> Individual -> Result (TERM ())
-mapIndivURI _ uriI = do
-    ur <- uriToIdM uriI
+mapIndivURI :: OS.Sign -> CASLSign -> Individual -> Result (TERM ())
+mapIndivURI oSig _ uriI = do
+    ur <- uriToIdM oSig uriI
     return $ mkAppl (mkQualOp ur (Op_type Total [] thing nullRange)) []
 
 mapNNInt :: NNInt -> TERM ()
@@ -330,38 +339,38 @@ mapLiteral lit = return $ case lit of
     _ -> mapNrLit lit
 
 -- | Mapping of data properties
-mapDataProp :: CASLSign -> DataPropertyExpression -> Int -> Int
+mapDataProp :: OS.Sign -> CASLSign -> DataPropertyExpression -> Int -> Int
             -> Result CASLFORMULA
-mapDataProp _ dp a b = fmap (mkPred dataPropPred [qualThing a, qualData b])
-    $ uriToIdM dp
+mapDataProp oSig _ dp a b = fmap (mkPred dataPropPred [qualThing a, qualData b])
+    $ uriToIdM oSig dp
 
 -- | Mapping of obj props
-mapObjProp :: CASLSign -> ObjectPropertyExpression -> Int -> Int
+mapObjProp :: OS.Sign -> CASLSign -> ObjectPropertyExpression -> Int -> Int
         -> Result CASLFORMULA
-mapObjProp cSig ob a b = case ob of
+mapObjProp oSig cSig ob a b = case ob of
       ObjectProp u -> fmap (mkPred objectPropPred $ map qualThing [a, b])
-            $ uriToIdM u
-      ObjectInverseOf u -> mapObjProp cSig u b a
+            $ uriToIdM oSig u
+      ObjectInverseOf u -> mapObjProp oSig cSig u b a
 
 -- | Mapping of obj props with Individuals
-mapObjPropI :: CASLSign -> ObjectPropertyExpression -> VarOrIndi -> VarOrIndi
+mapObjPropI :: OS.Sign -> CASLSign -> ObjectPropertyExpression -> VarOrIndi -> VarOrIndi
               -> Result CASLFORMULA
-mapObjPropI cSig ob lP rP = case ob of
+mapObjPropI oSig cSig ob lP rP = case ob of
     ObjectProp u -> do
-        l <- mapVar cSig lP
-        r <- mapVar cSig rP
-        fmap (mkPred objectPropPred [l, r]) $ uriToIdM u
-    ObjectInverseOf u -> mapObjPropI cSig u rP lP
+        l <- mapVar oSig cSig lP
+        r <- mapVar oSig cSig rP
+        fmap (mkPred objectPropPred [l, r]) $ uriToIdM oSig u
+    ObjectInverseOf u -> mapObjPropI oSig cSig u rP lP
 
 -- | mapping of individual list
-mapComIndivList :: CASLSign -> SameOrDifferent -> Maybe Individual
+mapComIndivList :: OS.Sign -> CASLSign -> SameOrDifferent -> Maybe Individual
     -> [Individual] -> Result [CASLFORMULA]
-mapComIndivList cSig sod mol inds = do
-    fs <- mapM (mapIndivURI cSig) inds
+mapComIndivList oSig cSig sod mol inds = do
+    fs <- mapM (mapIndivURI oSig cSig) inds
     tps <- case mol of
         Nothing -> return $ comPairs fs fs
         Just ol -> do
-            f <- mapIndivURI cSig ol
+            f <- mapIndivURI oSig cSig ol
             return $ mkPairs f fs
     return $ map (\ (x, y) -> case sod of
         Same -> mkStEq x y
@@ -369,38 +378,38 @@ mapComIndivList cSig sod mol inds = do
 
 {- | Mapping along DataPropsList for creation of pairs for commutative
 operations. -}
-mapComDataPropsList :: CASLSign -> Maybe DataPropertyExpression
+mapComDataPropsList :: OS.Sign -> CASLSign -> Maybe DataPropertyExpression
     -> [DataPropertyExpression] -> Int -> Int
     -> Result [(CASLFORMULA, CASLFORMULA)]
-mapComDataPropsList cSig md props a b = do
-    fs <- mapM (\ x -> mapDataProp cSig x a b) props
+mapComDataPropsList oSig cSig md props a b = do
+    fs <- mapM (\ x -> mapDataProp oSig cSig x a b) props
     case md of
         Nothing -> return $ comPairs fs fs
-        Just dp -> fmap (`mkPairs` fs) $ mapDataProp cSig dp a b
+        Just dp -> fmap (`mkPairs` fs) $ mapDataProp oSig cSig dp a b
 
 {- | Mapping along ObjectPropsList for creation of pairs for commutative
 operations. -}
-mapComObjectPropsList :: CASLSign -> Maybe ObjectPropertyExpression
+mapComObjectPropsList :: OS.Sign -> CASLSign -> Maybe ObjectPropertyExpression
     -> [ObjectPropertyExpression] -> Int -> Int
     -> Result [(CASLFORMULA, CASLFORMULA)]
-mapComObjectPropsList cSig mol props a b = do
-    fs <- mapM (\ x -> mapObjProp cSig x a b) props
+mapComObjectPropsList oSig cSig mol props a b = do
+    fs <- mapM (\ x -> mapObjProp oSig cSig x a b) props
     case mol of
         Nothing -> return $ comPairs fs fs
-        Just ol -> fmap (`mkPairs` fs) $ mapObjProp cSig ol a b
+        Just ol -> fmap (`mkPairs` fs) $ mapObjProp oSig cSig ol a b
 
 -- | mapping of Data Range
-mapDataRange :: CASLSign -> DataRange -> Int -> Result (CASLFORMULA, CASLSign)
-mapDataRange cSig dr i = case dr of
+mapDataRange :: OS.Sign -> CASLSign -> DataRange -> Int -> Result (CASLFORMULA, CASLSign)
+mapDataRange oSig cSig dr i = case dr of
     DataType d fl -> do
-        let dt = mkMember (qualData i) $ uriToCaslId d
+        let dt = mkMember (qualData i) $ uriToCaslId oSig d
         (sens, s) <- mapAndUnzipM (mapFacet cSig i) fl
         return (conjunct $ dt : sens, uniteL $ cSig : s)
     DataComplementOf drc -> do
-        (sens, s) <- mapDataRange cSig drc i
+        (sens, s) <- mapDataRange oSig cSig drc i
         return (mkNeg sens, uniteCASLSign cSig s)
     DataJunction jt drl -> do
-        (jl, sl) <- mapAndUnzipM ((\ s v r -> mapDataRange s r v) cSig i) drl
+        (jl, sl) <- mapAndUnzipM ((\ s v r -> mapDataRange oSig s r v) cSig i) drl
         let usig = uniteL sl
         return $ case jt of
                 IntersectionOf -> (conjunct jl, usig)
@@ -422,34 +431,34 @@ mapFacet sig var (f, r) = do
     return (fp, uniteCASLSign sig $ (emptySign ())
             {predMap = MapSet.fromList [(cf, [dataPred])]})
 
-cardProps :: Bool -> CASLSign
+cardProps :: Bool -> OS.Sign -> CASLSign
     -> Either ObjectPropertyExpression DataPropertyExpression -> Int
     -> [Int] -> Result [CASLFORMULA]
-cardProps b cSig prop var vLst =
-    if b then let Left ope = prop in mapM (mapObjProp cSig ope var) vLst
-     else let Right dpe = prop in mapM (mapDataProp cSig dpe var) vLst
+cardProps b oSig cSig prop var vLst =
+    if b then let Left ope = prop in mapM (mapObjProp oSig cSig ope var) vLst
+     else let Right dpe = prop in mapM (mapDataProp oSig cSig dpe var) vLst
 
-mapCard :: Bool -> CASLSign -> CardinalityType -> Int
+mapCard :: Bool -> OS.Sign -> CASLSign -> CardinalityType -> Int
     -> Either ObjectPropertyExpression DataPropertyExpression
     -> Maybe (Either ClassExpression DataRange) -> Int
     -> Result (FORMULA (), CASLSign)
-mapCard b cSig ct n prop d var = do
+mapCard b oSig cSig ct n prop d var = do
     let vlst = map (var +) [1 .. n]
         vlstM = vlst ++ [n + var + 1]
     (dOut, s) <- case d of
         Nothing -> return ([], [emptySign ()])
         Just y ->
            if b then let Left ce = y in mapAndUnzipM
-                        (mapDescription cSig ce) vlst
-           else let Right dr = y in mapAndUnzipM (mapDataRange cSig dr) vlst
+                        (mapDescription oSig cSig ce) vlst
+           else let Right dr = y in mapAndUnzipM (mapDataRange oSig cSig dr) vlst
     let dlst = map (\ (x, y) -> mkNeg $ mkStEq (qualThing x) $ qualThing y)
                         $ comPairs vlst vlst
         dlstM = map (\ (x, y) -> mkStEq (qualThing x) $ qualThing y)
                         $ comPairs vlstM vlstM
         qVars = map thingDecl vlst
         qVarsM = map thingDecl vlstM
-    oProps <- cardProps b cSig prop var vlst
-    oPropsM <- cardProps b cSig prop var vlstM
+    oProps <- cardProps b oSig cSig prop var vlst
+    oPropsM <- cardProps b oSig cSig prop var vlstM
     let minLst = mkExist qVars $ conjunct $ dlst ++ dOut ++ oProps
         maxLst = mkForall qVarsM $ mkImpl (conjunct $ oPropsM ++ dOut)
                         $ disjunct dlstM
@@ -460,43 +469,43 @@ mapCard b cSig ct n prop d var = do
             ExactCardinality -> (conjunct [minLst, maxLst], ts)
 
 -- | mapping of OWL2 Descriptions
-mapDescription :: CASLSign -> ClassExpression -> Int ->
+mapDescription :: OS.Sign -> CASLSign -> ClassExpression -> Int ->
     Result (CASLFORMULA, CASLSign)
-mapDescription cSig desc var = case desc of
+mapDescription oSig cSig desc var = case desc of
     Expression u -> do
-        c <- mapClassURI cSig u $ mkNName var
+        c <- mapClassURI oSig cSig u $ mkNName var
         return (c, cSig)
     ObjectJunction ty ds -> do
-        (els, s) <- mapAndUnzipM (flip (mapDescription cSig) var) ds
+        (els, s) <- mapAndUnzipM (flip (mapDescription oSig cSig) var) ds
         return ((case ty of
                 UnionOf -> disjunct
                 IntersectionOf -> conjunct)
             els, uniteL $ cSig : s)
     ObjectComplementOf d -> do
-        (els, s) <- mapDescription cSig d var
+        (els, s) <- mapDescription oSig cSig d var
         return (mkNeg els, uniteCASLSign cSig s)
     ObjectOneOf is -> do
-        il <- mapM (mapIndivURI cSig) is
+        il <- mapM (mapIndivURI oSig cSig) is
         return (disjunct $ map (mkStEq $ qualThing var) il, cSig)
     ObjectValuesFrom ty o d -> let n = var + 1 in do
-        oprop0 <- mapObjProp cSig o var n
-        (desc0, s) <- mapDescription cSig d n
+        oprop0 <- mapObjProp oSig cSig o var n
+        (desc0, s) <- mapDescription oSig cSig d n
         return $ case ty of
             SomeValuesFrom -> (mkExist [thingDecl n] $ conjunct [oprop0, desc0],
                     uniteCASLSign cSig s)
             AllValuesFrom -> (mkVDecl [n] $ mkImpl oprop0 desc0,
                     uniteCASLSign cSig s)
     ObjectHasSelf o -> do
-        op <- mapObjProp cSig o var var
+        op <- mapObjProp oSig cSig o var var
         return (op, cSig)
     ObjectHasValue o i -> do
-        op <- mapObjPropI cSig o (OVar var) (OIndi i)
+        op <- mapObjPropI oSig cSig o (OVar var) (OIndi i)
         return (op, cSig)
-    ObjectCardinality (Cardinality ct n oprop d) -> mapCard True cSig ct n
+    ObjectCardinality (Cardinality ct n oprop d) -> mapCard True oSig cSig ct n
         (Left oprop) (fmap Left d) var
     DataValuesFrom ty dpe dr -> let n = var + 1 in do
-        oprop0 <- mapDataProp cSig dpe var n
-        (desc0, s) <- mapDataRange cSig dr n
+        oprop0 <- mapDataProp oSig cSig dpe var n
+        (desc0, s) <- mapDataRange oSig cSig dr n
         let ts = uniteCASLSign cSig s
         return $ case ty of
             SomeValuesFrom -> (mkExist [dataDecl n] $ conjunct [oprop0, desc0],
@@ -505,44 +514,41 @@ mapDescription cSig desc var = case desc of
     DataHasValue dpe c -> do
         con <- mapLiteral c
         return (mkPred dataPropPred [qualThing var, con]
-                           $ uriToCaslId dpe, cSig)
-    DataCardinality (Cardinality ct n dpe dr) -> mapCard False cSig ct n
+                           $ uriToCaslId oSig dpe, cSig)
+    DataCardinality (Cardinality ct n dpe dr) -> mapCard False oSig cSig ct n
         (Right dpe) (fmap Right dr) var
 
 -- | Mapping of a list of descriptions
-mapDescriptionList :: CASLSign -> Int -> [ClassExpression]
+mapDescriptionList :: OS.Sign -> CASLSign -> Int -> [ClassExpression]
         -> Result ([CASLFORMULA], CASLSign)
-mapDescriptionList cSig n lst = do
-    (els, s) <- mapAndUnzipM (uncurry $ mapDescription cSig)
+mapDescriptionList oSig cSig n lst = do
+    (els, s) <- mapAndUnzipM (uncurry $ mapDescription oSig cSig)
                     $ zip lst $ replicate (length lst) n
     return (els, uniteL $ cSig : s)
 
 -- | Mapping of a list of pairs of descriptions
-mapDescriptionListP :: CASLSign -> Int -> [(ClassExpression, ClassExpression)]
+mapDescriptionListP :: OS.Sign -> CASLSign -> Int -> [(ClassExpression, ClassExpression)]
                     -> Result ([(CASLFORMULA, CASLFORMULA)], CASLSign)
-mapDescriptionListP cSig n lst = do
+mapDescriptionListP oSig cSig n lst = do
     let (l, r) = unzip lst
-    ([lls, rls], s) <- mapAndUnzipM (mapDescriptionList cSig n) [l, r]
+    ([lls, rls], s) <- mapAndUnzipM (mapDescriptionList oSig cSig n) [l, r]
     return (zip lls rls, uniteL $ cSig : s)
 
-mapFact :: CASLSign -> Extended -> Fact -> Result CASLFORMULA
-mapFact cSig ex f = case f of
+mapFact :: OS.Sign -> CASLSign -> Extended -> Fact -> Result CASLFORMULA
+mapFact oSig cSig ex f = case f of
     ObjectPropertyFact posneg obe ind -> case ex of
         SimpleEntity (Entity _ NamedIndividual siri) -> do
-            inS <- mapIndivURI cSig siri
-            inT <- mapIndivURI cSig ind
-            oPropH <- mapObjProp cSig obe 1 2
+            oPropH <- mapObjPropI oSig cSig obe (OIndi ind) (OIndi siri)
             let oProp = case posneg of
                     Positive -> oPropH
                     Negative -> Negation oPropH nullRange
-            return $ mkVDecl [1, 2] $ implConj
-                            [mkEqDecl 1 inS, mkEqDecl 2 inT] oProp
+            return oProp
         _ -> fail $ "ObjectPropertyFactsFacts Entity fail: " ++ show f
     DataPropertyFact posneg dpe lit -> case ex of
         SimpleEntity (Entity _ NamedIndividual iri) -> do
-            inS <- mapIndivURI cSig iri
+            inS <- mapIndivURI oSig cSig iri
             inT <- mapLiteral lit
-            oPropH <- mapDataProp cSig dpe 1 2
+            oPropH <- mapDataProp oSig cSig dpe 1 2
             let oProp = case posneg of
                     Positive -> oPropH
                     Negative -> Negation oPropH nullRange
@@ -550,59 +556,59 @@ mapFact cSig ex f = case f of
                 [mkEqDecl 1 inS, mkEqVar (dataDecl 2) $ upcast inT dataS] oProp
         _ -> fail $ "DataPropertyFact Entity fail " ++ show f
 
-mapCharact :: CASLSign -> ObjectPropertyExpression -> Character
+mapCharact :: OS.Sign -> CASLSign -> ObjectPropertyExpression -> Character
             -> Result CASLFORMULA
-mapCharact cSig ope c = case c of
+mapCharact oSig cSig ope c = case c of
     Functional -> do
-        so1 <- mapObjProp cSig ope 1 2
-        so2 <- mapObjProp cSig ope 1 3
+        so1 <- mapObjProp oSig cSig ope 1 2
+        so2 <- mapObjProp oSig cSig ope 1 3
         return $ mkFIE [1, 2, 3] [so1, so2] 2 3
     InverseFunctional -> do
-        so1 <- mapObjProp cSig ope 1 3
-        so2 <- mapObjProp cSig ope 2 3
+        so1 <- mapObjProp oSig cSig ope 1 3
+        so2 <- mapObjProp oSig cSig ope 2 3
         return $ mkFIE [1, 2, 3] [so1, so2] 1 2
     Reflexive -> do
-        so <- mapObjProp cSig ope 1 1
+        so <- mapObjProp oSig cSig ope 1 1
         return $ mkRI [1] 1 so
     Irreflexive -> do
-        so <- mapObjProp cSig ope 1 1
+        so <- mapObjProp oSig cSig ope 1 1
         return $ mkRI [1] 1 $ mkNeg so
     Symmetric -> do
-        so1 <- mapObjProp cSig ope 1 2
-        so2 <- mapObjProp cSig ope 2 1
+        so1 <- mapObjProp oSig cSig ope 1 2
+        so2 <- mapObjProp oSig cSig ope 2 1
         return $ mkVDecl [1, 2] $ mkImpl so1 so2
     Asymmetric -> do
-        so1 <- mapObjProp cSig ope 1 2
-        so2 <- mapObjProp cSig ope 2 1
+        so1 <- mapObjProp oSig cSig ope 1 2
+        so2 <- mapObjProp oSig cSig ope 2 1
         return $ mkVDecl [1, 2] $ mkImpl so1 $ mkNeg so2
     Antisymmetric -> do
-        so1 <- mapObjProp cSig ope 1 2
-        so2 <- mapObjProp cSig ope 2 1
+        so1 <- mapObjProp oSig cSig ope 1 2
+        so2 <- mapObjProp oSig cSig ope 2 1
         return $ mkFIE [1, 2] [so1, so2] 1 2
     Transitive -> do
-        so1 <- mapObjProp cSig ope 1 2
-        so2 <- mapObjProp cSig ope 2 3
-        so3 <- mapObjProp cSig ope 1 3
+        so1 <- mapObjProp oSig cSig ope 1 2
+        so2 <- mapObjProp oSig cSig ope 2 3
+        so3 <- mapObjProp oSig cSig ope 1 3
         return $ mkVDecl [1, 2, 3] $ implConj [so1, so2] so3
 
 -- | Mapping of ObjectSubPropertyChain
-mapSubObjPropChain :: CASLSign -> [ObjectPropertyExpression]
-    -> ObjectPropertyExpression -> Int -> Result CASLFORMULA
-mapSubObjPropChain cSig props oP n = let m = n + 1 in do
-    let (_, vars) = unzip $ zip (tail props) [m + 1 ..]
-        vl = n : vars ++ [m]
-    oProps <- mapM (\ (z, x, y) -> mapObjProp cSig z x y) $
-                zip3 props vl $ tail vl
-    ooP <- mapObjProp cSig oP n m
-    return $ mkVDecl [1, 2] $ mkVDecl vars $ implConj oProps ooP
+mapSubObjPropChain :: OS.Sign -> CASLSign -> [ObjectPropertyExpression]
+    -> ObjectPropertyExpression -> Result CASLFORMULA
+mapSubObjPropChain oSig cSig props oP = do
+    let (_, vars) = unzip $ zip (oP:props) [1 ..] 
+    -- because we need n+1 vars for a chain of n roles
+    oProps <- mapM (\ (z, x) -> mapObjProp oSig cSig z x (x+1)) $
+                zip props vars
+    ooP <- mapObjProp oSig cSig oP 1 (head $ reverse vars)
+    trace (show ooP) $ return $ mkVDecl vars $ implConj oProps ooP
 
 -- | Mapping of subobj properties
-mapSubObjProp :: CASLSign -> ObjectPropertyExpression
+mapSubObjProp :: OS.Sign -> CASLSign -> ObjectPropertyExpression
     -> ObjectPropertyExpression -> Int -> Result CASLFORMULA
-mapSubObjProp cSig e1 e2 a = do
+mapSubObjProp oSig cSig e1 e2 a = do
     let b = a + 1
-    l <- mapObjProp cSig e1 a b
-    r <- mapObjProp cSig e2 a b
+    l <- mapObjProp oSig cSig e1 a b
+    r <- mapObjProp oSig cSig e2 a b
     return $ mkForallRange (map thingDecl [a, b]) (mkImpl l r) nullRange
 
 mkEDPairs :: CASLSign -> [Int] -> Maybe O.Relation -> [(FORMULA f, FORMULA f)]
@@ -616,53 +622,53 @@ mkEDPairs s il mr pairs = do
     return (ls, s)
 
 -- | Mapping of ListFrameBit
-mapListFrameBit :: CASLSign -> Extended -> Maybe O.Relation -> ListFrameBit
+mapListFrameBit :: OS.Sign -> CASLSign -> Extended -> Maybe O.Relation -> ListFrameBit
        -> Result ([CASLFORMULA], CASLSign)
-mapListFrameBit cSig ex rel lfb =
+mapListFrameBit oSig cSig ex rel lfb =
     let err = failMsg $ PlainAxiom ex $ ListFrameBit rel lfb
     in case lfb of
     AnnotationBit _ -> return ([], cSig)
     ExpressionBit cls -> case ex of
           Misc _ -> let cel = map snd cls in do
-            (els, s) <- mapDescriptionListP cSig 1 $ comPairs cel cel
+            (els, s) <- mapDescriptionListP oSig cSig 1 $ comPairs cel cel
             mkEDPairs (uniteCASLSign cSig s) [1] rel els
           SimpleEntity (Entity _ ty iri) -> do
-              (els, s) <- mapAndUnzipM (\ (_, c) -> mapDescription cSig c 1) cls
+              (els, s) <- mapAndUnzipM (\ (_, c) -> mapDescription oSig cSig c 1) cls
               case ty of
                 NamedIndividual | rel == Just Types -> do
-                  inD <- mapIndivURI cSig iri
+                  inD <- mapIndivURI oSig cSig iri
                   return (map (mk1VDecl . mkImpl (mkEqDecl 1 inD)) els,
                         uniteL $ cSig : s)
                 DataProperty | rel == (Just $ DRRelation ADomain) -> do
-                  oEx <- mapDataProp cSig iri 1 2
+                  oEx <- mapDataProp oSig cSig iri 1 2
                   let vars = (mkNName 1, mkNName 2)
-                  return (map (mkFEI [tokDecl $ fst vars]
+                  return (map (mkFI [tokDecl $ fst vars]
                        [mkVarDecl (snd vars) dataS] oEx) els, uniteL $ cSig : s)
                 _ -> err
           ObjectEntity oe -> case rel of
               Nothing -> err
               Just re -> case re of
                   DRRelation r -> do
-                    tobjP <- mapObjProp cSig oe 1 2
-                    (tdsc, s) <- mapAndUnzipM (\ (_, c) -> mapDescription cSig c
+                    tobjP <- mapObjProp oSig cSig oe 1 2
+                    (tdsc, s) <- mapAndUnzipM (\ (_, c) -> mapDescription oSig cSig c
                         $ case r of
                                 ADomain -> 1
                                 ARange -> 2) cls
                     let vars = case r of
                                 ADomain -> (mkNName 1, mkNName 2)
                                 ARange -> (mkNName 2, mkNName 1)
-                    return (map (mkFEI [tokDecl $ fst vars]
-                            [tokDecl $ snd vars] tobjP) tdsc, uniteL $ cSig : s)
+                    return (map (mkFI [tokDecl $ fst vars] [tokDecl $ snd vars] tobjP) tdsc, 
+                            uniteL $ cSig : s)
                   _ -> err
           ClassEntity ce -> let cel = map snd cls in case rel of
               Nothing -> return ([], cSig)
               Just r -> case r of
-                EDRelation _ -> do
-                    (decrsS, s) <- mapDescriptionListP cSig 1 $ mkPairs ce cel
+                EDRelation _ -> do 
+                    (decrsS, s) <- mapDescriptionListP oSig cSig 1 $ mkPairs ce cel
                     mkEDPairs (uniteCASLSign cSig s) [1] rel decrsS
                 SubClass -> do
-                  (domT, s1) <- mapDescription cSig ce 1
-                  (codT, s2) <- mapDescriptionList cSig 1 cel
+                  (domT, s1) <- mapDescription oSig cSig ce 1
+                  (codT, s2) <- mapDescriptionList oSig cSig 1 cel
                   return (map (mk1VDecl . mkImpl domT) codT,
                         uniteL [cSig, s1, s2])
                 _ -> err
@@ -670,19 +676,19 @@ mapListFrameBit cSig ex rel lfb =
       Nothing -> err
       Just r -> case ex of
         Misc _ -> do
-            pairs <- mapComObjectPropsList cSig Nothing opl 1 2
+            pairs <- mapComObjectPropsList oSig cSig Nothing opl 1 2
             mkEDPairs cSig [1, 2] rel pairs
         ObjectEntity op -> case r of
             EDRelation _ -> do
-                pairs <- mapComObjectPropsList cSig (Just op) opl 1 2
+                pairs <- mapComObjectPropsList oSig cSig (Just op) opl 1 2
                 mkEDPairs cSig [1, 2] rel pairs
             SubPropertyOf -> do
-                os <- mapM (\ (o1, o2) -> mapSubObjProp cSig o1 o2 3)
+                os <- mapM (\ (o1, o2) -> mapSubObjProp oSig cSig o1 o2 3)
                     $ mkPairs op opl
                 return (os, cSig)
             InverseOf -> do
-                os1 <- mapM (\ o1 -> mapObjProp cSig o1 1 2) opl
-                o2 <- mapObjProp cSig op 2 1
+                os1 <- mapM (\ o1 -> mapObjProp oSig cSig o1 1 2) opl
+                o2 <- mapObjProp oSig cSig op 2 1
                 return (map (mkVDecl [1, 2] . mkEqv o2) os1, cSig)
             _ -> err
         _ -> err
@@ -690,17 +696,17 @@ mapListFrameBit cSig ex rel lfb =
       Nothing -> return ([], cSig)
       Just r -> case ex of
         Misc _ -> do
-            pairs <- mapComDataPropsList cSig Nothing dl 1 2
+            pairs <- mapComDataPropsList oSig cSig Nothing dl 1 2
             mkEDPairs cSig [1, 2] rel pairs
         SimpleEntity (Entity _ DataProperty iri) -> case r of
             SubPropertyOf -> do
-                os1 <- mapM (\ o1 -> mapDataProp cSig o1 1 2) dl
-                o2 <- mapDataProp cSig iri 2 1
+                os1 <- mapM (\ o1 -> mapDataProp oSig cSig o1 1 2) dl
+                o2 <- mapDataProp oSig cSig iri 2 1
                 return (map (mkForall [thingDecl 1, dataDecl 2]
                     . mkImpl o2) os1, cSig)
             EDRelation _ -> do
-                pairs <- mapComDataPropsList cSig (Just iri) dl 1 2
-                mkEDPairs cSig [1, 2] rel pairs
+                pairs <- mapComDataPropsList oSig cSig (Just iri) dl 1 2
+                mkEDPairs cSig [1, 2] rel pairs 
             _ -> return ([], cSig)
         _ -> err
     IndividualSameOrDifferent al -> case rel of
@@ -709,52 +715,52 @@ mapListFrameBit cSig ex rel lfb =
             let mi = case ex of
                     SimpleEntity (Entity _ NamedIndividual iri) -> Just iri
                     _ -> Nothing
-            fs <- mapComIndivList cSig re mi $ map snd al
+            fs <- mapComIndivList oSig cSig re mi $ map snd al
             return (fs, cSig)
         _ -> err
     DataPropRange dpr -> case ex of
         SimpleEntity (Entity _ DataProperty iri) -> do
-            oEx <- mapDataProp cSig iri 1 2
-            (odes, s) <- mapAndUnzipM (\ (_, c) -> mapDataRange cSig c 2) dpr
+            oEx <- mapDataProp oSig cSig iri 1 2
+            (odes, s) <- mapAndUnzipM (\ (_, c) -> mapDataRange oSig cSig c 2) dpr
             let vars = (mkNName 1, mkNName 2)
             return (map (mkFEI [tokDecl $ fst vars]
                         [tokDataDecl $ snd vars] oEx) odes, uniteL $ cSig : s)
         _ -> err
     IndividualFacts indf -> do
-        fl <- mapM (mapFact cSig ex . snd) indf
+        fl <- mapM (mapFact oSig cSig ex . snd) indf
         return (fl, cSig)
     ObjectCharacteristics ace -> case ex of
         ObjectEntity ope -> do
-            cl <- mapM (mapCharact cSig ope . snd) ace
+            cl <- mapM (mapCharact oSig cSig ope . snd) ace
             return (cl, cSig)
         _ -> err
 
 -- | Mapping of AnnFrameBit
-mapAnnFrameBit :: CASLSign -> Extended -> Annotations -> AnnFrameBit
+mapAnnFrameBit :: OS.Sign -> CASLSign -> Extended -> Annotations -> AnnFrameBit
             -> Result ([CASLFORMULA], CASLSign)
-mapAnnFrameBit cSig ex ans afb =
+mapAnnFrameBit oSig cSig ex ans afb =
     let err = failMsg $ PlainAxiom ex $ AnnFrameBit ans afb
     in case afb of
     AnnotationFrameBit _ -> return ([], cSig)
     DataFunctional -> case ex of
         SimpleEntity (Entity _ _ iri) -> do
-            so1 <- mapDataProp cSig iri 1 2
-            so2 <- mapDataProp cSig iri 1 3
+            so1 <- mapDataProp oSig cSig iri 1 2
+            so2 <- mapDataProp oSig cSig iri 1 3
             return ([mkForall (thingDecl 1 : map dataDecl [2, 3]) $ implConj
                         [so1, so2] $ mkEqVar (dataDecl 2) $ qualData 3], cSig)
         _ -> err
     DatatypeBit dr -> case ex of
         SimpleEntity (Entity _ Datatype iri) -> do
-            (odes, s) <- mapDataRange cSig dr 2
+            (odes, s) <- mapDataRange oSig cSig dr 2
             return ([mkVDataDecl [2] $ mkEqv odes $ mkMember
-                    (qualData 2) $ uriToCaslId iri], uniteCASLSign cSig s)
+                    (qualData 2) $ uriToCaslId oSig iri], uniteCASLSign cSig s)
         _ -> err
     ClassDisjointUnion clsl -> case ex of
         ClassEntity (Expression iri) -> do
-            (decrs, s1) <- mapDescriptionList cSig 1 clsl
-            (decrsS, s2) <- mapDescriptionListP cSig 1 $ comPairs clsl clsl
+            (decrs, s1) <- mapDescriptionList oSig cSig 1 clsl
+            (decrsS, s2) <- mapDescriptionListP oSig cSig 1 $ comPairs clsl clsl
             let decrsP = map (\ (x, y) -> conjunct [x, y]) decrsS
-            mcls <- mapClassURI cSig iri $ mkNName 1
+            mcls <- mapClassURI oSig cSig iri $ mkNName 1
             return ([mk1VDecl $ mkEqv mcls $ conjunct
                     [disjunct decrs, mkNC decrsP]], uniteL [cSig, s1, s2])
         _ -> err
@@ -765,31 +771,34 @@ mapAnnFrameBit cSig ex ans afb =
             uptoOP = [2 .. lo + 1]
             uptoDP = [lo + 2 .. lo + ld + 1]
             tl = lo + ld + 2
-        ol <- mapM (\ (n, o) -> mapObjProp cSig o 1 n) $ zip uptoOP opl
-        nol <- mapM (\ (n, o) -> mapObjProp cSig o tl n) $ zip uptoOP opl
-        dl <- mapM (\ (n, d) -> mapDataProp cSig d 1 n) $ zip uptoDP dpl
-        ndl <- mapM (\ (n, d) -> mapDataProp cSig d tl n) $ zip uptoDP dpl
+        ol <- mapM (\ (n, o) -> mapObjProp oSig cSig o 1 n) $ zip uptoOP opl
+        nol <- mapM (\ (n, o) -> mapObjProp oSig cSig o tl n) $ zip uptoOP opl
+        dl <- mapM (\ (n, d) -> mapDataProp oSig cSig d 1 n) $ zip uptoDP dpl
+        ndl <- mapM (\ (n, d) -> mapDataProp oSig cSig d tl n) $ zip uptoDP dpl
         (keys, s) <-
-            mapKey cSig ce (ol ++ dl) (nol ++ ndl) tl (uptoOP ++ uptoDP) lo
+            mapKey oSig cSig ce (ol ++ dl) (nol ++ ndl) tl (uptoOP ++ uptoDP) lo
         return ([keys], uniteCASLSign cSig s)
-    ObjectSubPropertyChain oplst -> do
-        os <- mapM (\ cd -> mapSubObjPropChain cSig oplst cd 3) oplst
-        return (os, cSig)
+    ObjectSubPropertyChain oplst -> 
+      case ex of 
+       ObjectEntity oe -> do
+        os <- mapSubObjPropChain oSig cSig oplst oe
+        return ([os], cSig)
+       _ -> error "wrong annotation"
 
 keyDecl :: Int -> [Int] -> [VAR_DECL]
 keyDecl h il = map thingDecl (take h il) ++ map dataDecl (drop h il)
 
-mapKey :: CASLSign -> ClassExpression -> [FORMULA ()] -> [FORMULA ()]
+mapKey :: OS.Sign -> CASLSign -> ClassExpression -> [FORMULA ()] -> [FORMULA ()]
     -> Int -> [Int] -> Int -> Result (FORMULA (), CASLSign)
-mapKey cSig ce pl npl p i h = do
-    (nce, s) <- mapDescription cSig ce 1
-    (c3, _) <- mapDescription cSig ce p
+mapKey oSig cSig ce pl npl p i h = do
+    (nce, s) <- mapDescription oSig cSig ce 1
+    (c3, _) <- mapDescription oSig cSig ce p
     let un = mkForall [thingDecl p] $ implConj (c3 : npl)
                 $ mkStEq (qualThing p) $ qualThing 1
     return (mkForall [thingDecl 1] $ mkImpl nce
             $ mkExist (keyDecl h i) $ conjunct $ pl ++ [un], s)
 
-mapAxioms :: CASLSign -> Axiom -> Result ([CASLFORMULA], CASLSign)
-mapAxioms cSig (PlainAxiom ex fb) = case fb of
-    ListFrameBit rel lfb -> mapListFrameBit cSig ex rel lfb
-    AnnFrameBit ans afb -> mapAnnFrameBit cSig ex ans afb
+mapAxioms :: OS.Sign -> CASLSign -> Axiom -> Result ([CASLFORMULA], CASLSign)
+mapAxioms oSig cSig (PlainAxiom ex fb) = case fb of
+    ListFrameBit rel lfb -> mapListFrameBit oSig cSig ex rel lfb
+    AnnFrameBit ans afb -> mapAnnFrameBit oSig cSig ex ans afb


### PR DESCRIPTION
This makes Fabian's file go through, as the prefixes are now expanded before translation of symbols to CASL. Also all the errors reported in 1203 are fixed. I will test if sentence translation contains other bugs, but I can create a new issue if that's going to be the case.