### PR TITLE
Split travis build into 'Hets-lib' and 'make check' jobs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,10 @@ before_install:
   - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
 install:
   - sudo apt-get install --no-install-recommends `dpkg-checkbuilddeps debian/control 2>&1 | cut -f3- -d":" | sed -e 's,([^)]*),,g' -e 's,openjdk-.*-jdk,,'` || true
+matrix:
+  include:
+    - env: WITH_MAKE_CHECK=1
+    - env: WITH_HETS_LIB=1
 before_script:
   - |
     if [ -d $HOME/Hets-lib/.git ]
@@ -38,7 +42,6 @@ before_script:
 script:
   # Prepare to run Hets
   - export HETS_MAGIC=$PWD/magic/hets.magic
-  - export HETS_LIB=$HOME/Hets-lib
 
   # Compile Hets
   - make stack
@@ -46,16 +49,16 @@ script:
   - make
   - ./hets -V
 
-  # Install Hets
-  # It needs to be installed before `make check` because it was already compiled
-  # by calling `make`.
-  - export PREFIX=/tmp/hets-install
-  - export PATH=$PREFIX/bin:$PATH
-  - mkdir -p $PREFIX
-  - make install-hets
-  - make install-common
-  - make install-owl-tools
+  # Run hets through Hets-lib
+  # Install Hets - this does not need to recompile Hets
+  - if [ -n "$WITH_HETS_LIB" ]; then export HETS_LIB=$HOME/Hets-lib; fi
+  - if [ -n "$WITH_HETS_LIB" ]; then export PREFIX=/tmp/hets-install; fi
+  - if [ -n "$WITH_HETS_LIB" ]; then export PATH=$PREFIX/bin:$PATH; fi
+  - if [ -n "$WITH_HETS_LIB" ]; then mkdir -p $PREFIX; fi
+  - if [ -n "$WITH_HETS_LIB" ]; then make install-hets; fi
+  - if [ -n "$WITH_HETS_LIB" ]; then make install-common; fi
+  - if [ -n "$WITH_HETS_LIB" ]; then make install-owl-tools; fi
+  - if [ -n "$WITH_HETS_LIB" ]; then test/hets-lib-check.sh; fi
 
-  # Run more checks
-  - make check
-  - test/hets-lib-check.sh
+  # Run make check
+  - if [ -n "$WITH_MAKE_CHECK" ]; then make check; fi


### PR DESCRIPTION
This splits the Travis-CI build into two separate jobs that are executed in parallel. 

If wanted, we can supply *n* different `test/hets-lib-testfiles_i` files that partition Hets-lib and analyse everything. This would result in *n+1* jobs in Travis.