### PR TITLE
names for nodes in unit specs

### DIFF
--- a/Static/AnalysisArchitecture.hs
+++ b/Static/AnalysisArchitecture.hs
@@ -19,8 +19,6 @@ module Static.AnalysisArchitecture
     , anaRefSpec
     ) where
 
-import Debug.Trace
-
 import Driver.Options
 
 import Logic.Logic
@@ -1019,8 +1017,7 @@ anaArgSpecs lgraph libEnv ln dg opts eo usName args = let
        l <- lookupLogic "anaArgSpecs " (currentLogic lgraph) lgraph
        let sp = item argSpec
            xName = makeName $ usName{abbrevPath = abbrevPath usName ++ show x}
-       (argSpec', argSig, dg') <- trace ("xName:" ++ show xName ++ 
-                                         "\nsp:" ++ show sp)$
+       (argSpec', argSig, dg') <- 
            anaSpec False False -- don't optimize the node out 
               lgraph libEnv ln aDG (EmptyNode l) 
               (xName{extIndex = x + 1})

--- a/Static/AnalysisArchitecture.hs
+++ b/Static/AnalysisArchitecture.hs
@@ -471,7 +471,7 @@ anaUnitBindings lgraph libEnv ln dg opts eo uctx@(buc, _) bs = case bs of
                (BranchRefSig _ (UnitSig argSigs nsig _, _), dg', usp') <-
                    anaUnitSpec lgraph libEnv ln dg opts eo 
                                un (EmptyNode curl) Nothing usp
-                         -- TODO: is un OK above?
+                         -- TODO: is un OK above? MC: yes, names are unique
                let ub' = Unit_binding un usp' poss
                case argSigs of
                     _ : _ -> plain_error ([], dg', [])

--- a/Static/AnalysisArchitecture.hs
+++ b/Static/AnalysisArchitecture.hs
@@ -19,6 +19,8 @@ module Static.AnalysisArchitecture
     , anaRefSpec
     ) where
 
+import Debug.Trace
+
 import Driver.Options
 
 import Logic.Logic
@@ -798,7 +800,7 @@ anaUnitSpec lgraph libEnv ln dg opts eo usName impsig rN usp = case usp of
           then this should be converted to a Spec_name -}
         anaUnitSpec lgraph libEnv ln dg opts eo usName impsig rN (Spec_name spn)
       _ -> do -- a trivial unit type
-       (resultSpec', resultSig, dg') <- anaSpec False lgraph libEnv ln
+       (resultSpec', resultSig, dg') <- anaSpec False True lgraph libEnv ln
            dg impsig 
            (makeName $ usName{abbrevPath = abbrevPath usName ++ "_res"}) 
            opts eo (item resultSpec) poss
@@ -817,7 +819,7 @@ anaUnitSpec lgraph libEnv ln dg opts eo usName impsig rN usp = case usp of
         {- if i have no imports, i can optimize?
         in that case, an identity morphism is introduced -}
        let resName = makeName $ usName{abbrevPath = abbrevPath usName ++ "_res"}
-       (resultSpec', resultSig, dg3) <- anaSpec True lgraph libEnv ln
+       (resultSpec', resultSig, dg3) <- anaSpec True True lgraph libEnv ln
            dg2 (JustNode sigUnion)
                (resName {extIndex = 1}) 
                opts eo (item resultSpec) poss
@@ -1017,13 +1019,14 @@ anaArgSpecs lgraph libEnv ln dg opts eo usName args = let
        l <- lookupLogic "anaArgSpecs " (currentLogic lgraph) lgraph
        let sp = item argSpec
            xName = makeName $ usName{abbrevPath = abbrevPath usName ++ show x}
-       (argSpec', argSig, dg') <-
-           anaSpec False lgraph libEnv ln aDG (EmptyNode l) 
+       (argSpec', argSig, dg') <- trace ("xName:" ++ show xName ++ 
+                                         "\nsp:" ++ show sp)$
+           anaSpec False False -- don't optimize the node out 
+              lgraph libEnv ln aDG (EmptyNode l) 
               (xName{extIndex = x + 1})
               opts eo sp $ getRange sp
        (argSigs, dg'', argSpecs') <-
            anaArgSpecsAux dg' (x + 1 ::Int) argSpecs
-             -- lgraph libEnv ln dg' opts eo usName argSpecs
        return (argSig : argSigs, dg'', replaceAnnoted argSpec' argSpec
                           : argSpecs')
  in anaArgSpecsAux dg 0 args

--- a/Static/AnalysisArchitecture.hs
+++ b/Static/AnalysisArchitecture.hs
@@ -958,7 +958,6 @@ lambda expressions, like you do in the following -}
      -- beh will be ignored for now
      (_rsig@(BranchRefSig _ (usig, _)), dg', asp') <- 
            anaUnitSpec lgraph libEnv ln dg opts eo rn' nsig nP uspec 
-                                       -- TODO: flag for source and target
      (_, _, _, _rsig'@(BranchRefSig n2 (usig', bsig)), dgr', rsp') <-
        anaRefSpec False lgraph libEnv ln dg' opts eo nsig rn emptyExtStUnitCtx Nothing rspec
              -- here Nothing is fine

--- a/Static/AnalysisLibrary.hs
+++ b/Static/AnalysisLibrary.hs
@@ -441,7 +441,8 @@ anaLibItem lg opts topLns currLn libenv dg eo itm =
     analyzing opts $ "unit spec " ++ usstr
     l <- lookupCurrentLogic "Unit_spec_defn" lg
     (rSig, dg', usp') <-
-      liftR $ anaUnitSpec lg libenv currLn dg opts eo (EmptyNode l) Nothing usp
+      liftR $ anaUnitSpec lg libenv currLn dg opts eo 
+                          usn' (EmptyNode l) Nothing usp
     unitSig <- liftR $ getUnitSigFromRef rSig
     let usd' = Unit_spec_defn usn usp' pos
         genv = globalEnv dg'

--- a/Static/AnalysisLibrary.hs
+++ b/Static/AnalysisLibrary.hs
@@ -612,9 +612,11 @@ anaEntailmentDefn lg ln libEnv dg opts eo en et pos = do
             spT = item asp2
             name = makeName en
         l <- lookupCurrentLogic "ENTAIL_DEFN" lg
-        (_spSrc', srcNsig, dg') <- anaSpec False lg libEnv ln dg (EmptyNode l)
-                          (extName "Source" name) opts eo spS $ getRange spS
-        (_spTgt', tgtNsig, dg'') <- anaSpec True lg libEnv ln dg' (EmptyNode l)
+        (_spSrc', srcNsig, dg') <- anaSpec False True lg libEnv ln 
+                          dg (EmptyNode l) (extName "Source" name)
+                          opts eo spS $ getRange spS
+        (_spTgt', tgtNsig, dg'') <- anaSpec True True lg libEnv ln 
+                          dg' (EmptyNode l)
                           (extName "Target" name) opts eo spT $ getRange spT
         incl <- ginclusion lg (getSig tgtNsig) (getSig srcNsig)
         let  dg3 = insLink dg'' incl globalThm SeeSource
@@ -685,9 +687,9 @@ anaViewType lg libEnv ln dg parSig opts eo name (View_type aspSrc aspTar pos) = 
   l <- lookupCurrentLogic "VIEW_TYPE" lg
   let spS = item aspSrc
       spT = item aspTar
-  (spSrc', srcNsig, dg') <- anaSpec False lg libEnv ln dg (EmptyNode l)
+  (spSrc', srcNsig, dg') <- anaSpec False True lg libEnv ln dg (EmptyNode l)
     (extName "Source" name) opts eo spS $ getRange spS
-  (spTar', tarNsig, dg'') <- anaSpec True lg libEnv ln dg' parSig
+  (spTar', tarNsig, dg'') <- anaSpec True True lg libEnv ln dg' parSig
     (extName "Target" name) opts eo spT $ getRange spT
   return (View_type (replaceAnnoted spSrc' aspSrc)
                     (replaceAnnoted spTar' aspTar)

--- a/Static/AnalysisLibrary.hs
+++ b/Static/AnalysisLibrary.hs
@@ -456,7 +456,8 @@ anaLibItem lg opts topLns currLn libenv dg eo itm =
     rn <- expCurieT (globalAnnos dg) eo rn'
     let rnstr = iriToStringUnsecure rn
     l <- lookupCurrentLogic "Ref_spec_defn" lg
-    (_, _, _, rsig, dg', rsp') <- liftR $ anaRefSpec lg libenv currLn dg opts eo
+    (_, _, _, rsig, dg', rsp') <- liftR $ 
+        anaRefSpec True lg libenv currLn dg opts eo
       (EmptyNode l) rn emptyExtStUnitCtx Nothing rsp
     analyzing opts $ "ref spec " ++ rnstr
     let rsd' = Ref_spec_defn rn rsp' pos

--- a/Static/AnalysisStructured.hs
+++ b/Static/AnalysisStructured.hs
@@ -38,8 +38,6 @@ module Static.AnalysisStructured
     , networkDiagram
     ) where
 
-import Debug.Trace
-
 import Driver.Options
 
 import Logic.Logic
@@ -535,7 +533,7 @@ anaSpecAux conser addSyms optNodes lg
       -- the case without parameters leads to a simpler dg
       (0, 0) -> case nsig of
           -- if the node shall not be named and the logic does not change,
-        EmptyNode _ | isInternal name && optNodes -> trace "notNamed" $ do
+        EmptyNode _ | isInternal name && optNodes -> do
           dg2 <- createConsLink DefLink conser lg dg nsig body SeeTarget
              -- then just return the body
           return (sp, body, dg2)


### PR DESCRIPTION
With
```
spec sp1 =
  sort s
end
unit spec usp1 = sp1 -> sp1
end

spec sp2 = sort t
end

spec sp = sp1 and sp2

unit spec usp2 = sp1 * sp2 -> sp
```
I get 
![graph](https://user-images.githubusercontent.com/1632930/31609641-549b7386-b275-11e7-82d8-586579242796.png)
