### PR TITLE
fail if names of sentences appear as names of symbols

### DIFF
--- a/Logic/Logic.hs
+++ b/Logic/Logic.hs
@@ -394,6 +394,16 @@ symset_of :: forall lid sentence sign morphism symbol .
              lid -> sign -> Set.Set symbol
 symset_of lid sig = Set.unions $ sym_of lid sig
 
+-- | check that all sentence names in a theory do not appear as symbol names
+checkSenNames :: forall lid sentence sign morphism symbol . 
+                 Sentences lid sentence sign morphism symbol =>
+                 lid -> sign -> [Named sentence] -> Set.Set String
+checkSenNames lid aSig nsens = 
+ let senNames = map senAttr nsens
+     symNames = map (show . (sym_name lid)) $ Set.toList $
+                symset_of lid aSig
+ in Set.intersection (Set.fromList symNames) $ Set.fromList senNames 
+
 -- | dependency ordered list of symbols for a signature
 symlist_of :: forall lid sentence sign morphism symbol .
               Sentences lid sentence sign morphism symbol =>

--- a/PGIP/Server.hs
+++ b/PGIP/Server.hs
@@ -314,8 +314,8 @@ oldWebApi opts tempLib sessRef re pathBits splitQuery meth respond
                  Just k' -> getHetsResult opts [] sessRef (qr k')
                               Nothing OldWebAPI proofFormatterOptions
                respond $ case ms of
-                 Nothing -> mkResponse textC status422 $ showRelDiags 1 ds
-                 Just (t, s) -> mkOkResponse t s
+                 Just (t, s) | not $ hasErrors ds-> mkOkResponse t s
+                 _ -> mkResponse textC status422 $ showRelDiags 1 ds
            -- AUTOMATIC PROOFS E.N.D.
            else getHetsResponse opts [] sessRef pathBits splitQuery respond
       "POST" -> do
@@ -467,8 +467,8 @@ parseRESTful
     Result ds ms <- liftIO $ runResultT $
       getHetsResult myOpts [] sessRef qr format RESTfulAPI pfOptions
     respond $ case ms of
-      Nothing -> mkResponse textC status422 $ showRelDiags 1 ds
-      Just (t, s) -> mkOkResponse t s
+      Just (t, s) | not $ hasErrors ds -> mkOkResponse t s
+      _ -> mkResponse textC status422 $ showRelDiags 1 ds
   getResponse = getResponseAux opts
   -- respond depending on request Method
   in case meth of

--- a/Static/AnalysisStructured.hs
+++ b/Static/AnalysisStructured.hs
@@ -323,7 +323,7 @@ anaSpecAux conser addSyms lg libEnv ln dg nsig name opts eo sp rg = case sp of
        let names = checkSenNames lid sigma_complete $ nameAndDisambiguate ax
        if not $ Set.null names  then
           fail $ "The following sentence names are also used as symbol names:" 
-          ++ show names
+          ++ (concatMap (\x -> x ++ " ") $ Set.toList names)
        else do
         diffSig <- case signatureDiff lid sigma_complete sig of
           Result _ (Just ds) -> return ds

--- a/Static/AnalysisStructured.hs
+++ b/Static/AnalysisStructured.hs
@@ -64,6 +64,7 @@ import Common.LibName
 import Common.Result
 import Common.Utils (number)
 import Common.Lib.MapSet (imageSet, setInsert)
+import Common.ProofUtils
 
 import Data.Graph.Inductive.Graph
 import qualified Data.Set as Set
@@ -319,21 +320,26 @@ anaSpecAux conser addSyms lg libEnv ln dg nsig name opts eo sp rg = case sp of
                Nothing | null ds ->
                  fail "basic analysis failed without giving a reason"
                _ -> res
-       diffSig <- case signatureDiff lid sigma_complete sig of
-         Result _ (Just ds) -> return ds
-         _ -> warning sigma_complete
-           "signature difference could not be computed using full one" pos
-       let gsysd = Set.map (G_symbol lid) sysd
-           (ns, dg') = insGTheory dg0 (setSrcRange rg name)
-             (DGBasicSpec (Just $ G_basic_spec lid bspec')
-             (G_sign lid (mkExtSign diffSig) startSigId) gsysd)
-               $ G_theory lid (currentSyntax lg) (ExtSign sigma_complete
-               $ Set.intersection
-                     (if addSyms then Set.union sys sysd else sysd)
-               $ symset_of lid sigma_complete)
-             startSigId (toThSens ax) startThId
-       dg'' <- createConsLink DefLink conser lg dg' nsig' ns DGLinkExtension
-       return (Basic_spec (G_basic_spec lid bspec') pos, ns, dg'')
+       let names = checkSenNames lid sigma_complete $ nameAndDisambiguate ax
+       if not $ Set.null names  then
+          fail $ "The following sentence names are also used as symbol names:" 
+          ++ show names
+       else do
+        diffSig <- case signatureDiff lid sigma_complete sig of
+          Result _ (Just ds) -> return ds
+          _ -> warning sigma_complete
+            "signature difference could not be computed using full one" pos
+        let gsysd = Set.map (G_symbol lid) sysd
+            (ns, dg') = insGTheory dg0 (setSrcRange rg name)
+              (DGBasicSpec (Just $ G_basic_spec lid bspec')
+              (G_sign lid (mkExtSign diffSig) startSigId) gsysd)
+                $ G_theory lid (currentSyntax lg) (ExtSign sigma_complete
+                $ Set.intersection
+                      (if addSyms then Set.union sys sysd else sysd)
+                $ symset_of lid sigma_complete)
+              startSigId (toThSens ax) startThId
+        dg'' <- createConsLink DefLink conser lg dg' nsig' ns DGLinkExtension
+        return (Basic_spec (G_basic_spec lid bspec') pos, ns, dg'')
   EmptySpec pos -> case nsig of
       EmptyNode _ -> do
         warning () "empty spec" pos


### PR DESCRIPTION
Without the call of `nameAndDisambiguate`, the following specification goes through:

```
spec S = 
 sort s_1
 op c : s_1
 op f : s_1 -> s_1
 
 . f(c) = c %(s)%
 . exists x : s_1 . f(x) = x %(s)%
end
```

but the second sentence is renamed to `s_1` for proving.