### PR TITLE
Revert outsourcing the function `parens`.

### DIFF
--- a/CommonLogic/Lexer_CLIF.hs
+++ b/CommonLogic/Lexer_CLIF.hs
@@ -52,6 +52,8 @@ enclosedname = do
    return $ c1 : s ++ [c2]
 
 -- | parser for parens
+-- Note that these use different oParenT and cParenT from the ones in
+-- Common.Lexer to skip whitespaces and comments.
 parens :: CharParser st a -> CharParser st a
 parens p = oParenT >> p << cParenT
 

--- a/CommonLogic/Lexer_CLIF.hs
+++ b/CommonLogic/Lexer_CLIF.hs
@@ -18,7 +18,6 @@ module CommonLogic.Lexer_CLIF where
 import CommonLogic.AS_CommonLogic
 import Common.Id as Id
 import qualified Common.Lexer as Lexer
-import Common.Lexer (parens)
 import Common.Parsec
 import Common.Keywords
 
@@ -51,6 +50,10 @@ enclosedname = do
    c2 <- char '\"' <?> "\""
    many white
    return $ c1 : s ++ [c2]
+
+-- | parser for parens
+parens :: CharParser st a -> CharParser st a
+parens p = oParenT >> p << cParenT
 
 -- Parser Keywords
 andKey :: CharParser st Id.Token

--- a/CommonLogic/Parse_CLIF.hs
+++ b/CommonLogic/Parse_CLIF.hs
@@ -20,7 +20,7 @@ import qualified Common.AS_Annotation as Annotation
 import CommonLogic.AS_CommonLogic as AS
 import Common.Id as Id
 import Common.IRI
-import Common.Lexer as Lexer hiding (oParenT, cParenT, pToken)
+import Common.Lexer as Lexer hiding (oParenT, cParenT, pToken, parens)
 import Common.Keywords (colonS, mapsTo)
 import Common.GlobalAnnotations (PrefixMap)
 import Common.Parsec


### PR DESCRIPTION
This shall fix #1732. It reverts a change introduced in f800c4bb2f0cf0000997a6d18c0b0e27d06fb2f2 which surprisingly broke the CLIF parser.