### PR TITLE
Extensions to hets api

### DIFF
--- a/PGIP/Query.hs
+++ b/PGIP/Query.hs
@@ -74,11 +74,11 @@ displayTypes =
 comorphs :: [String]
 comorphs = ["provers", "translations"]
 
-data NodeCmd = Node | Info | Theory | Symbols
-  deriving (Show, Eq, Bounded, Enum)
+data NodeCmd = Node | Info | Theory | Symbols | Translate String
+  deriving (Show, Eq)
 
 nodeCmds :: [NodeCmd]
-nodeCmds = [minBound .. maxBound]
+nodeCmds = [Node, Info, Theory, Symbols]
 
 showNodeCmd :: NodeCmd -> String
 showNodeCmd = map toLower . show
@@ -344,7 +344,7 @@ anaNodeQuery ans i moreTheorems incls pss =
       cmds = map (\ a -> (showNodeCmd a, a)) nodeCmds
   in case ans of
        [] -> Right $ NodeQuery i
-         $ if noPP then NcCmd minBound else pp
+         $ if noPP then NcCmd Node else pp
        [cmd] -> case cmd of
          "prove" -> Right $ NodeQuery i pp
          "provers" | noIncl && isNothing prover ->

--- a/PGIP/Query.hs
+++ b/PGIP/Query.hs
@@ -128,6 +128,7 @@ showPathQuery p q = showPath p ++ if null q then "" else showQuery q
 
 data QueryKind =
     DisplayQuery (Maybe String)
+  | DGTranslation String
   | GlobCmdQuery String
   | GlProvers ProverMode (Maybe String)
   | GlTranslations

--- a/PGIP/Server.hs
+++ b/PGIP/Server.hs
@@ -469,9 +469,7 @@ parseRESTful
       in return . Query (DGQuery sId (Just p)) . nodeQuery (getFragment p)
   -- call getHetsResult with the properly generated query (Final Result)
   getResponseAux myOpts qr = do
-    let format' = case format of 
-                    Nothing -> Just "xml"
-                    _ -> format
+    let format' = Just $ fromMaybe "xml" format
     Result ds ms <- liftIO $ runResultT $
       getHetsResult myOpts [] sessRef qr format' RESTfulAPI pfOptions
     respond $ case ms of
@@ -561,21 +559,21 @@ parseRESTful
              in case nodeM of
              Nothing -> GlAutoProve pc
              Just n -> nodeQuery n $ ProveNode pc
-           "dg" -> case transM of 
+           "dg" -> case transM of
              Nothing -> DisplayQuery (Just $ fromMaybe "xml" format)
              Just tr -> Query.DGTranslation tr
            "theory" -> case transM of
              Nothing -> case nodeM of
-                         Just x -> NodeQuery (maybe (Right x) Left $ readMaybe x) 
+                         Just x -> NodeQuery (maybe (Right x) Left $ readMaybe x)
                                    $ NcCmd Query.Theory
                          Nothing -> error "REST: theory"
              Just tr -> case nodeM of
-                         Just x -> NodeQuery (maybe (Right x) Left $ readMaybe x) 
+                         Just x -> NodeQuery (maybe (Right x) Left $ readMaybe x)
                                    $ NcCmd $ Query.Translate tr
                          Nothing -> error "REST: theory"
            _ -> error $ "REST: unknown " ++ newIde
          in getResponseAux newOpts . Query (NewDGQuery libIri $ cmdList
-            ++ Set.toList (Set.fromList $ optFlags ++ qOpts)) $ qkind 
+            ++ Set.toList (Set.fromList $ optFlags ++ qOpts)) $ qkind
                  else queryFailure
       _ -> queryFailure
     "PUT" -> case pathBits of
@@ -974,7 +972,7 @@ getHetsResult opts updates sessRef (Query dgQ qk) format api pfOptions = do
               Just str | elem str ppList
                 -> ppDGraph dg $ lookup str $ zip ppList prettyList
               _ -> sessAns ln svg sk
-            Query.DGTranslation path -> do 
+            Query.DGTranslation path -> do
               -- compose the comorphisms passed in translation
                let coms = map getCom $ splitOn ',' path
                com <- foldM compComorphism (head coms) $ tail coms
@@ -1078,7 +1076,7 @@ getHetsResult opts updates sessRef (Query dgQ qk) format api pfOptions = do
                         lift $ nextSess newLib sess sessRef k
                         return (xmlC, ppTopElement $ formatConsNode res txt)
                     _ -> case nc of
-                      NcCmd Query.Theory -> case api of 
+                      NcCmd Query.Theory -> case api of
                           OldWebAPI -> lift $ fmap (\ t -> (htmlC, t))
                                        $ showGlobalTh dg i gTh k fstLine
                           RESTfulAPI -> lift $ fmap (\ t -> (xmlC, t))
@@ -1102,7 +1100,7 @@ getHetsResult opts updates sessRef (Query dgQ qk) format api pfOptions = do
                                           (i, n1, globDefLink gmor SeeSource) -- origin to be corrected
                                           dg1
                           -- show the theory of n1 in xml format
-                          lift $ fmap (\ t -> (xmlC, t)) $ showNodeXml opts (globalAnnos dg2) libEnv dg2 n1 
+                          lift $ fmap (\ t -> (xmlC, t)) $ showNodeXml opts (globalAnnos dg2) libEnv dg2 n1
                       NcProvers mp mt -> do
                         availableProvers <- liftIO $ getProverList mp mt subL
                         return $ case api of
@@ -1210,7 +1208,7 @@ showBool = map toLower . show
 showNodeXml :: HetcatsOpts -> GlobalAnnos -> LibEnv -> DGraph -> Int -> IO String
 showNodeXml opts ga lenv dg n = let
  lNodeN = lab (dgBody dg) n
- in case lNodeN of 
+ in case lNodeN of
      Just lNode -> return $ ppTopElement $ ToXml.lnode opts ga lenv (n,lNode)
      Nothing -> error $ "no node for " ++ show n
 

--- a/PGIP/Server.hs
+++ b/PGIP/Server.hs
@@ -91,9 +91,9 @@ import Common.ResultT
 import Common.ToXml
 import Common.Utils
 import Common.XUpdate
+import Common.GlobalAnnotations
 
 import Control.Monad
-import Control.Exception.Base (SomeException)
 
 import qualified Data.IntMap as IntMap
 import qualified Data.Map as Map
@@ -385,7 +385,7 @@ nodeEdgeIdes = ["nodes", "edges"]
 newRESTIdes :: [String]
 newRESTIdes =
   [ "dg", "translations", "provers", "consistency-checkers", "prove"
-  , "consistency-check" ]
+  , "consistency-check", "theory" ]
 
 queryFail :: String -> WebResponse
 queryFail msg respond = respond $ mkResponse textC status400 msg
@@ -464,8 +464,11 @@ parseRESTful
       in return . Query (DGQuery sId (Just p)) . nodeQuery (getFragment p)
   -- call getHetsResult with the properly generated query (Final Result)
   getResponseAux myOpts qr = do
+    let format' = case format of 
+                    Nothing -> Just "xml"
+                    _ -> format
     Result ds ms <- liftIO $ runResultT $
-      getHetsResult myOpts [] sessRef qr format RESTfulAPI pfOptions
+      getHetsResult myOpts [] sessRef qr format' RESTfulAPI pfOptions
     respond $ case ms of
       Nothing -> mkResponse textC status422 $ showRelDiags 1 ds
       Just (t, s) -> mkOkResponse t s
@@ -533,9 +536,8 @@ parseRESTful
             newOpts = foldl makeOpts opts $ mapMaybe (`lookup` optionFlags)
               optFlags
         in if elem newIde newRESTIdes && all (`elem` globalCommands) cmdList
-        then getResponseAux newOpts . Query (NewDGQuery libIri $ cmdList
-            ++ Set.toList (Set.fromList $ optFlags ++ qOpts))
-         $ case newIde of
+        then let
+         qkind = case newIde of
            "translations" -> case nodeM of
              Nothing -> GlTranslations
              Just n -> nodeQuery n $ NcTranslations Nothing
@@ -554,8 +556,20 @@ parseRESTful
              in case nodeM of
              Nothing -> GlAutoProve pc
              Just n -> nodeQuery n $ ProveNode pc
-           _ -> DisplayQuery (Just $ fromMaybe "xml" format)
-        else queryFailure
+           "dg" -> DisplayQuery (Just $ fromMaybe "xml" format)
+           "theory" -> case transM of
+             Nothing -> case nodeM of
+                         Just x -> NodeQuery (maybe (Right x) Left $ readMaybe x) 
+                                   $ NcCmd Query.Theory
+                         Nothing -> error "REST: theory"
+             Just tr -> case nodeM of
+                         Just x -> NodeQuery (maybe (Right x) Left $ readMaybe x) 
+                                   $ NcCmd $ Query.Translate tr
+                         Nothing -> error "REST: theory"
+           _ -> error $ "REST: unknown " ++ newIde
+         in getResponseAux newOpts . Query (NewDGQuery libIri $ cmdList
+            ++ Set.toList (Set.fromList $ optFlags ++ qOpts)) $ qkind 
+                 else queryFailure
       _ -> queryFailure
     "PUT" -> case pathBits of
       {- execute global commands
@@ -1045,8 +1059,36 @@ getHetsResult opts updates sessRef (Query dgQ qk) format api pfOptions = do
                         lift $ nextSess newLib sess sessRef k
                         return (xmlC, ppTopElement $ formatConsNode res txt)
                     _ -> case nc of
-                      NcCmd Query.Theory -> lift $ fmap (\ t -> (htmlC, t))
-                          $ showGlobalTh dg i gTh k fstLine
+                      NcCmd Query.Theory -> case api of 
+                          OldWebAPI -> lift $ fmap (\ t -> (htmlC, t))
+                                       $ showGlobalTh dg i gTh k fstLine
+                          RESTfulAPI -> lift $ fmap (\ t -> (xmlC, t))
+                                       $ showNodeXml opts (globalAnnos dg) libEnv dg i
+                      NcCmd (Query.Translate x) -> do
+                          -- compose the comorphisms passed in translation
+                          let getCom n = let ncoms = filter (\(Comorphism cid) -> language_name cid == n) comorphismList
+                                          in case ncoms of
+                                              [c] -> c
+                                              [] -> error $ "comorphism not found:" ++ n
+                                              _ -> error $ "more than one comorphism found for:" ++ n
+                              coms = map getCom $ splitOn ',' x
+                          com <- foldM compComorphism (head coms) $ tail coms
+                          -- translate the theory of i along com
+                          gTh1 <- liftR $ mapG_theory com gTh
+                          -- insert the translation of i in dg
+                          let n1 = getNewNodeDG dg
+                              labN1 = newInfoNodeLab
+                                       emptyNodeName
+                                       (newNodeInfo DGBasic) -- to be corrected
+                                       gTh1
+                              dg1 = insLNodeDG (n1, labN1) dg
+                          gmor <- liftR $ gEmbedComorphism com $ signOf $ dgn_theory dgnode
+                          -- add a link from i to n1 labeled with (com, id)
+                          let (_, dg2) = insLEdgeDG
+                                          (i, n1, globDefLink gmor SeeSource) -- origin to be corrected
+                                          dg1
+                          -- show the theory of n1 in xml format
+                          lift $ fmap (\ t -> (xmlC, t)) $ showNodeXml opts (globalAnnos dg2) libEnv dg2 n1 
                       NcProvers mp mt -> do
                         availableProvers <- liftIO $ getProverList mp mt subL
                         return $ case api of
@@ -1150,6 +1192,13 @@ resultStyles = unlines
 
 showBool :: Bool -> String
 showBool = map toLower . show
+
+showNodeXml :: HetcatsOpts -> GlobalAnnos -> LibEnv -> DGraph -> Int -> IO String
+showNodeXml opts ga lenv dg n = let
+ lNodeN = lab (dgBody dg) n
+ in case lNodeN of 
+     Just lNode -> return $ ppTopElement $ ToXml.lnode opts ga lenv (n,lNode)
+     Nothing -> error $ "no node for " ++ show n
 
 {- | displays the global theory for a node with the option to prove theorems
 and select proving options -}

--- a/PGIP/Server.hs
+++ b/PGIP/Server.hs
@@ -12,6 +12,10 @@ Portability :  non-portable (via imports)
 
 module PGIP.Server (hetsServer) where
 
+#ifdef WARP3
+import Control.Exception.Base (SomeException)
+#endif
+
 import PGIP.Output.Formatting
 import PGIP.Output.Mime
 import PGIP.Output.Proof


### PR DESCRIPTION
implements support for the extensions specified in #1561. 

Tests:

 ```
curl localhost:8000/dg/https%3a%2f%2fontohub.org%2fhets-lib%2fPropositional%2fBirds.het/full-signatures/full-theories/auto?translation=Propositional2OWL2
```
  the graph gets translated to OWL2 (and displayed in XML format)
 
```
curl localhost:8000/theory/https%3a%2f%2fontohub.org%2fhets-lib%2fPropositional%2fBirds.het/full-signatures/full-theories/auto?node=Animal
```

 the theory `Animal` is displayed

 ```
curl localhost:8000/theory/https%3a%2f%2fontohub.org%2fhets-lib%2fPropositional%2fBirds.het/full-signatures/full-theories/auto?node=Animal&translation=Propositional2OWL2
```

 the theory `Animal` gets translated to OWL2
 
```
curl localhost:8000/theory/https%3a%2f%2fontohub.org%2fhets-lib%2fPropositional%2fBirds.het/full-signatures/full-theories/auto?node=0&translation=Propositional2OWL2
```
 the theory of the node 0 (`Animal`) gets translated to OWL2

```
curl localhost:8000/theory/https%3a%2f%2fontohub.org%2fhets-lib%2fPropositional%2fBirds.het/full-signatures/full-theories/auto?translation=Propositional2OWL2,OWL22CommonLogic&node=Animal
```

the theory of `Animal` gets translated via OWL2 to CommonLogic
