### PR TITLE
make it compile using ghc-8.0.1

### DIFF
--- a/ATC/Grothendieck.der.hs
+++ b/ATC/Grothendieck.der.hs
@@ -82,7 +82,7 @@ fromShATermLG' lg i att = case getATerm' i att of
                (attN, t) -> (setATerm' i t attN, t)
 
 -- generic undecidable instance
-instance ShATermConvertible a => ShATermLG a where
+instance (ShATermConvertible a, Typeable a) => ShATermLG a where
   toShATermLG = toShATermAux
   fromShATermLG _ = fromShATermAux
 

--- a/Logic/Morphism.hs
+++ b/Logic/Morphism.hs
@@ -176,11 +176,12 @@ instance Language cid => Language (SpanDomain cid) where
 {- the category of signatures is exactly the category of signatures of
 the sublogic on which the morphism is defined, but with another name -}
 
-instance Morphism cid
+instance (Morphism cid
             lid1 sublogics1 basic_spec1 sentence1 symb_items1 symb_map_items1
                 sign1 morphism1 sign_symbol1 symbol1 proof_tree1
             lid2 sublogics2 basic_spec2 sentence2 symb_items2 symb_map_items2
                 sign2 morphism2 sign_symbol2 symbol2 proof_tree2
+         , Pretty sign_symbol1)
          => Syntax (SpanDomain cid) () sign_symbol1 () ()
 -- default is ok
 
@@ -188,11 +189,12 @@ newtype S2 s = S2 { sentence2 :: s }
   deriving (Eq, Ord, Show, Typeable, Data, ShATermConvertible, Pretty
            , GetRange, ToJson, ToXml)
 
-instance Morphism cid
+instance (Morphism cid
             lid1 sublogics1 basic_spec1 sentence1 symb_items1 symb_map_items1
                 sign1 morphism1 sign_symbol1 symbol1 proof_tree1
             lid2 sublogics2 basic_spec2 sentence2 symb_items2 symb_map_items2
                 sign2 morphism2 sign_symbol2 symbol2 proof_tree2
+         , Category sign1 morphism1, Ord sign_symbol1, GetRange sign_symbol1)
     => Sentences (SpanDomain cid) (S2 sentence2) sign1 morphism1
        sign_symbol1 where
 
@@ -220,7 +222,8 @@ instance (Morphism cid
             lid1 sublogics1 basic_spec1 sentence1 symb_items1 symb_map_items1
                 sign1 morphism1 sign_symbol1 symbol1 proof_tree1
             lid2 sublogics2 basic_spec2 sentence2 symb_items2 symb_map_items2
-                sign2 morphism2 sign_symbol2 symbol2 proof_tree2)
+                sign2 morphism2 sign_symbol2 symbol2 proof_tree2
+         , Ord symbol1, GetRange symbol1, Pretty symbol1, Typeable symbol1)
         => StaticAnalysis (SpanDomain cid) () (S2 sentence2) () ()
            sign1 morphism1 sign_symbol1 symbol1 where
  ensures_amalgamability l _ = statFail l "ensures_amalgamability"
@@ -297,7 +300,8 @@ instance ( MinSublogic sublogics1 ()
                 sign1 morphism1 sign_symbol1 symbol1 proof_tree1
             lid2 sublogics2 basic_spec2 sentence2 symb_items2 symb_map_items2
                 sign2 morphism2 sign_symbol2 symbol2 proof_tree2
-         ) => Logic (SpanDomain cid) (SublogicsPair sublogics1 sublogics2) ()
+         , Ord proof_tree2, Show proof_tree2)
+         => Logic (SpanDomain cid) (SublogicsPair sublogics1 sublogics2) ()
           (S2 sentence2) () () sign1 morphism1 sign_symbol1 symbol1 proof_tree2
     where
       stability (SpanDomain _) = Experimental


### PR DESCRIPTION
the changes of this PR are needed to make it compile using ghc-8.0.1 and cabal version 1.24. It still compiles using ghc-7.10.3 and the ghc version from trusty.

I've also uploaded a fixed haskell package https://hackage.haskell.org/package/uni-htk-2.2.1.3 (for ghc-8.0.1) and made a (local) glade release  to be installed by: `cabal install https://github.com/cmaeder/glade/releases/download/v0.13.1/glade-0.13.1.tar.gz`

Please review and allow me to merge to master.