### PR TITLE
1641 prefixes of modules

### DIFF
--- a/OWL2/ExtractModule.hs
+++ b/OWL2/ExtractModule.hs
@@ -26,6 +26,8 @@ import Common.AS_Annotation
 import Common.GlobalAnnotations
 import qualified Common.IRI as IRI
 
+import qualified Data.Map as Map
+
 import Control.Monad.Trans
 import System.IO.Unsafe
 
@@ -38,7 +40,7 @@ extractModule syms onto =
 
 extractModuleAux :: [IRI.IRI] -> (Sign, [Named Axiom])
                               -> ResultT IO (Sign, [Named Axiom])
-extractModuleAux syms onto = do
+extractModuleAux syms onto@(osig,_) = do
   let ontology_content = show $ printOWLBasicTheory onto
   inFile <- lift $ getTempFile ontology_content "in"
   outFile <- lift $ getTempFile "" "out"
@@ -51,5 +53,8 @@ extractModuleAux syms onto = do
    [modOnto] -> do
      (_ontodoc, ExtSign sig _, sens) <- liftR $
          basicOWL2Analysis (modOnto, emptySign, emptyGlobalAnnos)
-     lift $ return (sig, sens)
+     lift $ return (sig {
+                      prefixMap = Map.union (prefixMap osig) 
+                                  $ prefixMap sig}, 
+                   sens)
    _ -> error "the module should be just one ontology"

--- a/OWL2/OWL22CASL.hs
+++ b/OWL2/OWL22CASL.hs
@@ -121,14 +121,14 @@ uriToCaslId urI = let
  in
   if ((isDatatypeKey urI) && (isThing urI))  then
         getId $ localPart urI
-   else getId $ localPart urI
-    {-let
+   else 
+    let
       ePart = expandedIRI urI
     in
       if ePart /= "" then
         getId $ expandedIRI urI
-      else -- this catches the datatypes, e.g. xsd:time, weird
-        getId $ localPart urI-}
+      else 
+        getId $ localPart urI
 
 tokDecl :: Token -> VAR_DECL
 tokDecl = flip mkVarDecl thing


### PR DESCRIPTION
Use expandedIRI when translating to CASL and unite the prefix map of the module with the one of the ontology it is extracted from, preferring the latter.