### PR TITLE
1758 adjust stabilities of the logics

### DIFF
--- a/Adl/Logic_Adl.hs
+++ b/Adl/Logic_Adl.hs
@@ -9,6 +9,12 @@ Maintainer  :  Christian.Maeder@dfki.de
 Stability   :  provisional
 Portability :  non-portable (import Logic.Logic)
 
+see
+Stef Joosten:
+Deriving Functional Specifications from Business Requirements with Ampersand
+
+and
+https://lab.cs.ru.nl/BusinessRules/Requirements_engineering
 -}
 
 module Adl.Logic_Adl where
@@ -34,7 +40,7 @@ import Logic.Logic
 data Adl = Adl deriving Show
 
 instance Language Adl where
-    description _ = "A description language"
+    description _ = "A description language for business rules"
 
 type Morphism = DefaultMorphism Sign
 

--- a/CASL_DL/Logic_CASL_DL.hs
+++ b/CASL_DL/Logic_CASL_DL.hs
@@ -136,7 +136,7 @@ instance Logic CASL_DL CASL_DL_SL
                DLSign
                DLMor
                Symbol RawSymbol ProofTree where
-         stability _ = Unstable
+         stability _ = Experimental
          top_sublogic _ = SROIQ
          all_sublogics _ = [SROIQ]
 

--- a/CASL_DL/Logic_CASL_DL.hs
+++ b/CASL_DL/Logic_CASL_DL.hs
@@ -44,7 +44,7 @@ data CASL_DL = CASL_DL deriving Show
 
 instance Language CASL_DL where
  description _ = unlines
-  [ "CASL_DL is at the same time an extension and a restriction of CASL."
+  [ "CASL_DL is the restriction of CASL to OWL 1 expressivity."
   , "It additionally provides cardinality restrictions in a description logic"
   , "sense; and it limits the expressivity of CASL to the description logic"
   , "SHOIN(D). Hence it provides the following sublogics:"

--- a/CSL/Logic_CSL.hs
+++ b/CSL/Logic_CSL.hs
@@ -11,6 +11,11 @@ Portability :  non-portable (imports Logic.Logic)
 
 Instance of class Logic for the CSL logic
    Also the instances for Syntax and Category.
+
+see
+Dominik Dietrich, Lutz Schröder, and Ewaryst Schulz:
+Formalizing and Operationalizing Industrial Standards.
+D. Giannakopoulou and F. Orejas (Eds.): FASE 2011, LNCS 6603, pp. 81–95, 2011.
 -}
 
 
@@ -40,7 +45,7 @@ instance Show CSL where
     show _ = "EnCL"
 
 instance Language CSL where
-    description _ = "EnCL Logic\n"
+    description _ = "A Domain-Specific Language for Engineering Calculations\n"
 -- language_name _ = "EnCL"
 
 -- | Instance of Category for CSL logic

--- a/CSMOF/Logic_CSMOF.hs
+++ b/CSMOF/Logic_CSMOF.hs
@@ -26,7 +26,7 @@ import Data.Monoid
 data CSMOF = CSMOF deriving Show
 
 instance Language CSMOF where
-  description _ = "CSMOF conformance relation"
+  description _ = "OMG's meta-object facility, a language for the specification of metamodels"
 
 type Morphism = DefaultMorphism Sign
 

--- a/CoCASL/Logic_CoCASL.hs
+++ b/CoCASL/Logic_CoCASL.hs
@@ -125,7 +125,7 @@ instance Logic CoCASL CoCASL_Sublogics
                CoCASLMor
                Symbol RawSymbol () where
          parse_basic_sen CoCASL = Just $ const parseSen
-         stability CoCASL = Unstable
+         stability CoCASL = Testing
          proj_sublogic_epsilon CoCASL = pr_epsilon emptyMorExt
          all_sublogics CoCASL = sublogics_all [True]
          sublogicDimensions CoCASL = sDims [[True]]

--- a/CommonLogic/Logic_CommonLogic.hs
+++ b/CommonLogic/Logic_CommonLogic.hs
@@ -40,7 +40,7 @@ import Logic.Logic
 data CommonLogic = CommonLogic deriving Show
 
 instance Language CommonLogic where
-    description _ = "CommonLogic Logic\n"
+    description _ = "CommonLogic (an ISO standard)\n"
 
 instance Category Sign Morphism
     where

--- a/CommonLogic/Logic_CommonLogic.hs
+++ b/CommonLogic/Logic_CommonLogic.hs
@@ -94,7 +94,7 @@ instance Logic CommonLogic
     Symbol            -- raw_symbol
     ProofTree         -- proof_tree
     where
-       stability CommonLogic = Testing
+       stability CommonLogic = Stable
        all_sublogics CommonLogic = sublogics_all
        empty_proof_tree CommonLogic = emptyProofTree
        provers CommonLogic = []

--- a/Comorphisms/LogicList.hs
+++ b/Comorphisms/LogicList.hs
@@ -96,7 +96,6 @@ logicList =
   , Logic SoftFOL
   , Logic Propositional
   , Logic QBF
-  , Logic HolLight
   , Logic FreeCAD
   , Logic CSL
 #ifdef PROGRAMATICA

--- a/CspCASL/Logic_CspCASL.hs
+++ b/CspCASL/Logic_CspCASL.hs
@@ -150,7 +150,7 @@ instance CspCASLSemantics a => Logic (GenCspCASL a)
     -- proof_tree (missing)
     ()
     where
-      stability (GenCspCASL _) = Experimental
+      stability (GenCspCASL _) = Testing
       data_logic (GenCspCASL _) = Just (Logic CASL)
       empty_proof_tree _ = ()
       provers (GenCspCASL _) = cspProvers (undefined :: a)

--- a/CspCASL/Logic_CspCASL.hs
+++ b/CspCASL/Logic_CspCASL.hs
@@ -66,8 +66,8 @@ instance Show a => Language (GenCspCASL a) where
       language_name (GenCspCASL a) = "CspCASL"
         ++ let s = show a in if s == "()" then "" else '_' : s
       description _ =
-        "CspCASL - see\n\n" ++
-        "http://www.cs.swan.ac.uk/~csmarkus/ProcessesAndData/"
+        "CspCASL - extension of CASL with the process algebra CSP\n" ++
+        "See http://www.cs.swan.ac.uk/~csmarkus/ProcessesAndData/"
 
 -- | Instance of Sentences for CspCASL
 instance Show a => Sentences (GenCspCASL a)

--- a/DMU/Logic_DMU.hs
+++ b/DMU/Logic_DMU.hs
@@ -38,7 +38,7 @@ import Data.Typeable
 data DMU = DMU deriving Show
 
 instance Language DMU where
-  description _ = "wrap Catia output"
+  description _ = "a logic to wrap output of the CAD tool Catia"
 
 newtype Text = Text { fromText :: String }
   deriving (Show, Eq, Ord, GetRange, Typeable, ShATermConvertible)

--- a/Driver/Options.hs
+++ b/Driver/Options.hs
@@ -137,6 +137,9 @@ fullTheoriesS = "full-theories"
 logicGraphS :: String
 logicGraphS = "logic-graph"
 
+logicListS :: String
+logicListS = "logic-list"
+
 fileTypeS :: String
 fileTypeS = "file-type"
 
@@ -218,6 +221,7 @@ data HetcatsOpts = HcOpt     -- for comments see usage info
   , blacklist :: [[String]]
   , runMMT :: Bool
   , fullTheories :: Bool
+  , outputLogicList :: Bool
   , outputLogicGraph :: Bool
   , fileType :: Bool
   , accessToken :: String
@@ -266,6 +270,7 @@ defaultHetcatsOpts = HcOpt
   , blacklist = []
   , runMMT = False
   , fullTheories = False
+  , outputLogicList = False
   , outputLogicGraph = False
   , fileType = False
   , accessToken = ""
@@ -280,6 +285,7 @@ instance Show HetcatsOpts where
     in
     showEqOpt verboseS (show $ verbose opts)
     ++ show (guiType opts)
+    ++ showFlag outputLogicList logicListS
     ++ showFlag outputLogicGraph logicGraphS
     ++ showFlag fileType fileTypeS
     ++ showFlag interactive interactiveS
@@ -375,6 +381,7 @@ data Flag =
   | FullTheories
   | FullSign
   | PrintAST
+  | OutputLogicList
   | OutputLogicGraph
   | FileType
   | AccessToken String
@@ -420,6 +427,7 @@ makeOpts opts flg =
     RelPos -> opts { useLibPos = True }
     UseMMT -> opts { runMMT = True }
     FullTheories -> opts { fullTheories = True }
+    OutputLogicList -> opts { outputLogicList = True }
     OutputLogicGraph -> opts { outputLogicGraph = True }
     FileType -> opts { fileType = True }
     FullSign -> opts { fullSign = True }
@@ -710,6 +718,8 @@ options = let
     , Option "X" ["server"] (NoArg Serve)
        "start hets as web-server"
 #endif
+    , Option "z" [logicListS] (NoArg OutputLogicList)
+      "output logic list as plain text"
     , Option "G" [logicGraphS] (NoArg OutputLogicGraph)
       "output logic graph (as xml) or as graph (-g)"
     , Option "I" [interactiveS] (NoArg Interactive)

--- a/ExtModal/Logic_ExtModal.hs
+++ b/ExtModal/Logic_ExtModal.hs
@@ -120,7 +120,7 @@ instance StaticAnalysis ExtModal EM_BASIC_SPEC ExtModalFORMULA SYMB_ITEMS
 
 instance Logic ExtModal ExtModalSL EM_BASIC_SPEC ExtModalFORMULA SYMB_ITEMS
     SYMB_MAP_ITEMS ExtModalSign ExtModalMorph Symbol RawSymbol () where
-        stability ExtModal = Experimental
+        stability ExtModal = Testing
         all_sublogics ExtModal = sublogics_all $ foleml : concat sublogicsDim
         sublogicDimensions ExtModal = sDims sublogicsDim
         parseSublogic ExtModal = parseSL $ Just . parseSublog

--- a/Fpl/Logic_Fpl.hs
+++ b/Fpl/Logic_Fpl.hs
@@ -85,5 +85,5 @@ instance Logic Fpl ()
                FplSign
                FplMor
                Symbol RawSymbol () where
-         stability _ = Unstable
+         stability _ = Experimental
          empty_proof_tree _ = ()

--- a/HasCASL/Logic_HasCASL.hs
+++ b/HasCASL/Logic_HasCASL.hs
@@ -43,8 +43,8 @@ data HasCASL = HasCASL deriving Show
 
 instance Language HasCASL where
  description _ = unlines
-  [ "HasCASL - Algebraic Specification + Functional Programming = "
-  , "            Environment for Formal Software Development"
+  [ "HasCASL - Algebraic Specification + Functional Programming"
+  , "            = Environment for Formal Software Development"
   , "This logic is based on the partial lambda calculus and"
   , "  features subtyping, overloading and type class polymorphism"
   , "See the HasCASL summary and further papers available at"

--- a/HasCASL/Logic_HasCASL.hs
+++ b/HasCASL/Logic_HasCASL.hs
@@ -172,6 +172,6 @@ instance Logic HasCASL Sublogic
                Env
                Morphism
                Symbol RawSymbol () where
-         stability _ = Testing
+         stability _ = Stable
          all_sublogics _ = sublogics_all
          empty_proof_tree _ = ()

--- a/HolLight/Logic_HolLight.hs
+++ b/HolLight/Logic_HolLight.hs
@@ -38,7 +38,7 @@ data HolLight = HolLight deriving Show
 
 
 instance Language HolLight where
-    description _ = "Hol Light\n"
+    description _ = "input language of the theorem prover Hol Light\n"
         ++ "for more information please refer to\n"
         ++ "http://www.cl.cam.ac.uk/~jrh13/hol-light/"
 

--- a/Isabelle/Logic_Isabelle.hs
+++ b/Isabelle/Logic_Isabelle.hs
@@ -32,7 +32,7 @@ data Isabelle = Isabelle deriving Show
 
 instance Language Isabelle where
  description _ =
-  "Isabelle - a generic theorem prover\n" ++
+  "logic of the generic theorem prover Isabelle\n" ++
   "This logic corresponds to the logic of Isabelle,\n" ++
   "a weak intuitionistic type theory\n" ++
   "Also, the logics encoded in Isabelle, like FOL, HOL, HOLCF, ZF " ++

--- a/Logic/Logic.hs
+++ b/Logic/Logic.hs
@@ -184,6 +184,10 @@ class Show lid => Language lid where
     -- default implementation
     description _ = ""
 
+-- short description = first line of description
+short_description :: Language lid => lid -> String
+short_description l = head ((lines $ description l) ++ [""])
+      
 {- | Categories are given as usual: objects, morphisms, identities,
      domain, codomain and composition. The type id is the name, or
      the identity of the category. It is an argument to all functions

--- a/Logic/PrintLogics.hs
+++ b/Logic/PrintLogics.hs
@@ -34,7 +34,7 @@ printLogicsWithStability s = do
   
 printLogic :: AnyLogic -> IO ()
 printLogic (Logic l) = do
-  putStrLn $ "  "++show l++": "++head ((lines $ description l) ++ [""])
+  putStrLn $ "  "++show l++": "++short_description l
   let ps = provers l
   unless (null ps) $ do
     putStr "    provers: "

--- a/Logic/PrintLogics.hs
+++ b/Logic/PrintLogics.hs
@@ -22,7 +22,7 @@ import Data.List
 main :: IO ()
 main = do
   putStrLn "*** List of logics in Hets ***"
-  mapM_ printLogics [Stable, Testing, Unstable, Experimental]
+  mapM_ printLogics [Stable, Testing, Experimental, Unstable]
 
 hasStability :: Stability -> AnyLogic -> Bool
 hasStability s (Logic l) = stability l == s

--- a/Logic/PrintLogics.hs
+++ b/Logic/PrintLogics.hs
@@ -38,5 +38,5 @@ printLogic (Logic l) = do
   let ps = provers l
   unless (null ps) $ do
     putStr "    provers: "
-    putStrLn $ concat $ intersperse ", " $ map proverName ps
+    putStrLn $ intercalate ", " $ map proverName ps
 

--- a/Logic/PrintLogics.hs
+++ b/Logic/PrintLogics.hs
@@ -19,16 +19,16 @@ import Logic.Logic
 import Control.Monad
 import Data.List
 
-main :: IO ()
-main = do
+printLogics :: IO ()
+printLogics = do
   putStrLn "*** List of logics in Hets ***"
-  mapM_ printLogics [Stable, Testing, Experimental, Unstable]
+  mapM_ printLogicsWithStability [Stable, Testing, Experimental, Unstable]
 
 hasStability :: Stability -> AnyLogic -> Bool
 hasStability s (Logic l) = stability l == s
 
-printLogics :: Stability -> IO ()
-printLogics s = do
+printLogicsWithStability :: Stability -> IO ()
+printLogicsWithStability s = do
   putStrLn $ "Stability: "++show s
   mapM_ printLogic $ filter (hasStability s) logicList
   

--- a/Logic/PrintLogics.hs
+++ b/Logic/PrintLogics.hs
@@ -1,0 +1,42 @@
+{- |
+Module      :  ./Logic/PrintLogics.hs
+Description :  Print list of all logics
+Copyright   :  (c) Till Mossakowski, and OvGU Magdeburg 2017
+License     :  GPLv2 or higher, see LICENSE.txt
+Maintainer  :  till@iks.cs.ovgu.de
+Stability   :  provisional
+Portability :  non-portable (various -fglasgow-exts extensions)
+
+Print list of all logics with some useful information.
+
+-}
+
+module Logic.PrintLogics where
+
+import Comorphisms.LogicList
+import Logic.Prover
+import Logic.Logic
+import Control.Monad
+import Data.List
+
+main :: IO ()
+main = do
+  putStrLn "*** List of logics in Hets ***"
+  mapM_ printLogics [Stable, Testing, Unstable, Experimental]
+
+hasStability :: Stability -> AnyLogic -> Bool
+hasStability s (Logic l) = stability l == s
+
+printLogics :: Stability -> IO ()
+printLogics s = do
+  putStrLn $ "Stability: "++show s
+  mapM_ printLogic $ filter (hasStability s) logicList
+  
+printLogic :: AnyLogic -> IO ()
+printLogic (Logic l) = do
+  putStrLn $ "  "++show l++": "++head ((lines $ description l) ++ [""])
+  let ps = provers l
+  unless (null ps) $ do
+    putStr "    provers: "
+    putStrLn $ concat $ intersperse ", " $ map proverName ps
+

--- a/Modal/Logic_Modal.hs
+++ b/Modal/Logic_Modal.hs
@@ -123,5 +123,5 @@ instance Logic Modal ()
                MSign
                ModalMor
                Symbol RawSymbol () where
-         stability _ = Unstable
+         stability _ = Testing
          empty_proof_tree _ = ()

--- a/Modal/Logic_Modal.hs
+++ b/Modal/Logic_Modal.hs
@@ -39,7 +39,8 @@ data Modal = Modal deriving Show
 
 instance Language Modal where
  description _ = unlines
-  [ "ModalCASL extends CASL by modal operators. Syntax for ordinary"
+  [ "ModalCASL extends CASL by modal operators."
+  , "Syntax for ordinary"
   , "modalities, multi-modal logics as well as  term-modal"
   , "logic (also covering dynamic logic) is provided."
   , "Specific modal logics can be obtained via restrictions to"

--- a/OWL2/Logic_OWL2.hs
+++ b/OWL2/Logic_OWL2.hs
@@ -150,6 +150,7 @@ instance Logic OWL2 ProfSub OntologyDocument Axiom SymbItems SymbMapItems
            (\ ct -> ConservativityChecker ("Locality_" ++ ct)
                     (checkOWLjar localityJar) $ conserCheck ct)
            ["BOTTOM_BOTTOM", "TOP_BOTTOM", "TOP_TOP"]
+         stability OWL2 = Stable
 
 instance SemiLatticeWithTop ProfSub where
     lub = maxS

--- a/Propositional/Logic_Propositional.hs
+++ b/Propositional/Logic_Propositional.hs
@@ -119,7 +119,7 @@ instance Logic Propositional
     where
         -- hybridization
       parse_basic_sen Propositional = Just $ const impFormula
-      stability Propositional = Experimental
+      stability Propositional = Stable
       top_sublogic Propositional = Sublogic.top
       all_sublogics Propositional = sublogics_all
       empty_proof_tree Propositional = emptyProofTree

--- a/QBF/Logic_QBF.hs
+++ b/QBF/Logic_QBF.hs
@@ -112,7 +112,7 @@ instance Logic QBF
     Symbol                    -- raw_symbol
     ProofTree                 -- proof_tree
     where
-      stability QBF = Experimental
+      stability QBF = Stable
       top_sublogic QBF = Sublogic.top
       all_sublogics QBF = sublogicsAll
       empty_proof_tree QBF = emptyProofTree

--- a/QBF/Logic_QBF.hs
+++ b/QBF/Logic_QBF.hs
@@ -53,7 +53,7 @@ import Data.Monoid
 data QBF = QBF deriving Show
 
 instance Language QBF where
-    description _ = "Propositional Logic extended with QBFs\n"
+    description _ = "Propositional Logic extended with quantified boolean formulas\n"
         ++ "for more information please refer to\n"
         ++ "http://en.wikipedia.org/wiki/Propositional_logic"
         ++ "http://www.voronkov.com/lics.cgi"

--- a/QVTR/Logic_QVTR.hs
+++ b/QVTR/Logic_QVTR.hs
@@ -27,7 +27,7 @@ import Data.Monoid
 data QVTR = QVTR deriving Show
 
 instance Language QVTR where
-  description _ = "QVT-Relations transformation"
+  description _ = "OMG's QVT-Relations transformation, a language for the specification of model transformations"
 
 type Morphism = DefaultMorphism Sign
 

--- a/RDF/Logic_RDF.hs
+++ b/RDF/Logic_RDF.hs
@@ -96,6 +96,7 @@ instance Logic RDF RDFSub TurtleDocument Axiom SymbItems SymbMapItems
                Sign
                RDFMorphism RDFEntity RawSymb ProofTree where
          empty_proof_tree RDF = emptyProofTree
+         stability RDF = Experimental
 
 {-
 instance SemiLatticeWithTop ProfSub where

--- a/SoftFOL/Logic_SoftFOL.hs
+++ b/SoftFOL/Logic_SoftFOL.hs
@@ -86,7 +86,7 @@ instance StaticAnalysis SoftFOL [TPTP] Sentence
 instance Logic SoftFOL () [TPTP] Sentence () ()
                Sign
                SoftFOLMorphism SFSymbol () ProofTree where
-         stability _ = Testing
+         stability _ = Stable
          provers SoftFOL = [spassProver]
 #ifndef NOHTTP
            ++ [mathServBroker, vampire]

--- a/TPTP/Logic_TPTP.hs
+++ b/TPTP/Logic_TPTP.hs
@@ -47,7 +47,7 @@ data TPTP = TPTP deriving (Show, Ord, Eq)
 instance Language TPTP
   where
     description _ =
-      "The TPTP (Thousands of Problems for Theorem Provers) Language" ++
+      "The TPTP (Thousands of Problems for Theorem Provers) Language\n" ++
       "See http://www.cs.miami.edu/~tptp/"
 
 instance Syntax TPTP BASIC_SPEC Symbol () ()

--- a/TPTP/Logic_TPTP.hs
+++ b/TPTP/Logic_TPTP.hs
@@ -78,7 +78,7 @@ instance StaticAnalysis TPTP BASIC_SPEC Sentence () () Sign Morphism Symbol ()
 
 instance Logic TPTP Sublogic BASIC_SPEC Sentence () () Sign Morphism Symbol () ProofTree
   where
-    stability _ = Testing
+    stability _ = Stable
     all_sublogics TPTP = [CNF, FOF, TFF, THF]
     provers TPTP = [cvc4, darwin, eprover, geo3, isabelle, leo2, satallax,
                     spass, vampire]

--- a/VSE/Logic_VSE.hs
+++ b/VSE/Logic_VSE.hs
@@ -107,6 +107,6 @@ instance Logic VSE ()
                VSESign
                VSEMor
                Symbol RawSymbol () where
-         stability VSE = Unstable
+         stability VSE = Testing
          empty_proof_tree VSE = ()
          provers VSE = [vse]

--- a/hets.hs
+++ b/hets.hs
@@ -27,6 +27,7 @@ import Driver.ReadFn (showFileType)
 import Driver.WriteFn
 
 import Static.DevGraph
+import Logic.PrintLogics
 
 #ifdef UNI_PACKAGE
 import GUI.ShowGraph
@@ -70,7 +71,10 @@ main =
        then cmdlRun opts >>= displayGraph "" opts . getMaybeLib . intState
        else do
          putIfVerbose opts 3 $ "Options: " ++ show opts
-         case (infiles opts, outputLogicGraph opts) of
+         if outputLogicList opts
+            then printLogics
+         else  
+          case (infiles opts, outputLogicGraph opts) of
            ([], lg) -> case guiType opts of
              UseGui ->
 #ifdef UNI_PACKAGE


### PR DESCRIPTION
fixes #1758 and also improves descriptions of various logics as well as provides an option `hets -z` for printing all logics