### PR TITLE
better error messages

### DIFF
--- a/OWL2/StaticAnalysis.hs
+++ b/OWL2/StaticAnalysis.hs
@@ -421,7 +421,8 @@ addEquiv ssig tsig l1 l2 = do
                          Map.insert e2 s Map.empty)
              else
               fail "only symbols of same kind can be equivalent in an alignment"
-          _ -> fail $ "non-unique symbol match:" ++ show l1 ++ " " ++ show l2
+          _ -> fail $ "non-unique symbol match:" ++ showDoc l1 " " 
+                                                 ++  showDoc l2 " "
     _ -> fail "terms not yet supported in alignments"
 
 corr2theo :: String -> Bool -> Sign -> Sign -> [SymbItems] -> [SymbItems] ->
@@ -527,5 +528,6 @@ corr2theo aname flag ssig tsig l1 l2 eMap1 eMap2 rref = do
                       Map.union eMap2' $ Map.fromAscList [(rsym, sym')]) 
                _ -> fail $ "too many matches for " ++ show rQName -}
             _ -> fail $ "nyi:" ++ show rref
-          _ -> fail $ "non-unique symbol match:" ++ show l1 ++ " " ++ show l2
+          _ -> fail $ "non-unique symbol match:" ++ showDoc l1 " " 
+                                                 ++ showDoc l2 " "
     _ -> fail "terms not yet supported in alignments"

--- a/Static/AnalysisLibrary.hs
+++ b/Static/AnalysisLibrary.hs
@@ -51,6 +51,7 @@ import Common.ResultT
 import Common.LibName
 import Common.Id
 import Common.IRI
+import Common.DocUtils
 import qualified Common.Unlit as Unlit
 
 import Driver.Options
@@ -574,7 +575,7 @@ symbolsOf lg gs1@(G_sign l1 (ExtSign sig1 sys1) _)
         (G_symb_items_list lid2 sis2) _ _ -> do
       ss1 <- coerceSymbItemsList lid1 l1 "symbolsOf1" sis1
       rs1 <- stat_symb_items l1 sig1 ss1
-      ss2 <- coerceSymbItemsList lid2 l2 "symbolsOf1" sis2
+      ss2 <- coerceSymbItemsList lid2 l2 "symbolsOf2" sis2
       rs2 <- stat_symb_items l2 sig2 ss2
       p <- case (rs1, rs2) of
         ([r1], [r2]) ->
@@ -583,10 +584,16 @@ symbolsOf lg gs1@(G_sign l1 (ExtSign sig1 sys1) _)
             , filter (\ sy -> matches l2 sy r2) $ Set.toList sys2) of
           ([s1], [s2]) ->
             return (G_symbol l1 s1, G_symbol l2 s2)
-          (ll1, ll2) ->
-                 error
-                  $ "non-unique symbol match: " ++ show ll1 ++ "\n" ++ show ll2
-        _ -> mkError "non-unique raw symbols" c
+          (ll1, ll2) -> 
+                 plain_error (G_symbol l1 $ head ll1, G_symbol l2 $ head ll2) -- this is a hack!
+                  ("Missing or non-unique symbol match " ++ 
+                   "for correspondence\nMatches for first symbol: " ++ 
+                   showDoc rs1 "\n" ++
+                   showDoc ll1 "\nMatches for second symbol: " ++ 
+                   showDoc rs2 "\n" ++
+                   showDoc ll2 "\n") 
+                  nullRange
+        _ -> fail $ "non-unique raw symbols"
       ps <- symbolsOf lg gs1 gs2 corresps'
       return $ Set.insert p ps
 


### PR DESCRIPTION
With
```
logic OWL

ontology O1 =
 Class: A
 Individual: A
end

ontology O2 =
 Class: B
end

alignment A1 : O1 to O2 = 
  A = C, 
  D = B
end
```
I get
```
*** Error:
Missing or non-unique symbol match for correspondence
Matches for first symbol: [A]
[Class A, NamedIndividual A]
Matches for second symbol: [C]
[]
*** Error:
Missing or non-unique symbol match for correspondence
Matches for first symbol: [D]
[]
Matches for second symbol: [B]
[Class B]
*** Error: non-unique symbol match:[A] [C]
hets: user error (Stopped due to errors)

```