### PR TITLE
fixed #1800

### DIFF
--- a/HasCASL/As.hs
+++ b/HasCASL/As.hs
@@ -23,6 +23,9 @@ import Common.AS_Annotation
 import Data.Data
 import qualified Data.Set as Set
 
+import Common.Doc
+import Common.DocUtils
+
 -- * abstract syntax entities with small utility functions
 
 -- | annotated basic items
@@ -370,6 +373,16 @@ data SymbKind =
   | SyKclass
     deriving (Show, Eq, Ord, Typeable, Data)
 
+instance Pretty SymbKind where
+  pretty symbol_kind = case symbol_kind of
+    Implicit -> text "implicit"
+    SyKtype -> text "type"
+    SyKsort -> text "sort"
+    SyKfun -> text "fun"
+    SyKop -> text "op"
+    SyKpred -> text "pred"
+    SyKclass -> text "class"
+    
 -- | type annotated symbols
 data Symb = Symb Id (Maybe SymbType) Range
   deriving (Show, Eq, Ord, Typeable, Data)

--- a/HasCASL/Logic_HasCASL.hs
+++ b/HasCASL/Logic_HasCASL.hs
@@ -91,6 +91,7 @@ instance Sentences HasCASL Sentence Env Morphism Symbol where
     print_named _ = printSemiAnno (changeGlobalAnnos addBuiltins . pretty) True
         . fromLabelledSen
     sym_name HasCASL = symName
+    symKind HasCASL = show . pretty . symbTypeToKind . symType
     sym_of HasCASL = symOf
     mostSymsOf HasCASL = mostSyms
     symmap_of HasCASL = morphismToSymbMap


### PR DESCRIPTION
provide function `symKind` for `Logic.Logic.Logic`. Use a pretty syntax where the prefix `SyK` has been removed.