### PR TITLE
Owl datatypes in casl

### DIFF
--- a/CASL_DL/PredefinedCASLAxioms.hs
+++ b/CASL_DL/PredefinedCASLAxioms.hs
@@ -339,7 +339,6 @@ floatSign = integerSign
                           (unMinus, [minusTy, minusFloat])
                         , (dec, [decTy])
                         , (eId, [expTy])
-                        , (cons, [consTy])
                         ]
                  , globAnnos = (globAnnos integerSign)
                      { literal_annos = (literal_annos $ globAnnos integerSign)
@@ -358,8 +357,8 @@ boolSign = (emptySign ())
                         ]
                  }
 
-stringSign :: CASLSign
-stringSign = (emptySign ())
+stringSignAux :: CASLSign
+stringSignAux = (emptySign ())
                  { sortRel = 
                       Rel.transClosure $ Rel.fromList
                        [ (stringS, dataS) ]
@@ -367,12 +366,16 @@ stringSign = (emptySign ())
                         $ 
                         [
                          (emptyString, [emptyStringTy])
+                         , (cons, [consTy])
                         ]
                  , globAnnos = emptyGlobalAnnos
                      { literal_annos = emptyLiteralAnnos
                        { 
                        string_lit = Just (emptyString, cons) }}
                  }
+
+stringSign :: CASLSign
+stringSign = uniteCASLSign stringSignAux charSign
 
 datatypeSigns :: Map.Map SORT CASLSign
 datatypeSigns = Map.fromList

--- a/CASL_DL/PredefinedCASLAxioms.hs
+++ b/CASL_DL/PredefinedCASLAxioms.hs
@@ -13,6 +13,7 @@ Portability :  portable
 module CASL_DL.PredefinedCASLAxioms
   ( predefSign
   , predefinedSign
+  , predefSign2
   , thing
   , nothing
   , conceptPred
@@ -231,6 +232,14 @@ noThing = Qual_pred_name nothing classPredType n
 intTypes :: [PredType]
 intTypes = map (\ t -> PredType [t]) [integer, nonNegInt]
 
+predefinedSign2 :: e -> Sign f e
+predefinedSign2 e = (emptySign e) {
+  sortRel = Rel.insertKey thing $ Rel.insertKey dataS Rel.empty
+  }
+
+predefSign2 :: CASLSign
+predefSign2 = predefinedSign2 ()
+
 predefinedSign :: e -> Sign f e
 predefinedSign e = (emptySign e)
                  { sortRel = Rel.insertKey (stringToId "Char")
@@ -287,7 +296,7 @@ predefinedAxioms = let
 
 mkNNameAux :: Int -> String
 mkNNameAux k = genNamePrefix ++ "x" ++ show k
- 
+
 -- | Build a name
 mkNName :: Int -> Token
 mkNName i = mkSimpleId $ hetsPrefix ++ mkNNameAux i

--- a/Logic/Logic.hs
+++ b/Logic/Logic.hs
@@ -395,14 +395,14 @@ symset_of :: forall lid sentence sign morphism symbol .
 symset_of lid sig = Set.unions $ sym_of lid sig
 
 -- | check that all sentence names in a theory do not appear as symbol names
-checkSenNames :: forall lid sentence sign morphism symbol . 
+checkSenNames :: forall lid sentence sign morphism symbol .
                  Sentences lid sentence sign morphism symbol =>
                  lid -> sign -> [Named sentence] -> Set.Set String
-checkSenNames lid aSig nsens = 
+checkSenNames lid aSig nsens =
  let senNames = map senAttr nsens
      symNames = map (show . (sym_name lid)) $ Set.toList $
                 symset_of lid aSig
- in Set.intersection (Set.fromList symNames) $ Set.fromList senNames 
+ in Set.intersection (Set.fromList symNames) $ Set.fromList senNames
 
 -- | dependency ordered list of symbols for a signature
 symlist_of :: forall lid sentence sign morphism symbol .
@@ -627,7 +627,7 @@ class ( Syntax lid basic_spec symbol symb_items symb_map_items
          equiv2cospan :: lid -> sign -> sign -> [symb_items] -> [symb_items]
            -> Result (sign, sign, sign, EndoMap symbol, EndoMap symbol)
          equiv2cospan _ _ _ _ _ = error "equiv2cospan nyi"
-         -- | extract the module 
+         -- | extract the module
          extract_module :: lid -> [IRI] -> (sign, [Named sentence])
                         -> Result (sign, [Named sentence])
          extract_module _ _ = return
@@ -849,6 +849,17 @@ class (StaticAnalysis lid
                           -> Result (sign, [Named sentence])
          -- no logic should throw an error here
          addOmdocToTheory _ _ t _ = return t
+
+
+-- | sublogic of a theory
+sublogicOfTheo :: (Logic lid sublogics
+        basic_spec sentence symb_items symb_map_items
+        sign morphism symbol raw_symbol proof_tree) =>
+    lid -> (sign, [sentence]) -> sublogics
+sublogicOfTheo _ (sig, axs) =
+  foldl lub (minSublogic sig) $
+  map minSublogic axs
+
 
 {- The class of logics which can be used as logical frameworks, in which object
    logics can be specified by the user. Currently the only logics implementing

--- a/OWL2/OWL22CASL.hs
+++ b/OWL2/OWL22CASL.hs
@@ -259,13 +259,14 @@ mapSign sig =
              , opMap = tMp indiConst . cvrt $ OS.individuals sig
              }
 
-loadDataInformation :: ProfSub -> Sign f ()
+loadDataInformation :: ProfSub -> CASLSign
 loadDataInformation sl = let
   dts = Set.map uriToCaslId $ SL.datatype $ sublogic sl
- in  (emptySign ()) { sortRel =
-       Rel.transClosure . Rel.fromSet .
-       Set.map  (\ d -> (d, dataS))
-       $ dts }
+  eSig x = (emptySign ()) { sortRel =
+       Rel.fromList  [(x, dataS)]}
+  sigs = Set.toList $ 
+         Set.map (\x -> Map.findWithDefault (eSig x) x datatypeSigns) dts
+ in  foldl uniteCASLSign (emptySign ()) sigs
 
 mapTheory :: (OS.Sign, [Named Axiom]) -> Result (CASLSign, [Named CASLFORMULA])
 mapTheory (owlSig, owlSens) = let

--- a/OWL2/OWL22CASL.hs
+++ b/OWL2/OWL22CASL.hs
@@ -736,7 +736,7 @@ mapListFrameBit cSig ex rel lfb =
       Just r -> case ex of
         Misc _ -> do
             pairs <- mapComDataPropsList cSig Nothing dl 1 2
-            mkEDPairs cSig [1, 2] rel pairs
+            mkEDPairs' cSig [1, 2] rel pairs
         SimpleEntity (Entity _ DataProperty iri) -> case r of
             SubPropertyOf -> do
                 os1 <- mapM (\ o1 -> mapDataProp cSig o1 1 2) dl

--- a/OWL2/OWL22CASL.hs
+++ b/OWL2/OWL22CASL.hs
@@ -280,8 +280,7 @@ mapTheory (owlSig, owlSens) = let
             (sen, sig) <- mapSentence y z
             return (sen ++ x, uniteCASLSign sig y)) ([], cSig) owlSens
     return (foldl1 uniteCASLSign [nSig, pSig],  -- , dTypes],
-            reverse cSens)
-           -- predefinedAxioms ++ (reverse cSens))
+            predefinedAxioms ++ (reverse cSens))
 
 -- | mapping of OWL to CASL_DL formulae
 mapSentence :: CASLSign -> Named Axiom -> Result ([Named CASLFORMULA], CASLSign)

--- a/OWL2/OWL22CASL.hs
+++ b/OWL2/OWL22CASL.hs
@@ -123,13 +123,13 @@ uriToCaslId urI = let
  in
   if ((isDatatypeKey urI) && (isThing urI))  then
         getId $ localPart urI
-   else
+   else {-
     let
       ePart = expandedIRI urI
     in
       if ePart /= "" then
         getId $ expandedIRI urI
-      else
+      else -}
         getId $ localPart urI
 
 tokDecl :: Token -> VAR_DECL

--- a/OWL2/OWL22CASL.hs
+++ b/OWL2/OWL22CASL.hs
@@ -740,7 +740,7 @@ mapListFrameBit cSig ex rel lfb =
         SimpleEntity (Entity _ DataProperty iri) -> case r of
             SubPropertyOf -> do
                 os1 <- mapM (\ o1 -> mapDataProp cSig o1 1 2) dl
-                o2 <- mapDataProp cSig iri 2 1
+                o2 <- mapDataProp cSig iri 1 2 -- was 2 1
                 return (map (mkForall [thingDecl 1, dataDecl 2]
                     . mkImpl o2) os1, cSig)
             EDRelation _ -> do
@@ -838,6 +838,6 @@ mapKey cSig ce pl npl p i h = do
             $ mkExist (keyDecl h i) $ conjunct $ pl ++ [un], s)
 
 mapAxioms :: CASLSign -> Axiom -> Result ([CASLFORMULA], CASLSign)
-mapAxioms cSig ax@(PlainAxiom ex fb) = case fb of
+mapAxioms cSig (PlainAxiom ex fb) = case fb of
     ListFrameBit rel lfb -> mapListFrameBit cSig ex rel lfb
     AnnFrameBit ans afb -> mapAnnFrameBit cSig ex ans afb


### PR DESCRIPTION
Not sure that this is optimal, please have a look. I have split the predefined theory in smaller parts corresponding to each type, stored the parts in a map according to the name of the sort, and unite all parts corresponding to the datatypes in the sublogic of a theory. 