### PR TITLE
Remove dependencies: wget, cat, tac, grep/ggrep

### DIFF
--- a/Common/Http.hs
+++ b/Common/Http.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {- |
 Module      :  ./Common/Http.hs
 Description :  wrapper for simple http
@@ -12,15 +13,36 @@ Portability :  non-portable (uses package HTTP)
 
 module Common.Http where
 
-import Common.Utils
-
-import System.Exit
+import Control.Exception (try)
+import qualified Data.ByteString.Lazy.Char8 as Char8
+import Network.Connection (TLSSettings(..))
+import Network.HTTP.Client
+import Network.HTTP.Client.TLS
 
 loadFromUri :: String -> IO (Either String String)
-loadFromUri str = do
-  (code, out, err) <- executeProcess "wget"
-     ["--header=Accept: */*; q=0.1, text/plain",
-      "--no-check-certificate", "-O", "-", str] ""
-  return $ case code of
-    ExitSuccess -> Right out
-    _ -> Left err
+loadFromUri uri = do
+  manager <- newManager noVerifyTlsManagerSettings
+  initialRequest <- parseRequest uri
+  let request = initialRequest
+        { requestHeaders = [ ("Accept", "*/*; q=0.1, text/plain") ]}
+  eResponse <- try $ httpLbs request manager
+  case eResponse of
+    Left err ->
+      case err :: HttpException of
+        HttpExceptionRequest _ exceptionContent ->
+          return $ Left
+            ("Failed to load " ++ show uri ++ ": " ++ show exceptionContent)
+        InvalidUrlException invalidUrl reason ->
+          return $ Left ("Failed to load " ++ show invalidUrl ++ ": " ++ reason)
+    Right response ->
+      return $ Right $ Char8.unpack $ responseBody response
+
+noVerifyTlsManagerSettings :: ManagerSettings
+noVerifyTlsManagerSettings = mkManagerSettings noVerifyTlsSettings Nothing
+
+noVerifyTlsSettings :: TLSSettings
+noVerifyTlsSettings =
+  TLSSettingsSimple { settingDisableCertificateValidation = True
+                    , settingDisableSession = True
+                    , settingUseServerName = False
+                    }

--- a/Common/Http.hs
+++ b/Common/Http.hs
@@ -13,15 +13,20 @@ Portability :  non-portable (uses package HTTP)
 
 module Common.Http where
 
+import Driver.Options
+
 import Control.Exception (try)
 import qualified Data.ByteString.Lazy.Char8 as Char8
 import Network.Connection (TLSSettings(..))
 import Network.HTTP.Client
 import Network.HTTP.Client.TLS
 
-loadFromUri :: String -> IO (Either String String)
-loadFromUri uri = do
-  manager <- newManager noVerifyTlsManagerSettings
+loadFromUri :: HetcatsOpts -> String -> IO (Either String String)
+loadFromUri opts uri = do
+  manager <-
+    if disableCertificateVerification opts
+    then newManager noVerifyTlsManagerSettings
+    else newManager tlsManagerSettings
   initialRequest <- parseRequest uri
   let request = initialRequest
         { requestHeaders = [ ("Accept", "*/*; q=0.1, text/plain") ]}

--- a/Common/ProverTools.hs
+++ b/Common/ProverTools.hs
@@ -18,13 +18,6 @@ import Common.Utils
 import System.Directory
 import System.FilePath
 
-executableWithDefault :: String -> String -> IO String
-executableWithDefault ex def = do
-  mPath <- findExecutable ex
-  case mPath of
-    Nothing -> return def
-    Just _ -> return ex
-
 missingExecutableInPath :: String -> IO Bool
 missingExecutableInPath name = do
   mp <- findExecutable name

--- a/Driver/Options.hs
+++ b/Driver/Options.hs
@@ -210,6 +210,7 @@ data HetcatsOpts = HcOpt     -- for comments see usage info
   , applyAutomatic :: Bool
   , computeNormalForm :: Bool
   , dumpOpts :: [String]
+  , disableCertificateVerification :: Bool
   , ioEncoding :: Enc
     -- | use the library name in positions to avoid differences after uploads
   , useLibPos :: Bool
@@ -260,6 +261,7 @@ defaultHetcatsOpts = HcOpt
   , applyAutomatic = False
   , computeNormalForm = False
   , dumpOpts = []
+  , disableCertificateVerification = False
   , ioEncoding = Utf8
   , useLibPos = False
   , unlit = False
@@ -369,6 +371,7 @@ data Flag =
   | Connect Int String
   | XML
   | Dump String
+  | DisableCertificateVerification
   | IOEncoding Enc
   | Unlit
   | RelPos
@@ -421,6 +424,8 @@ makeOpts opts flg =
     Quiet -> opts { verbose = 0 }
     Uncolored -> opts { uncolored = True }
     Dump s -> opts { dumpOpts = s : dumpOpts opts }
+    DisableCertificateVerification ->
+      opts { disableCertificateVerification = True }
     IOEncoding e -> opts { ioEncoding = e }
     Serve -> opts { serve = True }
     Unlit -> opts { unlit = True }
@@ -762,6 +767,9 @@ options = let
         map (++ bracket bafS) [bracket treeS ++ genTermS]))
     , Option "d" ["dump"] (ReqArg Dump "STRING")
       "dump various strings"
+    , Option "" ["disable-certificate-verification"]
+      (NoArg DisableCertificateVerification)
+      "Disable TLS certificate verification"
     , Option "e" ["encoding"] (ReqArg parseEncoding "ENCODING")
       "latin1 or utf8 (default) encoding"
     , Option "" [unlitS] (NoArg Unlit) "unlit input source"

--- a/Driver/ReadFn.hs
+++ b/Driver/ReadFn.hs
@@ -169,7 +169,7 @@ loadAccessUri opts fn = do
         "" -> ""
         t -> '?' : accessTokenS ++ "=" ++ t
   putIfVerbose opts 4 $ "downloading " ++ u
-  loadFromUri u
+  loadFromUri opts u
 
 downloadSource :: HetcatsOpts -> FilePath -> IO (Either String String)
 downloadSource opts fn =

--- a/Hets.cabal
+++ b/Hets.cabal
@@ -62,6 +62,9 @@ Executable hets
   Main-is: hets.hs
   build-depends:
       HTTP >= 4000.2.4
+    , http-client >= 0.5.7.0
+    , http-client-tls >= 0.3.5.1
+    , connection >= 0.2.8
     , array >= 0.1.0.0
     , aterm >= 0.1.0.1
     , base >= 4.0.0.0

--- a/SoftFOL/ProveDarwin.hs
+++ b/SoftFOL/ProveDarwin.hs
@@ -282,7 +282,6 @@ runEProverBuffered saveTPTP graph fullgraph options tmpFileName prob = do
    (err, out) <-
       do
        timeTmpFile <- getTempFile prob tmpFile
-       grep <- executableWithDefault "ggrep" "grep"
        (_, out, err, _) <-
         if graph || fullgraph || not s then do
               bufferFile <- getTempFile "" "eprover-proof-buffer"
@@ -294,12 +293,11 @@ runEProverBuffered saveTPTP graph fullgraph options tmpFileName prob = do
                `Exception.catch` (\ ThreadKilled -> terminateProcess h)
               hClose buff
               mkGraph bufferFile
-              runInteractiveCommand $ unwords [grep, "-e", "axiom",
-               "-e", "SZS", bufferFile, "&&", "rm", "-f", bufferFile]
+              runInteractiveCommand $ unwords ["egrep", "axiom|SZS",
+                bufferFile, "&&", "rm", "-f", bufferFile]
         else runInteractiveCommand $ unwords
              [bin, "--proof-object", options, timeTmpFile,
-              "|", grep, "-e", "axiom", "-e", "SZS",
-               "&&", "rm", timeTmpFile]
+              "|", "egrep", "axiom|SZS", "&&", "rm", timeTmpFile]
        return (out, err)
    perr <- hGetContents err
    pout <- hGetContents out

--- a/SoftFOL/ProveDarwin.hs
+++ b/SoftFOL/ProveDarwin.hs
@@ -244,12 +244,12 @@ runDarwinProcess bin saveTPTP options tmpFileName prob = do
 
 mkGraph :: String -> IO ()
 mkGraph f = do
- (_, cat, _) <- executeProcess "cat" [f] ""
- (_, tac, _) <- executeProcess "tac" [f] ""
+ fContent <- readFile f
+ let fLines = lines fContent
  let ((p_set, (cs, axs)), res) =
       processProof (zipF proofInfo $ zipF conjectures axioms)
-       (Set.empty, ([], [])) $ lines tac
-     (aliases, _) = processProof alias Map.empty $ lines cat
+       (Set.empty, ([], [])) $ reverse fLines
+     (aliases, _) = processProof alias Map.empty fLines
      same_rank = intercalate "; " $ map (\ (_, n) -> 'v' : n) $
                  filter (\ (_, n) -> Set.member n p_set
                                 && isNothing (Map.lookup n aliases)) $ cs ++ axs
@@ -259,7 +259,7 @@ mkGraph f = do
  writeFile "/tmp/graph.dot" $ unlines ["digraph {",
   "subgraph { rank = same; " ++ same_rank ++ " }",
   (\ (_, _, d, _) -> d) . fst $ processProof (digraph p_set aliases)
-   (Set.empty, Set.empty, "", Map.empty) $ lines cat, "}"]
+   (Set.empty, Set.empty, "", Map.empty) fLines, "}"]
 
 runEProverBuffered
   :: Bool -- ^ save problem

--- a/debian/control
+++ b/debian/control
@@ -45,7 +45,7 @@ Description: Data used by the hets-server as well as hets-desktop package.
 
 Package: hets-desktop
 Architecture: i386 amd64
-Depends: hets-common, hets-libs, owltools, ksh, darwin, eprover, spass, openjdk-8-jre | openjdk-7-jre, graphviz, wget, patch, file, perl, udrawgraph [i386] | udrawgraph:i386 [amd64],    libatk1.0-0, libc6, libffi6, libgdk-pixbuf2.0-0, libglade2-0, libglib2.0-0, libgmp10, libgtk2.0-0, libpango-1.0-0, libtinfo5
+Depends: hets-common, hets-libs, owltools, ksh, darwin, eprover, spass, openjdk-8-jre | openjdk-7-jre, graphviz, patch, file, perl, udrawgraph [i386] | udrawgraph:i386 [amd64],    libatk1.0-0, libc6, libffi6, libgdk-pixbuf2.0-0, libglade2-0, libglib2.0-0, libgmp10, libgtk2.0-0, libpango-1.0-0, libtinfo5
 Description: The Heterogeneous Tool Set (hets) - desktop version.
  This package contains the desktop version of the Heterogeneous Tool Set (hets).
  Hets is a parsing, static analysis and proof management tool combining
@@ -58,7 +58,7 @@ Description: The Heterogeneous Tool Set (hets) - desktop version.
 
 Package: hets-server
 Architecture: i386 amd64
-Depends: hets-common, hets-libs, owltools, ksh, darwin, eprover, spass, openjdk-8-jre-headless | openjdk-7-jre-headless, graphviz, wget, patch, file, perl,    libc6, libffi6, libgmp10
+Depends: hets-common, hets-libs, owltools, ksh, darwin, eprover, spass, openjdk-8-jre-headless | openjdk-7-jre-headless, graphviz, patch, file, perl,    libc6, libffi6, libgmp10
 Description: The Heterogeneous Tool Set (hets) - server version.
  This package contains the server version of the Heterogeneous Tool
  Set (hets).  Hets is a parsing, static analysis and proof management

--- a/utils/debian/auto-package/debian-server/control
+++ b/utils/debian/auto-package/debian-server/control
@@ -22,7 +22,7 @@ Homepage: http://www.informatik.uni-bremen.de/agbkb/forschung/formal_methods/CoF
 
 Package: hets-server-core
 Architecture: i386 amd64
-Depends: wget, darwin, eprover, default-jre-headless, spass, graphviz, texlive-latex-base, ${shlibs:Depends}, ${misc:Depends}
+Depends: darwin, eprover, default-jre-headless, spass, graphviz, texlive-latex-base, ${shlibs:Depends}, ${misc:Depends}
 Recommends: man
 Description: Package containing the core of Hets - the Heterogeneous Tool Set.
  Hets is a parsing, static analysis and proof management tool combining


### PR DESCRIPTION
This removes wget as a dependency. This now uses the package `http-client` to make HTTP calls. It also adds an option to disable TLS certificate verification.

@jelmd, Please tell me if the wget dependency should stay in the Debian control files.