### PR TITLE
Use consistent naming of provers

### DIFF
--- a/PGIP/Common.hs
+++ b/PGIP/Common.hs
@@ -1,0 +1,7 @@
+module PGIP.Common where
+
+import Proofs.AbstractState
+
+data ProverOrConsChecker = Prover G_prover
+                         | ConsChecker G_cons_checker
+                         deriving (Show)

--- a/PGIP/Output/Formatting.hs
+++ b/PGIP/Output/Formatting.hs
@@ -1,18 +1,20 @@
-module PGIP.Output.Formatting
-  ( getWebProverName
-  , showComorph
-  , showProversOnly
-  , removeFunnyChars
-  ) where
+module PGIP.Output.Formatting where
 
 import Common.Utils
 
 import Logic.Logic
 import Logic.Comorphism
 
+import PGIP.Common
+
 import Proofs.AbstractState
 
 import Data.Char
+
+proverOrConsCheckerName :: ProverOrConsChecker -> String
+proverOrConsCheckerName p = case p of
+  Prover prover -> getWebProverName prover
+  ConsChecker consChecker -> getCcName consChecker
 
 showComorph :: AnyComorphism -> String
 showComorph (Comorphism cid) = removeFunnyChars . drop 1 . dropWhile (/= ':')

--- a/PGIP/Output/Proof.hs
+++ b/PGIP/Output/Proof.hs
@@ -10,6 +10,8 @@ module PGIP.Output.Proof
   , formatProofs
   ) where
 
+import PGIP.Common
+
 import PGIP.Output.Formatting
 import PGIP.Output.Mime
 
@@ -30,8 +32,8 @@ import Numeric
 
 import Text.XML.Light (ppTopElement)
 
-type ProofResult = (String, String, String,
-                -- (goalName, goalResult, goalDetails
+type ProofResult = (String, String, String, ProverOrConsChecker,
+                -- ^(goalName, goalResult, goalDetails, prover
                     AnyComorphism, Maybe (LP.ProofStatus G_proof_tree))
                 -- translation, proofStatusM)
 type ProofFormatter =
@@ -70,7 +72,8 @@ formatProofs format options proofs = case format of
     }
 
   convertGoal :: ProofResult -> ProofGoal
-  convertGoal (goalName, goalResult, goalDetails, translation, proofStatusM) =
+  convertGoal (goalName, goalResult, goalDetails, proverOrConsChecker,
+               translation, proofStatusM) =
     ProofGoal
       { name = goalName
       , result = goalResult
@@ -78,7 +81,7 @@ formatProofs format options proofs = case format of
           if pfoIncludeDetails options
           then Just goalDetails
           else Nothing
-      , usedProver = fmap LP.usedProver proofStatusM
+      , usedProver = proverOrConsCheckerName proverOrConsChecker
       , usedTranslation = showComorph translation
       , tacticScript = fmap convertTacticScript proofStatusM
       , proofTree = fmap (show . LP.proofTree) proofStatusM
@@ -121,7 +124,7 @@ data ProofGoal = ProofGoal
   { name :: String
   , result :: String
   , details :: Maybe String
-  , usedProver :: Maybe String
+  , usedProver :: String
   , usedTranslation :: String
   , tacticScript :: Maybe TacticScript
   , proofTree :: Maybe String

--- a/PGIP/Output/Proof.hs
+++ b/PGIP/Output/Proof.hs
@@ -33,12 +33,12 @@ import Numeric
 import Text.XML.Light (ppTopElement)
 
 type ProofResult = (String, String, String, ProverOrConsChecker,
-                -- ^(goalName, goalResult, goalDetails, prover
+                -- (goalName, goalResult, goalDetails, prover,
                     AnyComorphism, Maybe (LP.ProofStatus G_proof_tree))
                 -- translation, proofStatusM)
 type ProofFormatter =
     ProofFormatterOptions -> [(String, [ProofResult])] -> (String, String)
-                          -- [(dgNodeName, result)] -> (responseType, response)
+                          -- [(dgNodeName, result)]  -> (responseType, response)
 
 data ProofFormatterOptions = ProofFormatterOptions
   { pfoIncludeProof :: Bool

--- a/PGIP/Server.hs
+++ b/PGIP/Server.hs
@@ -12,6 +12,8 @@ Portability :  non-portable (via imports)
 
 module PGIP.Server (hetsServer) where
 
+import PGIP.Common
+
 import PGIP.Output.Formatting
 import PGIP.Output.Mime
 import PGIP.Output.Proof
@@ -1001,7 +1003,7 @@ getHetsResult opts updates sessRef (Query dgQ qk) format api pfOptions = do
                               pfOptions
                               [(getDGNodeName dgnode, proofResults)]
                       GlConsistency -> do
-                        (newLib, [(_, res, txt, _, _)]) <- consNode libEnv ln dg nl
+                        (newLib, [(_, res, txt, _, _, _)]) <- consNode libEnv ln dg nl
                           subL incl mp mt tl
                         lift $ nextSess sess sessRef newLib k
                         return (xmlC, ppTopElement $ formatConsNode res txt)
@@ -1031,7 +1033,7 @@ getHetsResult opts updates sessRef (Query dgQ qk) format api pfOptions = do
 
 formatGoals :: Bool -> [ProofResult] -> [Element]
 formatGoals includeDetails =
-  map (\ (n, e, d, _, mps) -> unode "goal"
+  map (\ (n, e, d, _, _, mps) -> unode "goal"
     ([unode "name" n, unode "result" e]
     ++ [unode "details" d | includeDetails]
     ++ case mps of
@@ -1428,7 +1430,8 @@ consNode le ln dg nl@(i, lb) subL useTh mp mt tl = do
                              CSInconsistent -> markNodeInconsistent "" lb
                              CSConsistent -> markNodeConsistent "" lb
                              _ -> lb)) le
-          return (le'', [(" ", drop 2 $ show cSt, show cstat, c, Nothing)])
+          return (le'', [(" ", drop 2 $ show cSt, show cstat,
+                          PGIP.Common.ConsChecker cc, c, Nothing)])
 
 proveNode :: LibEnv -> LibName -> DGraph -> (Int, DGNodeLab) -> G_theory
   -> G_sublogics -> Bool -> Maybe String -> Maybe String -> Maybe Int
@@ -1453,14 +1456,15 @@ proveNode le ln dg nl gTh subL useTh mp mt tl thms axioms = do
 
 combineToProofResult :: [(String, String, String)] -> (G_prover, AnyComorphism)
   -> [ProofStatus G_proof_tree] -> [ProofResult]
-combineToProofResult sens (_, comorphism) proofStatuses = let
+combineToProofResult sens (prover, comorphism) proofStatuses = let
   findProofStatusByName :: String -> Maybe (ProofStatus G_proof_tree)
   findProofStatusByName n =
     case filter ((n ==) . goalName) proofStatuses of
       [] -> Nothing
       (ps : _) -> Just ps
   combineSens :: (String, String, String) -> ProofResult
-  combineSens (n, e, d) = (n, e, d, comorphism, findProofStatusByName n)
+  combineSens (n, e, d) = (n, e, d, PGIP.Common.Prover prover, comorphism,
+                           findProofStatusByName n)
   in map combineSens sens
 
 -- run over multiple dgnodes and prove available goals for each
@@ -1493,7 +1497,7 @@ proveMultiNodes pm le ln dg useTh mp mt tl nodeSel axioms = let
 
 formatResultsAux :: Bool -> ProverMode -> String -> [ProofResult] -> Element
 formatResultsAux xF pm nm sens = unode nm $ case (sens, pm) of
-    ([(_, e, d, _, _)], GlConsistency) | xF -> formatConsNode e d
+    ([(_, e, d, _, _, _)], GlConsistency) | xF -> formatConsNode e d
     _ -> unode "results" $ formatGoals xF sens
 
 mkPath :: Session -> LibName -> Int -> String


### PR DESCRIPTION
This shall fix #1475.

Instead of the prover set in the ProofStatus object, we use the Prover
set in the proving/consistency-checking functions. This allows us to
be sure to have the prover object and use the same name-retrieval
functions as in the provers/consistency-checkers command.

The `usedProver` is like an id for ontohub and we need it to be the same all over the responses.

Running
```
curl -X POST -H 'Content-Type: application/json' http://localhost:8000/prove/http%3A%2F%2Fdevelop.ontohub.org%2Fdefault%2Fpartial_order%2F%2Fstrict_partial_order/auto -d '{"format":"json", "node":"strict_partial_order", "theorems": ["asymmetric"], "prover":"MathServeBroker"}'
```

previously we got:
```json
[{
"node": "strict_partial_order",
"goals": [{
 ... "usedProver": "MathServe Broker [via MathServe]", ...
 }]
}]
```

now we get:
```json
[{
"node": "strict_partial_order",
"goals": [{
 ... "usedProver": "MathServeBroker", ...
 }]
}]
```

while the list of provers remains:
```json
{
"provers": [
 "QuickCheck",
 "Pellet",
 "eprover",
 "darwin",
 "darwin-non-fd",
 "Vampire",
 "MathServeBroker",
 "SPASS"]
}
```