### PR TITLE
make mysql support optional

### DIFF
--- a/Hets.cabal
+++ b/Hets.cabal
@@ -61,6 +61,9 @@ flag haxml
 flag httpclient
   description: use native http-client implementation instead of wget
 
+flag mysql
+  description: enable persistent support for MySQL
+
 Executable hets
   Main-is: hets.hs
   build-depends:
@@ -133,6 +136,11 @@ Executable hets
       , gtk >= 0.11.2
     cpp-options: -DGTKGLADE
 
+  if flag(mysql)
+    build-depends:
+      persistent-mysql >= 2.6.1
+    cpp-options: -DMYSQL
+
   if flag(server)
     build-depends:
         wai-extra >= 3.0 && < 4.0
@@ -145,7 +153,6 @@ Executable hets
       , file-embed >= 0.0.10
       , persistent >= 2.7.0
       , persistent-template >= 2.5.2
-      , persistent-mysql >= 2.6.1
       , persistent-postgresql >= 2.6.1
       , persistent-sqlite >= 2.6.2
       , yaml >= 0.8.23.3

--- a/Persistence/DBConfig.hs
+++ b/Persistence/DBConfig.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE CPP, DeriveGeneric #-}
 
 module Persistence.DBConfig where
 
@@ -57,12 +57,13 @@ emptyDBConfig = DBConfig { adapter = Nothing
                          , pool = Nothing
                          , needMigration = Just True
                          }
-
+#ifdef MYSQL
 isMySql :: DBConfig -> Bool
 isMySql dbConfig = case adapter dbConfig of
   Just "mysql" -> True
   Just "mysql2" -> True
   _ -> False
+#endif
 
 parseDatabaseConfig :: FilePath -> FilePath -> String -> Bool -> IO DBConfig
 parseDatabaseConfig dbFile dbConfigFile subconfigKey performMigration =

--- a/Persistence/MySQL.hs
+++ b/Persistence/MySQL.hs
@@ -1,7 +1,9 @@
+{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE GADTs                      #-}
 {-# LANGUAGE ScopedTypeVariables        #-}
 
+#ifdef MYSQL
 module Persistence.MySQL (connection) where
 
 import Persistence.DBConfig
@@ -38,3 +40,4 @@ connectionInfo config =
                          , connectPassword = passArg
                          , connectDatabase = database config
                          }
+#endif

--- a/stack.yaml
+++ b/stack.yaml
@@ -72,6 +72,7 @@ flags:
     gtkglade: true
     server: true
     haxml: true
+    mysql: false
 
 # Extra package databases containing global packages
 extra-package-dbs: []


### PR DESCRIPTION
persistent-mysql & friends do not exists on Ubuntu (neither xenial nor bionic+) - perhaps because of license concerns. Making mysql optional (disabled by default as currently is hardcoded anyway) allows one to build on bionic+ with system modules ...