### PR TITLE
made empty names non-empty in graphs of arch specs

### DIFF
--- a/Static/ArchDiagram.hs
+++ b/Static/ArchDiagram.hs
@@ -187,12 +187,13 @@ from given NodeSig -}
 extendDGraph :: DGraph    -- ^ the development graph to be extended
              -> NodeSig   -- ^ the NodeSig from which the morphism originates
              -> GMorphism -- ^ the morphism to be inserted
+             -> IRI       -- ^ the name of the node to be inserted
              -> DGOrigin
              -> Result (NodeSig, DGraph)
 -- ^ returns the target signature of the morphism and the resulting DGraph
-extendDGraph dg (NodeSig n _) morph orig = case cod morph of
+extendDGraph dg (NodeSig n _) morph i orig = case cod morph of
     targetSig@(G_sign lid tar ind) -> let
-      nodeContents = newNodeLab emptyNodeName orig
+      nodeContents = newNodeLab (makeName i) orig
         $ noSensGTheory lid tar ind
       linkContents = globDefLink morph SeeTarget
       node = getNewNodeDG dg
@@ -205,12 +206,13 @@ given NodeSig -}
 extendDGraphRev :: DGraph    -- ^ the development graph to be extended
              -> NodeSig   -- ^ the NodeSig to which the morphism points
              -> GMorphism -- ^ the morphism to be inserted
+             -> IRI       -- ^ the name of the node to be inserted
              -> DGOrigin
              -> Result (NodeSig, DGraph)
 -- ^ returns the source signature of the morphism and the resulting DGraph
-extendDGraphRev dg (NodeSig n _) morph orig = case dom morph of
+extendDGraphRev dg (NodeSig n _) morph i orig = case dom morph of
     sourceSig@(G_sign lid src ind) -> let
-      nodeContents = newNodeLab emptyNodeName orig
+      nodeContents = newNodeLab (makeName i) orig
         $ noSensGTheory lid src ind
       linkContents = globDefLink morph SeeSource
       node = getNewNodeDG dg
@@ -223,12 +225,13 @@ given NodeSig -}
 extendDGraphRevHide :: DGraph    -- ^ the development graph to be extended
              -> NodeSig   -- ^ the NodeSig to which the morphism points
              -> GMorphism -- ^ the morphism to be inserted
+             -> IRI       -- ^ the name of the node to be inserted
              -> DGOrigin
              -> Result (NodeSig, DGraph)
 -- ^ returns the source signature of the morphism and the resulting DGraph
-extendDGraphRevHide dg (NodeSig n _) morph orig = case dom morph of
+extendDGraphRevHide dg (NodeSig n _) morph i orig = case dom morph of
     sourceSig@(G_sign lid src ind) -> let
-      nodeContents = newNodeLab emptyNodeName orig
+      nodeContents = newNodeLab (makeName i) orig
         $ noSensGTheory lid src ind
       linkContents = defDGLink morph HidingDefLink
                                       DGLinkProof
@@ -245,14 +248,16 @@ extendDiagramWithMorphismRevHide :: Range       -- ^ the position (for diagnosti
                              -- ^ the node to which the edge should point
                              -> GMorphism
                              -- ^ the morphism as label for the new edge
+                             -> IRI       
+                             -- ^ the name of the node to be inserted
                              -> String -- ^ a diagnostic node description
                              -> DGOrigin      -- ^ the origin of the new node
                              -> Result (DiagNodeSig, Diag, DGraph)
 -- ^ returns the new node, the extended diagram and extended development graph
 extendDiagramWithMorphismRevHide pos _ diag dg (Diag_node_sig n nsig)
-                             mor desc orig =
+                             mor i desc orig =
   if getSig nsig == cod mor then
-     do (sourceSig, dg') <- extendDGraphRevHide dg nsig mor orig
+     do (sourceSig, dg') <- extendDGraphRevHide dg nsig mor i orig
         let nodeContents = DiagNode {dn_sig = sourceSig, dn_desc = desc}
             diagGr = diagGraph diag
             node = Tree.getNewNode diagGr
@@ -281,13 +286,15 @@ extendDiagramWithMorphism :: Range         -- ^ the position (for diagnostics)
                           -- ^ the node from which the edge should originate
                           -> GMorphism
                           -- ^ the morphism as label for the new edge
+                          -> IRI     
+                          -- ^ the name of the node to be inserted         
                           -> String -- ^ the node description (for diagnostics)
                           -> DGOrigin -- ^ the origin of the new node
                           -> Result (DiagNodeSig, Diag, DGraph)
 -- ^ returns the new node, the extended diagram and extended development graph
-extendDiagramWithMorphism pos _ diag dg (Diag_node_sig n nsig) mor desc orig =
+extendDiagramWithMorphism pos _ diag dg (Diag_node_sig n nsig) mor i desc orig =
   if getSig nsig == dom mor then
-     do (targetSig, dg') <- extendDGraph dg nsig mor orig
+     do (targetSig, dg') <- extendDGraph dg nsig mor i orig
         let nodeContents = DiagNode {dn_sig = targetSig, dn_desc = desc}
             diagGr = diagGraph diag
             node = Tree.getNewNode diagGr
@@ -316,13 +323,14 @@ extendDiagramWithMorphismRev :: Range       -- ^ the position (for diagnostics)
                              -> GMorphism
                              -- ^ the morphism as label for the new edge
                              -> String -- ^ a diagnostic node description
+                             -> IRI       -- ^ the name of the node to be inserted
                              -> DGOrigin      -- ^ the origin of the new node
                              -> Result (DiagNodeSig, Diag, DGraph)
 -- ^ returns the new node, the extended diagram and extended development graph
 extendDiagramWithMorphismRev pos _ diag dg (Diag_node_sig n nsig)
-                             mor desc orig =
+                             mor desc i orig =
   if getSig nsig == cod mor then
-     do (sourceSig, dg') <- extendDGraphRev dg nsig mor orig
+     do (sourceSig, dg') <- extendDGraphRev dg nsig mor i orig
         let nodeContents = DiagNode {dn_sig = sourceSig, dn_desc = desc}
             diagGr = diagGraph diag
             node = Tree.getNewNode diagGr


### PR DESCRIPTION
Should fix #1764. I guess one could get better names, because in some cases i generate them from the nodes of the unit terms where some operation is applied. But this would require more names to be passed around. Maybe we can do this later.