### PR TITLE
1506 glade gtk13

### DIFF
--- a/GUI/GtkAutomaticProofs.hs
+++ b/GUI/GtkAutomaticProofs.hs
@@ -336,7 +336,7 @@ updateComorphism view list cbComorphism sh = do
   signalUnblock sh
 
 expand :: Finder -> [ComboBoxText]
-expand = map (toComboBoxText . show) . comorphism
+expand = toComboBoxText . comorphism
 
 setSelectedComorphism :: TreeView -> ListStore Finder -> ComboBox -> IO ()
 setSelectedComorphism view list cbComorphism = do

--- a/GUI/GtkAutomaticProofs.hs
+++ b/GUI/GtkAutomaticProofs.hs
@@ -335,8 +335,8 @@ updateComorphism view list cbComorphism sh = do
     Nothing -> return ()
   signalUnblock sh
 
-expand :: Finder -> [String]
-expand = map show . comorphism
+expand :: Finder -> [ComboBoxText]
+expand = map (toComboBoxText . show) . comorphism
 
 setSelectedComorphism :: TreeView -> ListStore Finder -> ComboBox -> IO ()
 setSelectedComorphism view list cbComorphism = do

--- a/GUI/GtkConsistencyChecker.hs
+++ b/GUI/GtkConsistencyChecker.hs
@@ -345,7 +345,7 @@ updateComorphism view list cbComorphism sh = do
   signalUnblock sh
 
 expand :: Finder -> [ComboBoxText]
-expand = map (toComboBoxText . show) . comorphism
+expand = toComboBoxText . comorphism
 
 setSelectedComorphism :: TreeView -> ListStore Finder -> ComboBox -> IO ()
 setSelectedComorphism view list cbComorphism = do

--- a/GUI/GtkConsistencyChecker.hs
+++ b/GUI/GtkConsistencyChecker.hs
@@ -344,8 +344,8 @@ updateComorphism view list cbComorphism sh = do
     Nothing -> return ()
   signalUnblock sh
 
-expand :: Finder -> [String]
-expand = map show . comorphism
+expand :: Finder -> [ComboBoxText]
+expand = map (toComboBoxText . show) . comorphism
 
 setSelectedComorphism :: TreeView -> ListStore Finder -> ComboBox -> IO ()
 setSelectedComorphism view list cbComorphism = do

--- a/GUI/GtkProverGUI.hs
+++ b/GUI/GtkProverGUI.hs
@@ -252,8 +252,8 @@ updateComorphism view list cbComorphism sh = do
     Nothing -> return ()
   signalUnblock sh
 
-expand :: GProver -> [String]
-expand = map show . comorphism
+expand :: GProver -> [ComboBoxText]
+expand = map (toComboBoxText . show) . comorphism
 
 setSelectedComorphism :: TreeView -> ListStore GProver -> ComboBox -> ProofState
   -> IO ProofState

--- a/GUI/GtkProverGUI.hs
+++ b/GUI/GtkProverGUI.hs
@@ -253,7 +253,7 @@ updateComorphism view list cbComorphism sh = do
   signalUnblock sh
 
 expand :: GProver -> [ComboBoxText]
-expand = map (toComboBoxText . show) . comorphism
+expand = toComboBoxText . comorphism
 
 setSelectedComorphism :: TreeView -> ListStore GProver -> ComboBox -> ProofState
   -> IO ProofState

--- a/GUI/GtkUtils.hs
+++ b/GUI/GtkUtils.hs
@@ -572,8 +572,9 @@ activate widgets active = mapM_ (`widgetSetSensitive` active) widgets
 
 toComboBoxText :: String -> ComboBoxText
 #ifdef GTK12
-type ComboBoxText = String
 toComboBoxText = id
+
+type ComboBoxText = String
 #else
 toComboBoxText = Text.pack
 #endif

--- a/GUI/GtkUtils.hs
+++ b/GUI/GtkUtils.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {- |
 Module      :  $Header$
 Description :  Access to the .glade files stored as strings inside the binary
@@ -69,8 +70,9 @@ module GUI.GtkUtils
   , activate
 
   , escapeGtkMarkup
-  )
-  where
+  , ComboBoxText
+  , toComboBoxText
+  ) where
 
 import Graphics.UI.Gtk
 import Graphics.UI.Gtk.Glade
@@ -85,6 +87,8 @@ import Common.Utils (getTempFile)
 
 import Control.Concurrent (forkIO)
 import Control.Monad (when)
+
+import qualified Data.Text as Text
 
 import System.Directory ( removeFile, doesFileExist
                         , canonicalizePath)
@@ -565,3 +569,11 @@ updateListData list listData = do
 -- | Activates or deactivates a list of widgets
 activate :: [Widget] -> Bool -> IO ()
 activate widgets active = mapM_ (`widgetSetSensitive` active) widgets
+
+toComboBoxText :: String -> ComboBoxText
+#ifdef GTK12
+type ComboBoxText = String
+toComboBoxText = id
+#else
+toComboBoxText = Text.pack
+#endif

--- a/GUI/GtkUtils.hs
+++ b/GUI/GtkUtils.hs
@@ -570,11 +570,11 @@ updateListData list listData = do
 activate :: [Widget] -> Bool -> IO ()
 activate widgets active = mapM_ (`widgetSetSensitive` active) widgets
 
-toComboBoxText :: String -> ComboBoxText
+toComboBoxText :: Show a => [a] -> [ComboBoxText]
 #ifdef GTK12
-toComboBoxText = id
+toComboBoxText = map show
 
 type ComboBoxText = String
 #else
-toComboBoxText = Text.pack
+toComboBoxText = map (Text.pack . show)
 #endif

--- a/PGIP/Server.hs
+++ b/PGIP/Server.hs
@@ -36,7 +36,7 @@ import Data.Conduit.Lazy (lazyConsume)
 import qualified Data.Text as T
 
 import Network.Wai
-import Network.Wai.Parse
+import Network.Wai.Parse as W
 
 import qualified Data.ByteString.Lazy.Char8 as BS
 import qualified Data.ByteString.Char8 as B8
@@ -913,7 +913,7 @@ cmpFilePath f1 f2 = case comparing hasTrailingPathSeparator f2 f1 of
   EQ -> compare f1 f2
   c -> c
 
-getHetsResponse :: HetcatsOpts -> [FileInfo BS.ByteString]
+getHetsResponse :: HetcatsOpts -> [W.FileInfo BS.ByteString]
   -> Cache -> [String] -> [QueryPair] -> WebResponse
 getHetsResponse opts updates sessRef pathBits query respond = do
   Result ds ms <- liftIO $ runResultT $ case anaUri pathBits query
@@ -925,7 +925,7 @@ getHetsResponse opts updates sessRef pathBits query respond = do
     Just (t, s) | not $ hasErrors ds -> mkOkResponse t s
     _ -> mkResponse textC status422 $ showRelDiags 1 ds
 
-getHetsResult :: HetcatsOpts -> [FileInfo BS.ByteString]
+getHetsResult :: HetcatsOpts -> [W.FileInfo BS.ByteString]
   -> Cache -> Query.Query -> Maybe String -> UsedAPI -> ProofFormatterOptions
   -> ResultT IO (String, String)
 getHetsResult opts updates sessRef (Query dgQ qk) format api pfOptions = do

--- a/var.mk
+++ b/var.mk
@@ -39,7 +39,10 @@ UNIX_PACKAGE = -DUNIX
 endif
 
 GLADEVERSION = $(shell $(HCPKG) latest glade)
-ifneq ($(findstring 0.1, $(GLADEVERSION)),)
+ifneq ($(findstring 0.12, $(GLADEVERSION)),)
+GLADE_PACKAGE = -DGTKGLADE -DGTK12 $(SUNRUNPATH)
+endif
+ifneq ($(findstring 0.13, $(GLADEVERSION)),)
 GLADE_PACKAGE = -DGTKGLADE $(SUNRUNPATH)
 endif
 


### PR DESCRIPTION
this patch can be merged to support GTK with ghc-7.10 in the future.
For ghc-7.10 a new glade package still needs to be uploaded to hackage.
Until then https://github.com/cmaeder/glade can be used. 

The branch https://github.com/spechub/Hets/tree/travis_ghc-7.10 shows that it works for ghc-7.10.2. 