### PR TITLE
better error message for Logic.Logic.inclusion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,10 @@ before_script:
       git clone --depth=1 https://github.com/spechub/Hets-lib.git $HOME/Hets-lib
     fi
 script:
+  # For some reason, Travis CI sets this environment variable, which breaks the
+  # tests (_JAVA_OPTIONS=-Xmx2048m -Xms512m)
+  - unset _JAVA_OPTIONS
+
   # Prepare to run Hets
   - export HETS_MAGIC=$PWD/magic/hets.magic
 

--- a/Logic/Logic.hs
+++ b/Logic/Logic.hs
@@ -638,8 +638,12 @@ inclusion :: StaticAnalysis lid basic_spec sentence symb_items symb_map_items
 inclusion l s1 s2 = if is_subsig l s1 s2 then subsig_inclusion l s1 s2
   else fail $ show $ fsep
        [ text (language_name l)
-       , text "symbol(s) missing in target:"
-       , pretty $ Set.difference (symset_of l s1) $ symset_of l s2 ]
+       , text "cannot construct inclusion. Symbol(s) missing in target:"
+       , pretty $ Set.difference (symset_of l s1) $ symset_of l s2
+       , text "\nSource is: "
+       , pretty $ symset_of l s1
+       , text "\nTarget is: "
+       , pretty $ symset_of l s2 ]
 
 {- | semi lattices with top (needed for sublogics). Note that `Ord` is
 only used for efficiency and is not related to the /partial/ order given


### PR DESCRIPTION
the error message informs about the context that an inclusion is being constructed, and also prints source and target signature