### PR TITLE
Partially solve 1494 parse dol standard examples

### DIFF
--- a/Common/AnnoParser.hs
+++ b/Common/AnnoParser.hs
@@ -27,6 +27,7 @@ module Common.AnnoParser
     , newlineOrEof
     ) where
 
+import Text.Parsec.Char (endOfLine)
 import Text.ParserCombinators.Parsec
 import Text.ParserCombinators.Parsec.Error
 import Text.ParserCombinators.Parsec.Pos as Pos
@@ -237,7 +238,8 @@ floatingAnno ps = literal2idsAnno ps Float_anno
 
 prefixAnno :: Range -> GenParser Char st Annotation
 prefixAnno ps = do
-    prefixes <- many $ do
+    prefixes <- many $ skipMany (commentLine >> endOfLine) >> do
+        spaces
         p <- (string colonS >> return "") <|>
              (IRI.ncname << string colonS)
         spaces

--- a/Common/AnnoParser.hs
+++ b/Common/AnnoParser.hs
@@ -27,7 +27,6 @@ module Common.AnnoParser
     , newlineOrEof
     ) where
 
-import Text.Parsec.Char (endOfLine)
 import Text.ParserCombinators.Parsec
 import Text.ParserCombinators.Parsec.Error
 import Text.ParserCombinators.Parsec.Pos as Pos
@@ -238,8 +237,7 @@ floatingAnno ps = literal2idsAnno ps Float_anno
 
 prefixAnno :: Range -> GenParser Char st Annotation
 prefixAnno ps = do
-    prefixes <- many $ skipMany (commentLine >> endOfLine) >> do
-        spaces
+    prefixes <- many $ skipMany (commentLine >> spaces) >> do
         p <- (string colonS >> return "") <|>
              (IRI.ncname << string colonS)
         spaces

--- a/Common/Keywords.hs
+++ b/Common/Keywords.hs
@@ -309,6 +309,9 @@ interpretationS = "interpretation"
 moduleS :: String
 moduleS = "module"
 
+omsS :: String
+omsS = "oms"
+
 ontologyS :: String
 ontologyS = "ontology"
 

--- a/Common/Keywords.hs
+++ b/Common/Keywords.hs
@@ -507,6 +507,9 @@ intersectS = "intersect"
 lambdaS :: String
 lambdaS = "lambda"
 
+languageS :: String
+languageS = "language"
+
 left_assocS :: String
 left_assocS = "left_assoc"
 

--- a/Common/Token.hs
+++ b/Common/Token.hs
@@ -119,7 +119,7 @@ terminatingKeywords =
 startingKeywords :: [String]
 startingKeywords =
     [ archS, fromS, logicS, newlogicS, refinementS, specS, unitS, viewS
-    , ontologyS, alignmentS, networkS, equivalenceS, newcomorphismS
+    , omsS, ontologyS, alignmentS, networkS, equivalenceS, newcomorphismS
     , interpretationS, entailmentS ]
 
 -- | keywords that may follow a defining equal sign

--- a/Common/Token.hs
+++ b/Common/Token.hs
@@ -112,7 +112,7 @@ criticalKeywords = terminatingKeywords ++ startingKeywords
 -- | keywords terminating a basic spec
 terminatingKeywords :: [String]
 terminatingKeywords =
-    [ andS, endS, extractS, fitS, forgetS, hideS, keepS, rejectS, removeS, 
+    [ andS, endS, extractS, fitS, forgetS, hideS, keepS, rejectS, removeS,
       revealS, selectS, thenS, withS, withinS, ofS, forS, toS, intersectS]
 
 -- | keywords starting a library item

--- a/Common/Token.hs
+++ b/Common/Token.hs
@@ -118,9 +118,9 @@ terminatingKeywords =
 -- | keywords starting a library item
 startingKeywords :: [String]
 startingKeywords =
-    [ archS, fromS, logicS, newlogicS, refinementS, specS, unitS, viewS
-    , omsS, ontologyS, alignmentS, networkS, equivalenceS, newcomorphismS
-    , interpretationS, entailmentS ]
+    [ archS, fromS, languageS, logicS, newlogicS, refinementS, specS, unitS
+    , viewS , omsS, ontologyS, alignmentS, networkS, equivalenceS
+    , newcomorphismS , interpretationS, entailmentS ]
 
 -- | keywords that may follow a defining equal sign
 otherStartKeywords :: [String]

--- a/Logic/KnownIris.hs
+++ b/Logic/KnownIris.hs
@@ -18,11 +18,18 @@ logPrefix, serPrefix :: String
 
 logPrefix = "http://purl.net/DOL/logics/"
 serPrefix = "http://purl.net/DOL/serializations/"
+lngPrefix = "http://purl.net/DOL/languages/"
 
 logicNames :: Map.Map String String
 logicNames = -- IRI -> local name
   Map.fromList
   [ (logPrefix ++ "CommonLogic", "CommonLogic"),
+    -- TODO: Properly support `language` declarations
+    -- The line below is part of a hack to support `language` declarations
+    -- without an accompanying `logic` declaration by essentially treating
+    -- `language` the same as `logic`.
+    -- This should probably be done properly instead, but it works for now.
+    (lngPrefix ++ "CommonLogic", "CommonLogic"),
     (logPrefix ++ "Propositional", "Propositional"),
     (logPrefix ++ "OWL2", "OWL"),
     (logPrefix ++ "SROIQ", "OWL")] -- should be "NP-sROIQ-D|-|"

--- a/Logic/KnownIris.hs
+++ b/Logic/KnownIris.hs
@@ -24,7 +24,10 @@ logicNames = -- IRI -> local name
   Map.fromList
   [ (logPrefix ++ "CommonLogic", "CommonLogic"),
     (logPrefix ++ "Propositional", "Propositional"),
-    (logPrefix ++ "OWL2", "OWL") ]
+    (logPrefix ++ "OWL2", "OWL"),
+    (logPrefix ++ "SROIQ", "OWL")] -- should be "NP-sROIQ-D|-|" instead of
+                                   -- "OWL" but Hets doesn't know that logic
+                                   -- yet for some reason...
 
 lookupLogicName :: String -> Maybe String
 lookupLogicName = (`Map.lookup` logicNames)

--- a/Logic/KnownIris.hs
+++ b/Logic/KnownIris.hs
@@ -16,8 +16,8 @@ import qualified Data.Map as Map
 
 logPrefix, serPrefix :: String
 
-logPrefix = "http://purl.net/dol/logics/"
-serPrefix = "http://purl.net/dol/serializations/"
+logPrefix = "http://purl.net/DOL/logics/"
+serPrefix = "http://purl.net/DOL/serializations/"
 
 logicNames :: Map.Map String String
 logicNames = -- IRI -> local name

--- a/Logic/KnownIris.hs
+++ b/Logic/KnownIris.hs
@@ -25,9 +25,9 @@ logicNames = -- IRI -> local name
   [ (logPrefix ++ "CommonLogic", "CommonLogic"),
     (logPrefix ++ "Propositional", "Propositional"),
     (logPrefix ++ "OWL2", "OWL"),
-    (logPrefix ++ "SROIQ", "OWL")] -- should be "NP-sROIQ-D|-|" instead of
-                                   -- "OWL" but Hets doesn't know that logic
-                                   -- yet for some reason...
+    (logPrefix ++ "SROIQ", "OWL")] -- should be "NP-sROIQ-D|-|"
+                                   -- (or "OWL.NP-sROIQ-D|-|"?) instead of
+                                   -- "OWL" but Hets claims not to kow both.
 
 lookupLogicName :: String -> Maybe String
 lookupLogicName = (`Map.lookup` logicNames) . filter (not . (`elem` "<>"))

--- a/Logic/KnownIris.hs
+++ b/Logic/KnownIris.hs
@@ -44,4 +44,5 @@ serializations l
   | otherwise = Map.empty
 
 lookupSerialization :: String -> String -> Maybe String
-lookupSerialization l = (`Map.lookup` serializations l)
+lookupSerialization l = (`Map.lookup` serializations l) .
+                        filter (not . (`elem` "<>"))

--- a/Logic/KnownIris.hs
+++ b/Logic/KnownIris.hs
@@ -19,17 +19,26 @@ logPrefix, serPrefix :: String
 logPrefix = "http://purl.net/DOL/logics/"
 serPrefix = "http://purl.net/DOL/serializations/"
 lngPrefix = "http://purl.net/DOL/languages/"
+trlPrefix = "http://purl.net/DOL/translations/"
 
 logicNames :: Map.Map String String
 logicNames = -- IRI -> local name
   Map.fromList
   [ (logPrefix ++ "CommonLogic", "CommonLogic"),
     -- TODO: Properly support `language` declarations
-    -- The line below is part of a hack to support `language` declarations
-    -- without an accompanying `logic` declaration by essentially treating
-    -- `language` the same as `logic`.
+    -- Everything up to the `logPrefix` lines below is part of a hack to
+    -- support `translation` declarations and `language` declarations without
+    -- an accompanying `logic` declaration by essentially treating `language`
+    -- the same as `logic`.
     -- This should probably be done properly instead, but it works for now.
+    (lngPrefix ++ "CASL", "CASL"),
     (lngPrefix ++ "CommonLogic", "CommonLogic"),
+    (lngPrefix ++ "HasCASL", "HasCASL"),
+    (lngPrefix ++ "Propositional", "Propositional"),
+    (lngPrefix ++ "OWL", "OWL"),
+    (lngPrefix ++ "OWL2", "OWL"),
+    (trlPrefix ++ "SROIQtoCL", "OWL22CommonLogic"),
+    (trlPrefix ++ "PropositionalToSROIQ", "Propositional2OWL2"),
     (logPrefix ++ "Propositional", "Propositional"),
     (logPrefix ++ "OWL2", "OWL"),
     (logPrefix ++ "SROIQ", "OWL")] -- should be "NP-sROIQ-D|-|"

--- a/Logic/KnownIris.hs
+++ b/Logic/KnownIris.hs
@@ -30,7 +30,7 @@ logicNames = -- IRI -> local name
                                    -- yet for some reason...
 
 lookupLogicName :: String -> Maybe String
-lookupLogicName = (`Map.lookup` logicNames)
+lookupLogicName = (`Map.lookup` logicNames) . filter (not . (`elem` "<>"))
 
 serializations :: String -> Map.Map String String
 serializations l

--- a/OWL2/Keywords.hs
+++ b/OWL2/Keywords.hs
@@ -15,7 +15,7 @@ plus owl, xsd, rdf and rdfs reserved keywords. All identifiers are mixed case
 
 module OWL2.Keywords where
 
-import Common.Keywords
+import Common.Keywords hiding (languageS)
 
 keywords :: [String]
 keywords =

--- a/Syntax/Parse_AS_Library.hs
+++ b/Syntax/Parse_AS_Library.hs
@@ -54,7 +54,7 @@ library :: LogicGraph -> AParser st LIB_DEFN
 library lG = do
     (lG1, an1) <- lGAnnos lG
     (ps, ln) <- option (nullRange, iriLibName nullIRI) $ do
-      s1 <- asKey libraryS <|> asKey "distributed-ontology"
+      s1 <- asKey libraryS
       n <- libName lG1
       return (tokPos s1, n)
     (lG2, an2) <- lGAnnos lG1

--- a/Syntax/Parse_AS_Library.hs
+++ b/Syntax/Parse_AS_Library.hs
@@ -115,7 +115,7 @@ emptyParams = Genericity (Params []) (Imported []) nullRange
 specDefn :: LogicGraph -> AParser st LIB_ITEM
 specDefn l = do
     s <- choice $ map asKey
-      ["specification", specS, ontologyS, "onto", "model", "OMS"]
+      ["specification", specS, ontologyS, "onto", "model", omsS]
     n <- hetIRI l
     g <- generics l
     e <- equalT

--- a/Syntax/Parse_AS_Library.hs
+++ b/Syntax/Parse_AS_Library.hs
@@ -213,11 +213,15 @@ libItem l = specDefn l
        en <- hetIRI l
        s2 <- colonT
        et <- equivType l
-       s3 <- equalT
-       sp <- fmap MkOms $ aSpec l
+       (ms3, sp) <- option (Nothing, MkOms $ emptyAnno $ EmptySpec nullRange)
+                           (do s3 <- equalT
+                               sp <- fmap MkOms $ aSpec l
+                               return (Just s3, sp))
        ep <- optEnd
        return . Equiv_defn en et sp
-         . catRange $ s1 : s2 : s3 : maybeToList ep
+         . catRange $ s1 : s2 : case ms3 of
+                                  Just s3 -> s3 : maybeToList ep
+                                  Nothing -> maybeToList ep
   <|> -- align defn
     do s1 <- asKey alignmentS
        an <- hetIRI l

--- a/Syntax/Parse_AS_Structured.hs
+++ b/Syntax/Parse_AS_Structured.hs
@@ -91,7 +91,7 @@ sublogicChars = many $ satisfy $ \ c -> notElem c ":./\\" && isSignChar c
 lookupLogicM :: IRI -> AParser st String
 lookupLogicM i = if isSimple i
                  then return l
-                 else case lookupLogicName l of
+                 else case lookupLogicName (filter (not . (`elem` "<>")) l) of
                    Just s -> return s
                    Nothing -> fail $ "logic " ++ show i ++ " not found"
   where l = iriToStringUnsecure i

--- a/Syntax/Parse_AS_Structured.hs
+++ b/Syntax/Parse_AS_Structured.hs
@@ -119,7 +119,7 @@ qualification :: LogicGraph -> AParser st (Token, LogicDescr)
 qualification l =
   pair (asKey logicS) (logicDescr l)
   <|> do
-    s <- asKey serializationS <|> asKey "language"
+    s <- asKey serializationS <|> asKey languageS
     i <- iriCurie
     skipSmart
     return (s,

--- a/Syntax/Parse_AS_Structured.hs
+++ b/Syntax/Parse_AS_Structured.hs
@@ -35,7 +35,7 @@ module Syntax.Parse_AS_Structured
 import Logic.Logic
 import Logic.Comorphism
 import Logic.Grothendieck
-import Logic.KnownIris
+import Logic.KnownIris (lookupLogicName)
 
 import Syntax.AS_Structured
 

--- a/Syntax/Parse_AS_Structured.hs
+++ b/Syntax/Parse_AS_Structured.hs
@@ -91,7 +91,7 @@ sublogicChars = many $ satisfy $ \ c -> notElem c ":./\\" && isSignChar c
 lookupLogicM :: IRI -> AParser st String
 lookupLogicM i = if isSimple i
                  then return l
-                 else case lookupLogicName (filter (not . (`elem` "<>")) l) of
+                 else case lookupLogicName l of
                    Just s -> return s
                    Nothing -> fail $ "logic " ++ show i ++ " not found"
   where l = iriToStringUnsecure i

--- a/Syntax/Parse_AS_Structured.hs
+++ b/Syntax/Parse_AS_Structured.hs
@@ -117,7 +117,12 @@ logicName l = do
 
 qualification :: LogicGraph -> AParser st (Token, LogicDescr)
 qualification l =
-  pair (asKey logicS) (logicDescr l)
+  -- TODO: Properly support `language` declarations
+  -- The `<|> asKey languageS` part in the line below is part of a hack to
+  -- support `language` declarations without an accompanying `logic`
+  -- declaration by essentially treating `language` the same as `logic`.
+  -- This should probably be done properly instead, but it works for now.
+  pair (asKey logicS <|> asKey languageS) (logicDescr l)
   <|> do
     s <- asKey serializationS <|> asKey languageS
     i <- iriCurie

--- a/Syntax/Print_AS_Structured.hs
+++ b/Syntax/Print_AS_Structured.hs
@@ -155,7 +155,7 @@ instance Pretty EXTRACTION where
 
 printEXTRACTION :: EXTRACTION -> Doc
 printEXTRACTION (ExtractOrRemove b aa _) =
-   keyword (if b then "extract" else "remove") <+> fsep (map pretty aa)
+   keyword (if b then extractS else removeS) <+> fsep (map pretty aa)
 
 instance Pretty RENAMING where
     pretty = printRENAMING

--- a/test/DOL/parserTest.dol
+++ b/test/DOL/parserTest.dol
@@ -13,7 +13,7 @@ bar: <http://www.example.com/bar.dol#>
 
 )%
 
-distributed-ontology foo:chocolate
+library foo:chocolate
 
 logic CommonLogic serialization CLIF
 

--- a/test/DOL/parserTest.dol
+++ b/test/DOL/parserTest.dol
@@ -15,18 +15,31 @@ bar: <http://www.example.com/bar.dol#>
 
 library foo:chocolate
 
-logic CommonLogic serialization CLIF
+%% TODO: logics should be complete IRIs (either full or prefixed) (legacy?)
+%%       relates to DOL issue #161
 
-ontology o1 =
-(and (P x)
-     (Q x)
-     ((that (exists (x) (R x)))) // possible in IKL
-     (iff (R x) ((that (R x))))  // a tautology
-     (forall (p) (iff (p) ((that (p))))) // another one
-     (forall (p) (= p (that (p)))) // NOT a tautology (see IKL-SPEC)
-     (= ('foo') foo) // should become a tautology
-     )
-end
+%% The commented lines are problematic because there is courrently no symbol
+%% parser for 'CommonLogic' which means that some of the symbols in the
+%% alignments further down lead to parse errors. As this is not a problem
+%% relating to the DOL parser, the logic/serialization declaration and the
+%% 'CommonLogic' specific parts have been commented out.
+%% This means the logic at work is now CASL which can parse nearly everything
+%% and thus all errors should be DOL related. Once we have a proper
+%% 'CommonLogic' symbol parser, the commented lines can go active again
+%% providing ready made test cases.
+
+%% logic CommonLogic serialization CLIF
+
+%%ontology o1 =
+%%(and (P x)
+%%     (Q x)
+%%     ((that (exists (x) (R x)))) // possible in IKL
+%%     (iff (R x) ((that (R x))))  // a tautology
+%%     (forall (p) (iff (p) ((that (p))))) // another one
+%%     (forall (p) (= p (that (p)))) // NOT a tautology (see IKL-SPEC)
+%%     (= ('foo') foo) // should become a tautology
+%%     )
+%%end
 
 ontology foo:a = {}
 ontology bar:b = {}
@@ -102,8 +115,11 @@ end
 alignment a14 align-arity-forward ? align-arity-backward 1 : foo:foo_bar to foo:baz
 end
 
-module m20 :
-    (P x)
-  of
-    (Q x)
-  for FOO
+%% See the commented directly after the library declaration at the top if you
+%% want to know why this has been commented out.
+
+%% module m20 :
+%%    (P x)
+%%  of
+%%    (Q x)
+%%  for FOO

--- a/test/DOL/parserTest.dol
+++ b/test/DOL/parserTest.dol
@@ -85,14 +85,12 @@ alignment a8 : foo:owltime_instant_l to bar:owltime_le
 , eRef1 %          (0.1) ERef2
 , eRef1 $\ni$      (0.1) ERef2
 , eRef1 $\in$      (0.1) ERef2
-, eRef1 $\mapsto$  (0.1) ERef2
 , eRef1 <                ERef2
 , eRef1 >                ERef2
 , eRef1 =                ERef2
 , eRef1 %                ERef2
 , eRef1 $\ni$            ERef2
 , eRef1 $\in$            ERef2
-, eRef1 $\mapsto$        ERef2
 , relation < (0.1) {eRef1 ERef2}
 , relation <       {eRef1 ERef2}
 , relation   (0.1) {eRef1 ERef2}

--- a/test/DOL/parserTest.dol
+++ b/test/DOL/parserTest.dol
@@ -63,37 +63,37 @@ alignment a7 : foo:foo_bar to foo:baz
 end
 
 alignment a8 : foo:owltime_instant_l to bar:owltime_le
-= eRef1 rRef       (0.1) ERef2 %( corrId )%
-, eRef1 rRef       (0.1) ERef2
+= eRef1 rRef         0.1 ERef2 %( corrId )%
+, eRef1 rRef         0.1 ERef2
 , eRef1 rRef             ERef2 %( corrId )%
 , eRef1 rRef             ERef2
-, eRef1 rRef       (0.1) ERef2 %( corrId )%
-, eRef1 rRef       (0.1) ERef2
+, eRef1 rRef         0.1 ERef2 %( corrId )%
+, eRef1 rRef         0.1 ERef2
 , eRef1 rRef             ERef2 %( corrId )%
 , eRef1 rRef             ERef2
-, eRef1            (0.1) ERef2 %( corrId )%
-, eRef1            (0.1) ERef2
+, eRef1              0.1 ERef2 %( corrId )%
+, eRef1              0.1 ERef2
 , eRef1                  ERef2 %( corrId )%
 , eRef1                  ERef2
-, eRef1            (0.1) ERef2 %( corrId )%
-, eRef1            (0.1) ERef2
+, eRef1              0.1 ERef2 %( corrId )%
+, eRef1              0.1 ERef2
 , eRef1                  ERef2 %( corrId )%
 , eRef1                  ERef2
-, eRef1 <          (0.1) ERef2
-, eRef1 >          (0.1) ERef2
-, eRef1 =          (0.1) ERef2
-, eRef1 %          (0.1) ERef2
-, eRef1 ni         (0.1) ERef2
-, eRef1 in         (0.1) ERef2
+, eRef1 <            0.1 ERef2
+, eRef1 >            0.1 ERef2
+, eRef1 =            0.1 ERef2
+, eRef1 %            0.1 ERef2
+, eRef1 ni           0.1 ERef2
+, eRef1 in           0.1 ERef2
 , eRef1 <                ERef2
 , eRef1 >                ERef2
 , eRef1 =                ERef2
 , eRef1 %                ERef2
 , eRef1 ni               ERef2
 , eRef1 in               ERef2
-, relation < (0.1) {eRef1 ERef2}
+, relation <   0.1 {eRef1 ERef2}
 , relation <       {eRef1 ERef2}
-, relation   (0.1) {eRef1 ERef2}
+, relation     0.1 {eRef1 ERef2}
 , relation         {eRef1 ERef2}
 end
 

--- a/test/DOL/parserTest.dol
+++ b/test/DOL/parserTest.dol
@@ -97,6 +97,10 @@ alignment a8 : foo:owltime_instant_l to bar:owltime_le
 , relation         {eRef1 ERef2}
 end
 
+alignment a9 : foo:owltime_instant_l to bar:owltime_le
+= eRef1 rRef       0.1 ERef2 %( corrId )%
+assuming SingleDomain
+end
 
 alignment a10 align-arity-forward 1 align-arity-backward 1 : foo:foo_bar to foo:baz
 end

--- a/test/DOL/parserTest.dol
+++ b/test/DOL/parserTest.dol
@@ -83,14 +83,14 @@ alignment a8 : foo:owltime_instant_l to bar:owltime_le
 , eRef1 >          (0.1) ERef2
 , eRef1 =          (0.1) ERef2
 , eRef1 %          (0.1) ERef2
-, eRef1 $\ni$      (0.1) ERef2
-, eRef1 $\in$      (0.1) ERef2
+, eRef1 ni         (0.1) ERef2
+, eRef1 in         (0.1) ERef2
 , eRef1 <                ERef2
 , eRef1 >                ERef2
 , eRef1 =                ERef2
 , eRef1 %                ERef2
-, eRef1 $\ni$            ERef2
-, eRef1 $\in$            ERef2
+, eRef1 ni               ERef2
+, eRef1 in               ERef2
 , relation < (0.1) {eRef1 ERef2}
 , relation <       {eRef1 ERef2}
 , relation   (0.1) {eRef1 ERef2}


### PR DESCRIPTION
The commits on this branch solve some of the parsing issues hets has with the DOL standard.
Two outstanding issues still remain:
- issues with language `serialization` CURIES (so don't use those yet when you're testing)
- `select` and `reject` can not handle `SymbolList`s

which is why the ticket can not be fully closed yet. The fixes for those issues will follow soon.
I'm creating this pull request before fully solving this issue because one can still use the parser on quite a few things, so it might be of some help already.

I tested for conflicts. There shouldn't be any.
