### PR TITLE
relax upper bounds

### DIFF
--- a/Hets.cabal
+++ b/Hets.cabal
@@ -77,7 +77,7 @@ Executable hets
     , parsec >= 2.1.0.0
     , pretty >= 1.0.0.0
     , process >= 1.0.1.1
-    , time >= 1.1.3 && < 1.6
+    , time >= 1.1.3 && < 1.7
     , utf8-string
     , bytestring >= 0.9
     , xml >= 1.3.7 && < 1.4
@@ -99,7 +99,7 @@ Executable hets
     cpp-options: -DHAXML
 
   if flag(tar)
-    build-depends: tar >= 0.3 && < 0.5
+    build-depends: tar >= 0.3 && < 0.6
     cpp-options: -DTAR_PACKAGE
 
   if flag(unix)
@@ -127,7 +127,7 @@ Executable hets
         wai-extra >= 3.0 && < 4.0
       , wai >= 3.0 && < 4.0
       , warp >= 3.0 && < 4.0
-      , http-types >= 0.6 && < 0.9
+      , http-types >= 0.6 && <= 1.0
       , text >= 0.5 && < 1.3
       , case-insensitive
       , random >= 1.0


### PR DESCRIPTION
I want to merge in this Hets.cabal change so that `cabal install --only-dependencies` works (after glade is installed). 