### PR TITLE
1477 REST: add display name to the provers list

### DIFF
--- a/PGIP/Output/Formatting.hs
+++ b/PGIP/Output/Formatting.hs
@@ -27,5 +27,8 @@ removeFunnyChars = filter (\ c -> isAlphaNum c || elem c "_.:-")
 getWebProverName :: G_prover -> String
 getWebProverName = removeFunnyChars . getProverName
 
+proversOnly :: [(AnyComorphism, [ProverOrConsChecker])] -> [ProverOrConsChecker]
+proversOnly = nubOrdOn proverOrConsCheckerName . concatMap snd
+
 showProversOnly :: [(AnyComorphism, [String])] -> [String]
 showProversOnly = nubOrd . concatMap snd

--- a/PGIP/Output/Provers.hs
+++ b/PGIP/Output/Provers.hs
@@ -31,7 +31,9 @@ formatProvers format proverMode availableProvers = case format of
   where
   computedProvers :: Provers
   computedProvers =
-    let proverNames = map proverOrConsCheckerName $ proversOnly availableProvers
+    let proverNames = map (\p -> Prover { name = proverOrConsCheckerName p
+                                        , displayName = ""
+                                        }) $ proversOnly availableProvers
     in case proverMode of
       GlProofs -> emptyProvers { provers = Just proverNames }
       GlConsistency -> emptyProvers { consistencyCheckers = Just proverNames }
@@ -43,8 +45,13 @@ formatProvers format proverMode availableProvers = case format of
   formatAsXML = (xmlC, ppTopElement $ asXml computedProvers)
 
 data Provers = Provers
-  { provers :: Maybe [String]
-  , consistencyCheckers :: Maybe [String]
+  { provers :: Maybe [Prover]
+  , consistencyCheckers :: Maybe [Prover]
+  } deriving (Show, Typeable, Data)
+
+data Prover = Prover
+  { name :: String
+  , displayName :: String
   } deriving (Show, Typeable, Data)
 
 emptyProvers :: Provers

--- a/PGIP/Output/Provers.hs
+++ b/PGIP/Output/Provers.hs
@@ -4,6 +4,8 @@ module PGIP.Output.Provers
   ( formatProvers
   ) where
 
+import qualified PGIP.Common
+
 import PGIP.Output.Formatting
 import PGIP.Output.Mime
 
@@ -18,8 +20,9 @@ import Text.XML.Light (ppTopElement)
 
 import Data.Data
 
-type ProversFormatter = ProverMode ->
-                        [(AnyComorphism, [String])] -> (String, String)
+type ProversFormatter = ProverMode
+                        -> [(AnyComorphism, [PGIP.Common.ProverOrConsChecker])]
+                        -> (String, String)
 
 formatProvers :: Maybe String -> ProversFormatter
 formatProvers format proverMode availableProvers = case format of
@@ -28,8 +31,8 @@ formatProvers format proverMode availableProvers = case format of
   where
   computedProvers :: Provers
   computedProvers =
-    let proverNames = showProversOnly availableProvers in
-    case proverMode of
+    let proverNames = map proverOrConsCheckerName $ proversOnly availableProvers
+    in case proverMode of
       GlProofs -> emptyProvers { provers = Just proverNames }
       GlConsistency -> emptyProvers { consistencyCheckers = Just proverNames }
 

--- a/PGIP/Output/Provers.hs
+++ b/PGIP/Output/Provers.hs
@@ -16,6 +16,8 @@ import Logic.Comorphism (AnyComorphism)
 import Common.Json (ppJson, asJson)
 import Common.ToXml (asXml)
 
+import Proofs.AbstractState
+
 import Text.XML.Light (ppTopElement)
 
 import Data.Data
@@ -32,11 +34,16 @@ formatProvers format proverMode availableProvers = case format of
   computedProvers :: Provers
   computedProvers =
     let proverNames = map (\p -> Prover { name = proverOrConsCheckerName p
-                                        , displayName = ""
+                                        , displayName = internalProverName p
                                         }) $ proversOnly availableProvers
     in case proverMode of
       GlProofs -> emptyProvers { provers = Just proverNames }
       GlConsistency -> emptyProvers { consistencyCheckers = Just proverNames }
+
+  internalProverName :: PGIP.Common.ProverOrConsChecker -> String
+  internalProverName pOrCc = case pOrCc of
+    PGIP.Common.Prover p -> getProverName p
+    PGIP.Common.ConsChecker cc -> getCcName cc
 
   formatAsJSON :: (String, String)
   formatAsJSON = (jsonC, ppJson $ asJson computedProvers)


### PR DESCRIPTION
This shall fix #1477. The displayName is not as beautiful as in the issue text, but as far as I can see, this is the best we have.

This branch is based on the branch of #1476 (**1475-use_consistent_naming_of_provers**) instead of **master**.  It might be easier to review that one first. (I needed the `PGIP.Common` module here as well.)

For
```
curl http://localhost:8000/provers/http%3A%2F%2Fdevelop.ontohub.org%2Fdefault%2Fpartial_order%2F%2Fstrict_partial_order/auto\?format\=json
```
on an Ubuntu machine I get
```json
{
"provers": [{
 "name": "QuickCheck", "displayName": "QuickCheck" }, {
 "name": "isabelle_process", "displayName": "isabelle_process" }, {
 "name": "Isabelle-jedit", "displayName": "Isabelle-jedit" }, {
 "name": "Isabelle-emacs", "displayName": "Isabelle-emacs" }, {
 "name": "eprover", "displayName": "eprover" }, {
 "name": "darwin", "displayName": "darwin" }, {
 "name": "darwin-non-fd", "displayName": "darwin-non-fd" }, {
 "name": "Vampire", "displayName": "Vampire" }, {
 "name": "MathServeBroker", "displayName": "MathServe Broker" }, {
 "name": "SPASS", "displayName": "SPASS" }, {
 "name": "Isabellesledgehammer",
 "displayName": "Isabelle (sledgehammer)"
 }, {
 "name": "Isabellerefute", "displayName": "Isabelle (refute)" }, {
 "name": "Isabellenitpick", "displayName": "Isabelle (nitpick)" }, {
 "name": "Isabelleautomated", "displayName": "Isabelle (automated)"
 }]
}
```