### PR TITLE
1488 put json keys in snake case

### DIFF
--- a/Common/Json.hs
+++ b/Common/Json.hs
@@ -41,6 +41,7 @@ import Common.GlobalAnnotations
 import Common.Id
 import Common.Parsec
 import Common.Result
+import Common.Utils
 
 import Data.Char
 import Data.Data
@@ -200,7 +201,8 @@ myDataToJson :: MyData -> Json
 myDataToJson md =
   let
     recordFieldToObject :: (String, MyData) -> (String, Json)
-    recordFieldToObject (fieldName, value) = (fieldName, myDataToJson value)
+    recordFieldToObject (fieldName, value) =
+      (toSnake fieldName, myDataToJson value)
   in
     case md of
       Builtin typ value -> case typ of

--- a/Common/Json.hs
+++ b/Common/Json.hs
@@ -202,7 +202,7 @@ myDataToJson md =
   let
     recordFieldToObject :: (String, MyData) -> (String, Json)
     recordFieldToObject (fieldName, value) =
-      (toSnake fieldName, myDataToJson value)
+      (toSnakeCase fieldName, myDataToJson value)
   in
     case md of
       Builtin typ value -> case typ of

--- a/Common/Utils.hs
+++ b/Common/Utils.hs
@@ -187,20 +187,14 @@ splitR p s =
    Based on https://gist.github.com/ruthenium/3715696
 -}
 toSnake :: String -> String
-toSnake = downcase . concat . underscores . glueSingletons "" . splitR isUpper
+toSnake = downcase . intercalate "_" . glueSingletons . splitR isUpper
   where
-    underscores :: [String] -> [String]
-    underscores [] = []
-    underscores (h : t) = h : map ('_' :) t
-
-    glueSingletons :: String -> [String] -> [String]
-    glueSingletons _ [] = []
-    glueSingletons acc ([] : ws) = glueSingletons acc ws
-    glueSingletons acc ([c] : ws) = glueSingletons (acc ++ [c]) ws
-    glueSingletons acc (w : ws) =
-      if null acc
-      then w : glueSingletons "" ws
-      else acc : w : glueSingletons "" ws
+    -- glue adjacent singleton lists together:
+    -- `glueSingletons "" ["abc", "d", "e", "fg" "h", "i"]
+    --     == ["abc", "de", "fg", "hi"]`
+    glueSingletons :: [String] -> [String]
+    glueSingletons = map (intercalate "") .
+      groupBy (\ v w -> (length w == 1) && (length v == 1))
 
 {- | The 'nubWith' function accepts as an argument a \"stop list\" update
 function and an initial stop list. The stop list is a set of list elements

--- a/Common/Utils.hs
+++ b/Common/Utils.hs
@@ -160,19 +160,17 @@ trimRight = foldr (\ c cs -> if isSpace c && null cs then [] else c : cs) ""
    `toSnakeCase "SomeSCREAMINGCamelCase" == "some_screaming_camel_case"`
 -}
 toSnakeCase :: String -> String
-toSnakeCase = toSnakeCase' False
-  where
-    toSnakeCase' :: Bool -> String -> String
-    toSnakeCase' screaming camel =
-      case camel of
-        a : r@(b : _) -> let
-          snake_tail = toSnakeCase' True r
-          snake_head = toLower a
-          in case (isLower a, isLower b) of
-            (True, False) -> a : '_' : toSnakeCase' False r
-            (False, True) | screaming -> '_' : snake_head : snake_tail
-            _ -> snake_head : snake_tail
-        _ -> map toLower camel
+toSnakeCase c = if hasBump c then unScream c else mkSnake c where
+  hasBump s = case s of
+    a : b : _ -> isUpper a && isLower b
+    _ -> False
+  unScream s = case s of
+    a : r -> toLower a : mkSnake r
+    _ -> s
+  mkSnake s = let newSnake t = '_' : unScream t in case s of
+    a : r@(b : _) | hasBump [b, a] -> a : newSnake r
+    _ | hasBump s -> newSnake s
+    _ -> unScream s
 
 {- | The 'nubWith' function accepts as an argument a \"stop list\" update
 function and an initial stop list. The stop list is a set of list elements


### PR DESCRIPTION
This shall fix #1488.

Truncated example output:

```json
❯ http --json http://localhost:8000/prove/http%3A%2F%2Fstaging.ontohub.org%2Fsandbox%2FSimple_Implications/auto axioms:='["leftunit"]' theorems:='["Group"]' format=json
HTTP/1.1 200 OK
Content-Type: application/json
Date: Mon, 20 Apr 2015 06:57:50 GMT
Server: Warp/3.0.11
Transfer-Encoding: chunked

[
    {
        "goals": [
            {
                "details": "",
                "name": "rightunit",
                "proof_tree": "",
                "prover_output": "...",
                "result": "Disproved",
                "tactic_script": {
                    "extra_options": [
                        "-DocProof"
                    ],
                    "time_limit": 1
                },
                "used_axioms": [],
                "used_prover": "SPASS",
                "used_time": {
                    "components": {
                        "hours": 0,
                        "mins": 0,
                        "secs": 0
                    },
                    "seconds": 0
                },
                "used_translation": "CASL2SoftFOL"
            },
            {
                "details": "",
                "name": "zero_plus",
                "proof_tree": "",
                "prover_output": "...",
                "result": "Proved",
                "tactic_script": {
                    "extra_options": [
                        "-DocProof"
                    ],
                    "time_limit": 1
                },
                "used_axioms": [
                    "leftunit"
                ],
                "used_prover": "SPASS",
                "used_time": {
                    "components": {
                        "hours": 0,
                        "mins": 0,
                        "secs": 0
                    },
                    "seconds": 0
                },
                "used_translation": "CASL2SoftFOL"
            }
        ],
        "node": "Group"
    }
]
```