### PR TITLE
Remove Persistent-fork and use Esqueleto

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "_dependencies/persistent"]
-	path = _dependencies/persistent
-	url = https://github.com/eugenk/persistent.git
-	branch = add_support_for_postgresqls_enumerated_types

--- a/Hets.cabal
+++ b/Hets.cabal
@@ -134,6 +134,7 @@ Executable hets
       , http-types >= 0.6 && <= 1.0
       , text >= 0.5 && < 1.3
       , case-insensitive
+      , esqueleto >= 2.5.3
       , file-embed >= 0.0.10
       , persistent >= 2.7.0
       , persistent-template >= 2.5.2

--- a/stack.yaml
+++ b/stack.yaml
@@ -45,16 +45,6 @@ resolver: lts-9.17
 # will not be run. This is useful for tweaking upstream packages.
 packages:
   - '.'
-  - location: './_dependencies/persistent/persistent'
-    extra-dep: true
-  - location: './_dependencies/persistent/persistent-postgresql'
-    extra-dep: true
-  - location: './_dependencies/persistent/persistent-sqlite'
-    extra-dep: true
-  - location: './_dependencies/persistent/persistent-template'
-    extra-dep: true
-  - location: './_dependencies/persistent/persistent-mysql'
-    extra-dep: true
 
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)


### PR DESCRIPTION
This removes the fork of Persistent that allowed to use Postgres enumeration types in database columns (see https://github.com/yesodweb/persistent/issues/264 for the currently unresolved issue) and adds Esqueleto.

We want to use Esqueleto anyway (in future pull requests) because of its feature to create `SELECT JOIN` SQL-statements. This library, however, is not compatible to the fork of Persistent.

If the new `select` calls look unusual to you, please see the `select` calls in #1829. The you should be able to see why it's necessary to `return` the arguments of the function pass to `from`. These arguments specify which tables to use in the SQL `SELECT` statement. Sometimes, not all of these tables need to be included in the result set.