### PR TITLE
Extract list with commas

### DIFF
--- a/Syntax/Parse_AS_Structured.hs
+++ b/Syntax/Parse_AS_Structured.hs
@@ -389,8 +389,8 @@ minimization lg = do
 extraction :: LogicGraph -> AParser st EXTRACTION
 extraction lg = do
   p <- asKey extractS <|> asKey removeS
-  is <- separatedBy (hetIRI lg) commaT
-  return . ExtractOrRemove (tokStr p == extractS) (fst is) $ tokPos p
+  (is,commas) <- separatedBy (hetIRI lg) commaT
+  return . ExtractOrRemove (tokStr p == extractS) is $ catRange (p:commas)
 
 filtering :: LogicGraph -> AParser st FILTERING
 filtering lg = do

--- a/Syntax/Parse_AS_Structured.hs
+++ b/Syntax/Parse_AS_Structured.hs
@@ -389,8 +389,8 @@ minimization lg = do
 extraction :: LogicGraph -> AParser st EXTRACTION
 extraction lg = do
   p <- asKey extractS <|> asKey removeS
-  is <- many1 (hetIRI lg)
-  return . ExtractOrRemove (tokStr p == extractS) is $ tokPos p
+  is <- separatedBy (hetIRI lg) commaT
+  return . ExtractOrRemove (tokStr p == extractS) (fst is) $ tokPos p
 
 filtering :: LogicGraph -> AParser st FILTERING
 filtering lg = do


### PR DESCRIPTION
adapts the syntax of `extract` to the DOL standard.