### PR TITLE
Add display name to prove-output.

### DIFF
--- a/PGIP/Common.hs
+++ b/PGIP/Common.hs
@@ -1,7 +1,0 @@
-module PGIP.Common where
-
-import Proofs.AbstractState
-
-data ProverOrConsChecker = Prover G_prover
-                         | ConsChecker G_cons_checker
-                         deriving (Show)

--- a/PGIP/Output/Formatting.hs
+++ b/PGIP/Output/Formatting.hs
@@ -9,9 +9,6 @@ import Proofs.AbstractState
 
 import Data.Char
 
-proverOrConsCheckerName :: ProverOrConsChecker -> String
-proverOrConsCheckerName = mkNiceProverName . internalProverName
-
 internalProverName :: ProverOrConsChecker -> String
 internalProverName pOrCc = case pOrCc of
   Proofs.AbstractState.Prover pr -> getProverName pr
@@ -29,7 +26,7 @@ getWebProverName :: G_prover -> String
 getWebProverName = mkNiceProverName . getProverName
 
 proversOnly :: [(AnyComorphism, [ProverOrConsChecker])] -> [ProverOrConsChecker]
-proversOnly = nubOrdOn proverOrConsCheckerName . concatMap snd
+proversOnly = nubOrdOn (mkNiceProverName . internalProverName) . concatMap snd
 
 showProversOnly :: [(AnyComorphism, [String])] -> [String]
 showProversOnly = nubOrd . concatMap snd

--- a/PGIP/Output/Formatting.hs
+++ b/PGIP/Output/Formatting.hs
@@ -12,9 +12,12 @@ import Proofs.AbstractState
 import Data.Char
 
 proverOrConsCheckerName :: ProverOrConsChecker -> String
-proverOrConsCheckerName p = case p of
-  Prover prover -> getWebProverName prover
-  ConsChecker consChecker -> getCcName consChecker
+proverOrConsCheckerName = removeFunnyChars . internalProverName
+
+internalProverName :: ProverOrConsChecker -> String
+internalProverName pOrCc = case pOrCc of
+  PGIP.Common.Prover pr -> getProverName pr
+  PGIP.Common.ConsChecker cc -> getCcName cc
 
 showComorph :: AnyComorphism -> String
 showComorph (Comorphism cid) = removeFunnyChars . drop 1 . dropWhile (/= ':')

--- a/PGIP/Output/Formatting.hs
+++ b/PGIP/Output/Formatting.hs
@@ -22,9 +22,6 @@ showComorph (Comorphism cid) = mkNiceProverName . drop 1 . dropWhile (/= ':')
 mkNiceProverName :: String -> String
 mkNiceProverName = filter (\ c -> isAlphaNum c || elem c "_.:-")
 
-getWebProverName :: G_prover -> String
-getWebProverName = mkNiceProverName . getProverName
-
 proversOnly :: [(AnyComorphism, [ProverOrConsChecker])] -> [ProverOrConsChecker]
 proversOnly = nubOrdOn (mkNiceProverName . internalProverName) . concatMap snd
 

--- a/PGIP/Output/Formatting.hs
+++ b/PGIP/Output/Formatting.hs
@@ -10,7 +10,7 @@ import Proofs.AbstractState
 import Data.Char
 
 proverOrConsCheckerName :: ProverOrConsChecker -> String
-proverOrConsCheckerName = removeFunnyChars . internalProverName
+proverOrConsCheckerName = mkNiceProverName . internalProverName
 
 internalProverName :: ProverOrConsChecker -> String
 internalProverName pOrCc = case pOrCc of
@@ -18,15 +18,15 @@ internalProverName pOrCc = case pOrCc of
   Proofs.AbstractState.ConsChecker cc -> getCcName cc
 
 showComorph :: AnyComorphism -> String
-showComorph (Comorphism cid) = removeFunnyChars . drop 1 . dropWhile (/= ':')
+showComorph (Comorphism cid) = mkNiceProverName . drop 1 . dropWhile (/= ':')
   . map (\ c -> if c == ';' then ':' else c)
   $ language_name cid
 
-removeFunnyChars :: String -> String
-removeFunnyChars = filter (\ c -> isAlphaNum c || elem c "_.:-")
+mkNiceProverName :: String -> String
+mkNiceProverName = filter (\ c -> isAlphaNum c || elem c "_.:-")
 
 getWebProverName :: G_prover -> String
-getWebProverName = removeFunnyChars . getProverName
+getWebProverName = mkNiceProverName . getProverName
 
 proversOnly :: [(AnyComorphism, [ProverOrConsChecker])] -> [ProverOrConsChecker]
 proversOnly = nubOrdOn proverOrConsCheckerName . concatMap snd

--- a/PGIP/Output/Formatting.hs
+++ b/PGIP/Output/Formatting.hs
@@ -5,8 +5,6 @@ import Common.Utils
 import Logic.Logic
 import Logic.Comorphism
 
-import PGIP.Common
-
 import Proofs.AbstractState
 
 import Data.Char
@@ -16,8 +14,8 @@ proverOrConsCheckerName = removeFunnyChars . internalProverName
 
 internalProverName :: ProverOrConsChecker -> String
 internalProverName pOrCc = case pOrCc of
-  PGIP.Common.Prover pr -> getProverName pr
-  PGIP.Common.ConsChecker cc -> getCcName cc
+  Proofs.AbstractState.Prover pr -> getProverName pr
+  Proofs.AbstractState.ConsChecker cc -> getCcName cc
 
 showComorph :: AnyComorphism -> String
 showComorph (Comorphism cid) = removeFunnyChars . drop 1 . dropWhile (/= ':')

--- a/PGIP/Output/Formatting.hs
+++ b/PGIP/Output/Formatting.hs
@@ -11,8 +11,8 @@ import Data.Char
 
 internalProverName :: ProverOrConsChecker -> String
 internalProverName pOrCc = case pOrCc of
-  Proofs.AbstractState.Prover pr -> getProverName pr
-  Proofs.AbstractState.ConsChecker cc -> getCcName cc
+  Prover pr -> getProverName pr
+  ConsChecker cc -> getCcName cc
 
 showComorph :: AnyComorphism -> String
 showComorph (Comorphism cid) = mkNiceProverName . drop 1 . dropWhile (/= ':')

--- a/PGIP/Output/Proof.hs
+++ b/PGIP/Output/Proof.hs
@@ -10,8 +10,6 @@ module PGIP.Output.Proof
   , formatProofs
   ) where
 
-import PGIP.Common
-
 import PGIP.Output.Formatting
 import PGIP.Output.Mime
 import PGIP.Output.Provers (Prover, prepareFormatProver)
@@ -21,7 +19,7 @@ import Logic.Comorphism (AnyComorphism)
 
 import qualified Logic.Prover as LP
 
-import Proofs.AbstractState (G_proof_tree)
+import Proofs.AbstractState (G_proof_tree, ProverOrConsChecker)
 
 import Common.Json (ppJson, asJson)
 import Common.ToXml (asXml)

--- a/PGIP/Output/Proof.hs
+++ b/PGIP/Output/Proof.hs
@@ -14,6 +14,7 @@ import PGIP.Common
 
 import PGIP.Output.Formatting
 import PGIP.Output.Mime
+import PGIP.Output.Provers (Prover, prepareFormatProver)
 
 import Interfaces.GenericATPState (tsTimeLimit, tsExtraOpts)
 import Logic.Comorphism (AnyComorphism)
@@ -81,7 +82,7 @@ formatProofs format options proofs = case format of
           if pfoIncludeDetails options
           then Just goalDetails
           else Nothing
-      , usedProver = proverOrConsCheckerName proverOrConsChecker
+      , usedProver = prepareFormatProver proverOrConsChecker
       , usedTranslation = showComorph translation
       , tacticScript = fmap convertTacticScript proofStatusM
       , proofTree = fmap (show . LP.proofTree) proofStatusM
@@ -124,7 +125,7 @@ data ProofGoal = ProofGoal
   { name :: String
   , result :: String
   , details :: Maybe String
-  , usedProver :: String
+  , usedProver :: Prover
   , usedTranslation :: String
   , tacticScript :: Maybe TacticScript
   , proofTree :: Maybe String

--- a/PGIP/Output/Provers.hs
+++ b/PGIP/Output/Provers.hs
@@ -18,8 +18,6 @@ import Logic.Comorphism (AnyComorphism)
 import Common.Json (ppJson, asJson)
 import Common.ToXml (asXml)
 
-import Proofs.AbstractState
-
 import Text.XML.Light (ppTopElement)
 
 import Data.Data
@@ -50,12 +48,6 @@ prepareFormatProver :: PGIP.Common.ProverOrConsChecker -> Prover
 prepareFormatProver p = Prover { name = proverOrConsCheckerName p
                                , displayName = internalProverName p
                                }
-  where
-  internalProverName :: PGIP.Common.ProverOrConsChecker -> String
-  internalProverName pOrCc = case pOrCc of
-    PGIP.Common.Prover pr -> getProverName pr
-    PGIP.Common.ConsChecker cc -> getCcName cc
-
 
 data Provers = Provers
   { provers :: Maybe [Prover]

--- a/PGIP/Output/Provers.hs
+++ b/PGIP/Output/Provers.hs
@@ -62,4 +62,4 @@ emptyProvers :: Provers
 emptyProvers = Provers { provers = Nothing, consistencyCheckers = Nothing }
 
 mkProver :: String -> Prover
-mkProver s = Prover { name = s, identifier = removeFunnyChars s }
+mkProver s = Prover { name = s, identifier = mkNiceProverName s }

--- a/PGIP/Output/Provers.hs
+++ b/PGIP/Output/Provers.hs
@@ -2,6 +2,8 @@
 
 module PGIP.Output.Provers
   ( formatProvers
+  , prepareFormatProver
+  , Prover (..)
   ) where
 
 import qualified PGIP.Common
@@ -33,23 +35,27 @@ formatProvers format proverMode availableProvers = case format of
   where
   computedProvers :: Provers
   computedProvers =
-    let proverNames = map (\p -> Prover { name = proverOrConsCheckerName p
-                                        , displayName = internalProverName p
-                                        }) $ proversOnly availableProvers
+    let proverNames = map prepareFormatProver $ proversOnly availableProvers
     in case proverMode of
       GlProofs -> emptyProvers { provers = Just proverNames }
       GlConsistency -> emptyProvers { consistencyCheckers = Just proverNames }
-
-  internalProverName :: PGIP.Common.ProverOrConsChecker -> String
-  internalProverName pOrCc = case pOrCc of
-    PGIP.Common.Prover p -> getProverName p
-    PGIP.Common.ConsChecker cc -> getCcName cc
 
   formatAsJSON :: (String, String)
   formatAsJSON = (jsonC, ppJson $ asJson computedProvers)
 
   formatAsXML :: (String, String)
   formatAsXML = (xmlC, ppTopElement $ asXml computedProvers)
+
+prepareFormatProver :: PGIP.Common.ProverOrConsChecker -> Prover
+prepareFormatProver p = Prover { name = proverOrConsCheckerName p
+                               , displayName = internalProverName p
+                               }
+  where
+  internalProverName :: PGIP.Common.ProverOrConsChecker -> String
+  internalProverName pOrCc = case pOrCc of
+    PGIP.Common.Prover pr -> getProverName pr
+    PGIP.Common.ConsChecker cc -> getCcName cc
+
 
 data Provers = Provers
   { provers :: Maybe [Prover]

--- a/PGIP/Output/Provers.hs
+++ b/PGIP/Output/Provers.hs
@@ -3,7 +3,8 @@
 module PGIP.Output.Provers
   ( formatProvers
   , prepareFormatProver
-  , Prover (..)
+  , Prover
+  , mkProver
   ) where
 
 import PGIP.Output.Formatting
@@ -45,9 +46,7 @@ formatProvers format proverMode availableProvers = case format of
   formatAsXML = (xmlC, ppTopElement $ asXml computedProvers)
 
 prepareFormatProver :: ProverOrConsChecker -> Prover
-prepareFormatProver p = Prover { identifier = proverOrConsCheckerName p
-                               , name = internalProverName p
-                               }
+prepareFormatProver = mkProver . internalProverName
 
 data Provers = Provers
   { provers :: Maybe [Prover]
@@ -61,3 +60,6 @@ data Prover = Prover
 
 emptyProvers :: Provers
 emptyProvers = Provers { provers = Nothing, consistencyCheckers = Nothing }
+
+mkProver :: String -> Prover
+mkProver s = Prover { name = s, identifier = removeFunnyChars s }

--- a/PGIP/Output/Provers.hs
+++ b/PGIP/Output/Provers.hs
@@ -6,14 +6,14 @@ module PGIP.Output.Provers
   , Prover (..)
   ) where
 
-import qualified PGIP.Common
-
 import PGIP.Output.Formatting
 import PGIP.Output.Mime
 
 import PGIP.Query (ProverMode (..))
 
 import Logic.Comorphism (AnyComorphism)
+
+import Proofs.AbstractState (ProverOrConsChecker)
 
 import Common.Json (ppJson, asJson)
 import Common.ToXml (asXml)
@@ -23,7 +23,7 @@ import Text.XML.Light (ppTopElement)
 import Data.Data
 
 type ProversFormatter = ProverMode
-                        -> [(AnyComorphism, [PGIP.Common.ProverOrConsChecker])]
+                        -> [(AnyComorphism, [ProverOrConsChecker])]
                         -> (String, String)
 
 formatProvers :: Maybe String -> ProversFormatter
@@ -44,7 +44,7 @@ formatProvers format proverMode availableProvers = case format of
   formatAsXML :: (String, String)
   formatAsXML = (xmlC, ppTopElement $ asXml computedProvers)
 
-prepareFormatProver :: PGIP.Common.ProverOrConsChecker -> Prover
+prepareFormatProver :: ProverOrConsChecker -> Prover
 prepareFormatProver p = Prover { identifier = proverOrConsCheckerName p
                                , name = internalProverName p
                                }

--- a/PGIP/Output/Provers.hs
+++ b/PGIP/Output/Provers.hs
@@ -45,8 +45,8 @@ formatProvers format proverMode availableProvers = case format of
   formatAsXML = (xmlC, ppTopElement $ asXml computedProvers)
 
 prepareFormatProver :: PGIP.Common.ProverOrConsChecker -> Prover
-prepareFormatProver p = Prover { name = proverOrConsCheckerName p
-                               , displayName = internalProverName p
+prepareFormatProver p = Prover { identifier = proverOrConsCheckerName p
+                               , name = internalProverName p
                                }
 
 data Provers = Provers
@@ -55,8 +55,8 @@ data Provers = Provers
   } deriving (Show, Typeable, Data)
 
 data Prover = Prover
-  { name :: String
-  , displayName :: String
+  { identifier :: String
+  , name :: String
   } deriving (Show, Typeable, Data)
 
 emptyProvers :: Provers

--- a/PGIP/Server.hs
+++ b/PGIP/Server.hs
@@ -12,8 +12,6 @@ Portability :  non-portable (via imports)
 
 module PGIP.Server (hetsServer) where
 
-import PGIP.Common
-
 import PGIP.Output.Formatting
 import PGIP.Output.Mime
 import PGIP.Output.Proof
@@ -1380,7 +1378,7 @@ proversToStringAux = map (\ (x, ps) -> (x, map proverOrConsCheckerName ps))
 getProversAux :: Maybe String -> G_sublogics
               -> IO [(AnyComorphism, [ProverOrConsChecker])]
 getProversAux mt x =
-  fmap (groupOnSnd PGIP.Common.Prover) $ getFilteredProvers mt x
+  fmap (groupOnSnd Proofs.AbstractState.Prover) $ getFilteredProvers mt x
 
 getFilteredProvers :: Maybe String -> G_sublogics
   -> IO [(G_prover, AnyComorphism)]
@@ -1398,7 +1396,7 @@ formatProvers pm = let
 getConsCheckersAux :: Maybe String -> G_sublogics
   -> IO [(AnyComorphism, [ProverOrConsChecker])]
 getConsCheckersAux mt =
-  fmap (groupOnSnd PGIP.Common.ConsChecker) . getFilteredConsCheckers mt
+  fmap (groupOnSnd Proofs.AbstractState.ConsChecker) . getFilteredConsCheckers mt
 
 getFilteredConsCheckers :: Maybe String -> G_sublogics
   -> IO [(G_cons_checker, AnyComorphism)]
@@ -1440,7 +1438,7 @@ consNode le ln dg nl@(i, lb) subL useTh mp mt tl = do
                              CSConsistent -> markNodeConsistent "" lb
                              _ -> lb)) le
           return (le'', [(" ", drop 2 $ show cSt, show cstat,
-                          PGIP.Common.ConsChecker cc, c, Nothing)])
+                          Proofs.AbstractState.ConsChecker cc, c, Nothing)])
 
 proveNode :: LibEnv -> LibName -> DGraph -> (Int, DGNodeLab) -> G_theory
   -> G_sublogics -> Bool -> Maybe String -> Maybe String -> Maybe Int
@@ -1472,8 +1470,8 @@ combineToProofResult sens (prover, comorphism) proofStatuses = let
       [] -> Nothing
       (ps : _) -> Just ps
   combineSens :: (String, String, String) -> ProofResult
-  combineSens (n, e, d) = (n, e, d, PGIP.Common.Prover prover, comorphism,
-                           findProofStatusByName n)
+  combineSens (n, e, d) = (n, e, d, Proofs.AbstractState.Prover prover,
+                           comorphism, findProofStatusByName n)
   in map combineSens sens
 
 -- run over multiple dgnodes and prove available goals for each

--- a/PGIP/Server.hs
+++ b/PGIP/Server.hs
@@ -57,24 +57,24 @@ import Logic.LGToXml
 import Syntax.ToXml
 import Syntax.Print_AS_Structured
 
-import Interfaces.Command hiding (Prover)
+import Interfaces.Command
 import Interfaces.CmdAction
 import Interfaces.GenericATPState
 
 import Comorphisms.LogicGraph
 
-import Logic.Prover hiding (ConsChecker, Prover)
+import Logic.Prover
 import Logic.Grothendieck
 import Logic.Comorphism
 import Logic.Logic
 
-import Proofs.AbstractState
+import Proofs.AbstractState as AbsState
 import Proofs.ConsistencyCheck
 
 import Text.ParserCombinators.Parsec (parse)
 
 import Text.XML.Light
-import Text.XML.Light.Cursor hiding (findChild)
+import Text.XML.Light.Cursor
 
 import Common.AutoProofUtils
 import Common.Doc
@@ -1379,7 +1379,7 @@ proversToStringAux = map (\ (x, ps) ->
 getProversAux :: Maybe String -> G_sublogics
               -> IO [(AnyComorphism, [ProverOrConsChecker])]
 getProversAux mt x =
-  fmap (groupOnSnd Prover) $ getFilteredProvers mt x
+  fmap (groupOnSnd AbsState.Prover) $ getFilteredProvers mt x
 
 getFilteredProvers :: Maybe String -> G_sublogics
   -> IO [(G_prover, AnyComorphism)]
@@ -1397,7 +1397,7 @@ formatProvers pm = let
 getConsCheckersAux :: Maybe String -> G_sublogics
   -> IO [(AnyComorphism, [ProverOrConsChecker])]
 getConsCheckersAux mt =
-  fmap (groupOnSnd ConsChecker) . getFilteredConsCheckers mt
+  fmap (groupOnSnd AbsState.ConsChecker) . getFilteredConsCheckers mt
 
 getFilteredConsCheckers :: Maybe String -> G_sublogics
   -> IO [(G_cons_checker, AnyComorphism)]
@@ -1439,7 +1439,7 @@ consNode le ln dg nl@(i, lb) subL useTh mp mt tl = do
                              CSConsistent -> markNodeConsistent "" lb
                              _ -> lb)) le
           return (le'', [(" ", drop 2 $ show cSt, show cstat,
-                          ConsChecker cc, c, Nothing)])
+                          AbsState.ConsChecker cc, c, Nothing)])
 
 proveNode :: LibEnv -> LibName -> DGraph -> (Int, DGNodeLab) -> G_theory
   -> G_sublogics -> Bool -> Maybe String -> Maybe String -> Maybe Int
@@ -1471,7 +1471,7 @@ combineToProofResult sens (prover, comorphism) proofStatuses = let
       [] -> Nothing
       (ps : _) -> Just ps
   combineSens :: (String, String, String) -> ProofResult
-  combineSens (n, e, d) = (n, e, d, Prover prover, comorphism,
+  combineSens (n, e, d) = (n, e, d, AbsState.Prover prover, comorphism,
                            findProofStatusByName n)
   in map combineSens sens
 

--- a/PGIP/Server.hs
+++ b/PGIP/Server.hs
@@ -1002,8 +1002,8 @@ getHetsResult opts updates sessRef (Query dgQ qk) format api pfOptions = do
                               pfOptions
                               [(getDGNodeName dgnode, proofResults)]
                       GlConsistency -> do
-                        (newLib, [(_, res, txt, _, _, _)]) <- consNode libEnv ln dg nl
-                          subL incl mp mt tl
+                        (newLib, [(_, res, txt, _, _, _)]) <-
+                          consNode libEnv ln dg nl subL incl mp mt tl
                         lift $ nextSess sess sessRef newLib k
                         return (xmlC, ppTopElement $ formatConsNode res txt)
                     _ -> case nc of
@@ -1304,9 +1304,9 @@ showProverSelection prOrCons subLs = do
         , "    }"
         , "  }"
         , "}" ]
-  pcs <- mapM (liftM proversToStringAux . ((case prOrCons of
+  pcs <- mapM (liftM proversToStringAux . (case prOrCons of
     GlProofs -> getProversAux
-    GlConsistency -> getConsCheckersAux) Nothing)) subLs
+    GlConsistency -> getConsCheckersAux) Nothing) subLs
   let allPrCm = nub $ concat pcs
   -- create prover selection (drop-down)
       prs = add_attr (mkAttr "name" "prover") $ unode "select" $ map (\ p ->

--- a/PGIP/Server.hs
+++ b/PGIP/Server.hs
@@ -1331,7 +1331,7 @@ filterByProver :: Maybe String -> [(G_prover, AnyComorphism)]
   -> [(G_prover, AnyComorphism)]
 filterByProver mp = case mp of
       Nothing -> id
-      Just p -> filter ((== p) . getWebProverName . fst)
+      Just p -> filter ((== p) . mkNiceProverName . getProverName . fst)
 
 filterByComorph :: Maybe String -> [(a, AnyComorphism)]
   -> [(a, AnyComorphism)]

--- a/PGIP/Server.hs
+++ b/PGIP/Server.hs
@@ -1371,7 +1371,8 @@ groupOnSnd f =
 
 proversToStringAux :: [(AnyComorphism, [ProverOrConsChecker])]
                    -> [(AnyComorphism, [String])]
-proversToStringAux = map (\ (x, ps) -> (x, map proverOrConsCheckerName ps))
+proversToStringAux = map (\ (x, ps) ->
+                           (x, map (mkNiceProverName . internalProverName) ps))
 
 {- | gather provers and comorphisms and resort them to
 (comorhism, supported provers) while not changing orig comorphism order -}

--- a/PGIP/Server.hs
+++ b/PGIP/Server.hs
@@ -57,13 +57,13 @@ import Logic.LGToXml
 import Syntax.ToXml
 import Syntax.Print_AS_Structured
 
-import Interfaces.Command
+import Interfaces.Command hiding (Prover)
 import Interfaces.CmdAction
 import Interfaces.GenericATPState
 
 import Comorphisms.LogicGraph
 
-import Logic.Prover
+import Logic.Prover hiding (ConsChecker, Prover)
 import Logic.Grothendieck
 import Logic.Comorphism
 import Logic.Logic
@@ -1379,7 +1379,7 @@ proversToStringAux = map (\ (x, ps) ->
 getProversAux :: Maybe String -> G_sublogics
               -> IO [(AnyComorphism, [ProverOrConsChecker])]
 getProversAux mt x =
-  fmap (groupOnSnd Proofs.AbstractState.Prover) $ getFilteredProvers mt x
+  fmap (groupOnSnd Prover) $ getFilteredProvers mt x
 
 getFilteredProvers :: Maybe String -> G_sublogics
   -> IO [(G_prover, AnyComorphism)]
@@ -1397,7 +1397,7 @@ formatProvers pm = let
 getConsCheckersAux :: Maybe String -> G_sublogics
   -> IO [(AnyComorphism, [ProverOrConsChecker])]
 getConsCheckersAux mt =
-  fmap (groupOnSnd Proofs.AbstractState.ConsChecker) . getFilteredConsCheckers mt
+  fmap (groupOnSnd ConsChecker) . getFilteredConsCheckers mt
 
 getFilteredConsCheckers :: Maybe String -> G_sublogics
   -> IO [(G_cons_checker, AnyComorphism)]
@@ -1439,7 +1439,7 @@ consNode le ln dg nl@(i, lb) subL useTh mp mt tl = do
                              CSConsistent -> markNodeConsistent "" lb
                              _ -> lb)) le
           return (le'', [(" ", drop 2 $ show cSt, show cstat,
-                          Proofs.AbstractState.ConsChecker cc, c, Nothing)])
+                          ConsChecker cc, c, Nothing)])
 
 proveNode :: LibEnv -> LibName -> DGraph -> (Int, DGNodeLab) -> G_theory
   -> G_sublogics -> Bool -> Maybe String -> Maybe String -> Maybe Int
@@ -1471,8 +1471,8 @@ combineToProofResult sens (prover, comorphism) proofStatuses = let
       [] -> Nothing
       (ps : _) -> Just ps
   combineSens :: (String, String, String) -> ProofResult
-  combineSens (n, e, d) = (n, e, d, Proofs.AbstractState.Prover prover,
-                           comorphism, findProofStatusByName n)
+  combineSens (n, e, d) = (n, e, d, Prover prover, comorphism,
+                           findProofStatusByName n)
   in map combineSens sens
 
 -- run over multiple dgnodes and prove available goals for each

--- a/Proofs/AbstractState.hs
+++ b/Proofs/AbstractState.hs
@@ -15,7 +15,8 @@ It is also used by the CMDL interface.
 -}
 
 module Proofs.AbstractState
-    ( G_prover (..)
+    ( ProverOrConsChecker (..)
+    , G_prover (..)
     , G_proof_tree (..)
     , getProverName
     , getCcName
@@ -80,6 +81,10 @@ import Static.GTheory
 -- import Interfaces.DataTypes (IntState)
 
 -- * Provers
+
+data ProverOrConsChecker = Prover G_prover
+                         | ConsChecker G_cons_checker
+                         deriving (Show)
 
 -- | provers and consistency checkers for specific logics
 data G_prover =


### PR DESCRIPTION
In Ontohub, we need the `used_prover` key of the `prove` command to include the `display_name` as well. I didn't think about it when I created #1478.