### PR TITLE
Always update version.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -447,7 +447,7 @@ derived_sources += $(drifted_files) Driver/Version.hs $(hs_der_files)
 .PHONY : all hets-opt hets-optimized clean o_clean clean_pretty \
     real_clean bin_clean distclean annos checkversion \
     check capa hacapa h2h h2hf showKP clean_genRules genRules \
-    count doc fromKif derivedSources release cgi ghci build callghc
+    count doc fromKif derivedSources release cgi ghci build callghc rev.txt
 
 .FORCE :
 


### PR DESCRIPTION
Shall fix #1485. This makes `Driver.Version` compile always and thus set the current version.