### PR TITLE
Fix proving when MathServe is not available.

### DIFF
--- a/PGIP/Output/Proof.hs
+++ b/PGIP/Output/Proof.hs
@@ -83,7 +83,7 @@ formatProofs format options proofs = case format of
           else Nothing
       , usedProver = proverOrConsCheckerName proverOrConsChecker
       , usedTranslation = showComorph translation
-      , tacticScript = fmap convertTacticScript proofStatusM
+      , tacticScript = convertTacticScript proofStatusM
       , proofTree = fmap (show . LP.proofTree) proofStatusM
       , usedTime = fmap (convertTime . LP.usedTime) proofStatusM
       , usedAxioms = fmap LP.usedAxioms proofStatusM
@@ -108,12 +108,17 @@ formatProofs format options proofs = case format of
         _ -> error $ "Failed reading the number " ++ show (todSec tod)
     }
 
-  convertTacticScript :: LP.ProofStatus G_proof_tree -> TacticScript
-  convertTacticScript ps =
-    let atp = read $ (\ (LP.TacticScript ts) -> ts) $ LP.tacticScript ps
-    in TacticScript { timeLimit = tsTimeLimit atp
-                    , extraOptions = tsExtraOpts atp
-                    }
+  convertTacticScript :: Maybe (LP.ProofStatus G_proof_tree)
+                      -> Maybe TacticScript
+  convertTacticScript Nothing = Nothing
+  convertTacticScript (Just ps) =
+    let ts = (\ (LP.TacticScript ts) -> ts) $ LP.tacticScript ps
+        atp = read ts
+    in if null ts
+       then Nothing
+       else Just $ TacticScript { timeLimit = tsTimeLimit atp
+                                , extraOptions = tsExtraOpts atp
+                                }
 
 data Proof = Proof
   { node :: String

--- a/PGIP/Output/Proof.hs
+++ b/PGIP/Output/Proof.hs
@@ -24,6 +24,7 @@ import Proofs.AbstractState (G_proof_tree)
 
 import Common.Json (ppJson, asJson)
 import Common.ToXml (asXml)
+import Common.Utils (readMaybe)
 
 import Data.Data
 import Data.Time.LocalTime
@@ -112,13 +113,12 @@ formatProofs format options proofs = case format of
                       -> Maybe TacticScript
   convertTacticScript Nothing = Nothing
   convertTacticScript (Just ps) =
-    let ts = (\ (LP.TacticScript ts) -> ts) $ LP.tacticScript ps
-        atp = read ts
-    in if null ts
-       then Nothing
-       else Just $ TacticScript { timeLimit = tsTimeLimit atp
-                                , extraOptions = tsExtraOpts atp
-                                }
+    let tsStr = (\ (LP.TacticScript ts) -> ts) $ LP.tacticScript ps
+    in case readMaybe tsStr of
+         Nothing -> Nothing
+         Just atp -> Just TacticScript { timeLimit = tsTimeLimit atp
+                                       , extraOptions = tsExtraOpts atp
+                                       }
 
 data Proof = Proof
   { node :: String

--- a/PGIP/Output/Proof.hs
+++ b/PGIP/Output/Proof.hs
@@ -113,12 +113,11 @@ formatProofs format options proofs = case format of
                       -> Maybe TacticScript
   convertTacticScript Nothing = Nothing
   convertTacticScript (Just ps) =
-    let tsStr = (\ (LP.TacticScript ts) -> ts) $ LP.tacticScript ps
-    in case readMaybe tsStr of
-         Nothing -> Nothing
-         Just atp -> Just TacticScript { timeLimit = tsTimeLimit atp
-                                       , extraOptions = tsExtraOpts atp
-                                       }
+    case (\ (LP.TacticScript ts) -> readMaybe ts) $ LP.tacticScript ps of
+      Nothing -> Nothing
+      Just atp -> Just TacticScript { timeLimit = tsTimeLimit atp
+                                    , extraOptions = tsExtraOpts atp
+                                    }
 
 data Proof = Proof
   { node :: String


### PR DESCRIPTION
With MathServ being offline, we get an empty string as the tactic
script. Calling `read` on it results in the error `no parse`.

To fix this, we simply return no tactic script (`Nothing`) in this case.