### PR TITLE
Fixing owl22casl

### DIFF
--- a/CASL/Induction.hs
+++ b/CASL/Induction.hs
@@ -12,7 +12,7 @@ We provide both second-order induction schemes as well as their
 instantiation to specific first-order formulas.
 -}
 
-module CASL.Induction (inductionScheme, generateInductionLemmas) where
+module CASL.Induction (inductionScheme, generateInductionLemmas, substitute) where
 
 import CASL.AS_Basic_CASL
 import CASL.Sign

--- a/CASL_DL/PredefinedCASLAxioms.hs
+++ b/CASL_DL/PredefinedCASLAxioms.hs
@@ -286,10 +286,8 @@ predefinedAxioms = let
             (Qual_pred_name thing classPredType n) [t1] n]
 
 mkNNameAux :: Int -> String
-mkNNameAux k = case k of
-    0 -> ""
-    j -> mkNNameAux (j `div` 26) ++ [chr (j `mod` 26 + 96)]
-
+mkNNameAux k = genNamePrefix ++ "x" ++ show k
+ 
 -- | Build a name
 mkNName :: Int -> Token
 mkNName i = mkSimpleId $ hetsPrefix ++ mkNNameAux i

--- a/OWL2/OWL22CASL.hs
+++ b/OWL2/OWL22CASL.hs
@@ -469,7 +469,7 @@ mapCard b cSig ct n prop d var = do
     let dlst = map (\ (x, y) -> mkNeg $ mkStEq (qualThing x) $ qualThing y)
                         $ comPairs vlst vlst
         dlstM = map (\ (x, y) -> mkStEq (qualThing x) $ qualThing y)
-                        $ mkPairs (n + var + 1) vlst
+                        $ comPairs vlstM vlstM
         qVars = map thingDecl vlst
         qVarsM = map thingDecl vlstM
         qVarsE = map thingDecl vlstE
@@ -656,7 +656,7 @@ mapListFrameBit cSig ex rel lfb =
               case ty of
                 NamedIndividual | rel == Just Types -> do
                   inD <- mapIndivURI cSig iri
-                  let els' = map (substitute (mkNName 1) thing inD) els 
+                  let els' = map (substitute (mkNName 1) thing inD) els
                   return ( els', uniteL $ cSig : s)
                 DataProperty | rel == (Just $ DRRelation ADomain) -> do
                   oEx <- mapDataProp cSig iri 1 2


### PR DESCRIPTION
Before the datatype translation is fixed, we should merge the concept and sentence translation. A test file is here: https://ontohub.org/sandbox/owl22casl.dol but if I missed something let me know. Also, if you don't like to have all these generated names for variables, I could implement another convention.