### PR TITLE
Add support for Fact++ jnilibs files.

### DIFF
--- a/OWL2/ProveFact.hs
+++ b/OWL2/ProveFact.hs
@@ -161,8 +161,6 @@ runTimedFact tmpFileName prob mEnt tLimit = do
       jlibSoName = "libFaCTPlusPlusJNI.so"
       jlibName = "libFaCTPlusPlusJNI.jnilib"
   (progTh, toolPath) <- check4HetsOWLjar jar
-  hasJniSoInLib <- doesFileExist $ "/lib/" ++ jlibSoName
-  hasJniInLib <- doesFileExist $ "/lib/" ++ jlibName
   (_, arch, _) <- executeProcess "uname" ["-m"] ""
   if progTh then
         withinDirectory toolPath $ do
@@ -170,13 +168,12 @@ runTimedFact tmpFileName prob mEnt tLimit = do
           let jni = fromMaybe ("lib/native/" ++ trim arch) mJni
           hasJniSo <- doesFileExist $ jni </> jlibSoName
           hasJni <- doesFileExist $ jni </> jlibName
-          if hasJni || hasJniSo || hasJniInLib || hasJniSoInLib then do
+          if hasJni || hasJniSo then do
             timeTmpFile <- getTempFile prob tmpFileName
             let entailsFile = timeTmpFile ++ ".entail.owl"
-                jargs = ["-Djava.library.path=" ++ jni
-                        | not (hasJniInLib || hasJniSoInLib) || isJust mJni ]
+                jargs = ["-Djava.library.path=" ++ jni | isJust mJni ]
                    ++ ["-jar", jar, "file://" ++ timeTmpFile]
-                  ++ ["file://" ++ entailsFile | hasEnt ]
+                   ++ ["file://" ++ entailsFile | hasEnt ]
             case mEnt of
               Just entail -> writeFile entailsFile entail
               _ -> return ()

--- a/OWL2/ProveFact.hs
+++ b/OWL2/ProveFact.hs
@@ -11,6 +11,7 @@ Fact++ prover for OWL
 -}
 
 module OWL2.ProveFact (factProver, factConsChecker) where
+import Data.List (intercalate) -- DEBUG
 
 import Logic.Prover
 
@@ -173,8 +174,18 @@ runTimedFact tmpFileName prob mEnt tLimit = do
           case mEnt of
             Just entail -> writeFile entailsFile entail
             _ -> return ()
+          putStrLn $ "" -- DEBUG
+          putStrLn $ "jargs: " ++ (intercalate " " jargs) -- DEBUG
+          putStrLn $ "mLibraryPath: " ++ show mLibraryPath -- DEBUG
+          executeProcess "cp" [timeTmpFile, "/tmp/timeTmpFile.owl"] "" -- DEBUG
+          executeProcess "cp" [entailsFile, "/tmp/entailsFile.owl"] "" -- DEBUG
           t_start <- getHetsTime
           mExit <- timeoutCommand tLimit "java" jargs
+          putStrLn $ (\ (Just (ex, out, err)) -> "exitCode: " ++ show ex) mExit -- DEBUG
+          putStrLn $ (\ (Just (ex, out, err)) -> "out: " ++ out) mExit -- DEBUG
+          putStrLn $ (\ (Just (ex, out, err)) -> "err: " ++ err) mExit -- DEBUG
+          putStrLn $ "" -- DEBUG
+          putStrLn $ "" -- DEBUG
           t_end <- getHetsTime
           removeFile timeTmpFile
           when hasEnt $ removeFile entailsFile

--- a/OWL2/ProveFact.hs
+++ b/OWL2/ProveFact.hs
@@ -11,7 +11,6 @@ Fact++ prover for OWL
 -}
 
 module OWL2.ProveFact (factProver, factConsChecker) where
-import Data.List (intercalate) -- DEBUG
 
 import Logic.Prover
 
@@ -174,18 +173,8 @@ runTimedFact tmpFileName prob mEnt tLimit = do
           case mEnt of
             Just entail -> writeFile entailsFile entail
             _ -> return ()
-          putStrLn $ "" -- DEBUG
-          putStrLn $ "jargs: " ++ (intercalate " " jargs) -- DEBUG
-          putStrLn $ "mLibraryPath: " ++ show mLibraryPath -- DEBUG
-          executeProcess "cp" [timeTmpFile, "/tmp/timeTmpFile.owl"] "" -- DEBUG
-          executeProcess "cp" [entailsFile, "/tmp/entailsFile.owl"] "" -- DEBUG
           t_start <- getHetsTime
           mExit <- timeoutCommand tLimit "java" jargs
-          putStrLn $ (\ (Just (ex, out, err)) -> "exitCode: " ++ show ex) mExit -- DEBUG
-          putStrLn $ (\ (Just (ex, out, err)) -> "out: " ++ out) mExit -- DEBUG
-          putStrLn $ (\ (Just (ex, out, err)) -> "err: " ++ err) mExit -- DEBUG
-          putStrLn $ "" -- DEBUG
-          putStrLn $ "" -- DEBUG
           t_end <- getHetsTime
           removeFile timeTmpFile
           when hasEnt $ removeFile entailsFile


### PR DESCRIPTION
This should allow to use both `libFaCTPlusPlusJNI.jnilib` and `libFaCTPlusPlusJNI.so` with Hets for Fact++. For the `libFaCTPlusPlusJNI.jnilib`, the `HETS_JNI_LIBS` environment variable is supposed to point to the directory containing the `libFaCTPlusPlusJNI.jnilib`.

This is about the discussion in #1412.
