### PR TITLE
compile using hets ppa

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,19 @@
+sudo: required
+dist: trusty
 language: haskell
-ghc: 7.8
+
 before_install:
- - sudo apt-get update -qq
- - sudo apt-get install -qq zlib1g-dev libncurses-dev libcairo2-dev libglib2.0-dev libpango1.0-dev libgtk2.0-dev libglade2-dev
+ - travis_retry sudo add-apt-repository -y ppa:hets/hets
+ - travis_retry sudo apt-get update -qq
+ - travis_retry sudo apt-get build-dep -qq hets
+ - travis_retry sudo apt-get install -qq texlive-latex-recommended
+
 install:
- - travis_retry cabal update
- - cabal install alex happy
- - cabal install gtk2hs-buildtools
- - cabal install glade parsec1
- - cabal install --only-dependencies
+ - export PATH=/usr/bin:$PATH
+ - cabal install parsec1
+
 script:
  - make
  - ./hets -V
  - export HETS_MAGIC=$PWD/magic/hets.magic
  - make check
-

--- a/var.mk
+++ b/var.mk
@@ -2,7 +2,7 @@
 
 GHCVERSION = $(shell ghc --numeric-version)
 ifneq ($(findstring 7., $(GHCVERSION)),)
-GHC7OPTS = -fcontext-stack=26
+GHC7OPTS =
 GHC7RTSOPTS = -rtsopts
 endif
 


### PR DESCRIPTION
It seems hackage (for cabal) is currently somehow broken. So you may want to use this travis setup.
However, this only uses an older ghc version and the packages provided by Ubuntu and `ppa:hets/hets`.