### PR TITLE
Add more clif-specifics to magic file.

### DIFF
--- a/magic/hets.magic
+++ b/magic/hets.magic
@@ -124,7 +124,7 @@
 0       search/4096/t   \(or\                   CLIF document
 !:mime  text/clif
 
-0       search/4096/t   \if(\                   CLIF document
+0       search/4096/t   \(if\                   CLIF document
 !:mime  text/clif
 
 0       search/4096/t   \(iff\                  CLIF document

--- a/magic/hets.magic
+++ b/magic/hets.magic
@@ -94,6 +94,12 @@
 0       search/4096/t   \(cl-text\              CLIF document
 !:mime  text/clif
 
+0       search/4096/t   \(cl-module\            CLIF document
+!:mime  text/clif
+
+0       search/4096/t   \(cl-excludes\          CLIF document
+!:mime  text/clif
+
 0       search/4096/t   \(cl-imports\           CLIF document
 !:mime  text/clif
 
@@ -101,6 +107,30 @@
 !:mime  text/clif
 
 0       search/4096/t   \(cl-comment\           CLIF document
+!:mime  text/clif
+
+0       search/4096/t   \(cl-roleset\           CLIF document
+!:mime  text/clif
+
+0       search/4096/t   \(forall\               CLIF document
+!:mime  text/clif
+
+0       search/4096/t   \(exists\               CLIF document
+!:mime  text/clif
+
+0       search/4096/t   \(and\                  CLIF document
+!:mime  text/clif
+
+0       search/4096/t   \(or\                   CLIF document
+!:mime  text/clif
+
+0       search/4096/t   \if(\                   CLIF document
+!:mime  text/clif
+
+0       search/4096/t   \(iff\                  CLIF document
+!:mime  text/clif
+
+0       search/4096/t   \(not\                  CLIF document
 !:mime  text/clif
 
 # DOL


### PR DESCRIPTION
This should fix #1516. Using `file -m ` with the new magic file, the referenced file from the issue is recognised as CLIF.