### PR TITLE
Fix the version timestamp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ define EOL
 endef
 
 # indicate, whether working on an exported repo
-GIT_TIMESTAMP := $(shell [ -d .git ] && git log -1 --format=%ct -- . )
+GIT_TIMESTAMP := $(shell [ -d .git ] && git log -1 --format=%ct )
 EXPORTED := $(shell [ -n "$(GIT_TIMESTAMP)" ] || printf 1)
 
 # the 'replacing spaces' example was taken from the (GNU) Make info manual


### PR DESCRIPTION
If no file is changed in a commit, `git log -1 -- .` does not display
this commit. The log of the whole repository must be used. Therefore,
the `-- .` must be removed.

Before, `make rev.txt` did not consider the merge commit b259e3b.