### PR TITLE
1823 webgui translation

### DIFF
--- a/PGIP/Query.hs
+++ b/PGIP/Query.hs
@@ -353,8 +353,9 @@ anaNodeQuery ans i moreTheorems incls pss =
             Right $ NodeQuery i $ NcProvers GlProofs trans
          "translations" | noIncl && isNothing trans ->
             Right $ NodeQuery i $ NcTranslations prover
-         _ -> case lookup cmd cmds of
-           Just nc | noPP -> Right $ NodeQuery i $ NcCmd nc
+         _ -> case (lookup cmd cmds,trans) of
+           (Just nc,_) | noPP -> Right $ NodeQuery i $ NcCmd nc
+           (Just Theory, Just tr) -> Right $ NodeQuery i $ NcCmd $ Translate tr
            _ -> Left $ "unknown node command '" ++ cmd ++ "' "
                 ++ shows incls " " ++ show pss
        _ -> Left $ "non-unique node command " ++ show ans

--- a/PGIP/Server.hs
+++ b/PGIP/Server.hs
@@ -1480,7 +1480,7 @@ showNode opts ga lenv dg n format_ =
            Just "xml" -> (xmlC,ppTopElement $ ToXml.lnode opts ga lenv (n,lNodeN)) 
            Just "json" -> (jsonC,ppJson $ ToJson.lnode opts ga lenv (n,lNodeN))
            Just str | elem str ["dol","het","text"]
-                      -> (textC,showGlobalDoc (globalAnnos dg) (n,lNodeN) "\n")
+                      -> (textC,showGlobalDoc (globalAnnos dg) (dgn_theory lNodeN) "\n")
            _ -> error ("unknown format: "++show format_)
 
 {- | displays the global theory for a node with the option to prove theorems

--- a/PGIP/Server.hs
+++ b/PGIP/Server.hs
@@ -1498,6 +1498,8 @@ showGlobalTh dg i gTh sessId fstLine = case simplifyTh gTh of
                        [ headr
                        , transBt
                        , prvsBt
+                       , htmlRow $ unode "h4" "Translate Theory"
+                       , translationForm
                        , htmlRow $ unode "h4" "Theory"
                        ] $ "<pre>\n" ++ sbShow ++ "\n<br />" ++ thShow ++ "\n</pre>\n"
       -- else create proving functionality
@@ -1537,10 +1539,27 @@ showGlobalTh dg i gTh sessId fstLine = case simplifyTh gTh of
           , transBt
           , prvsBt
           , goBack
+          , htmlRow $ unode "h4" "Translate Theory"
+          , translationForm
           , htmlRow $ unode "h4" "Theorems"
           , thmMenu
           , htmlRow $ unode "h4" "Theory"
           ] $ "<pre>\n" ++ sbShow ++ "\n<br />" ++ thShow ++ "\n</pre>\n"
+  where
+    translationForm =
+      let selectElement =
+            add_attr (mkAttr "class" "eight wide column") $ unode "div" $
+              singleSelectionDropDown "Translation" "translation" Nothing [] -- last element is list of comorphisms as [(String <label>, String <value>, [Attr] <additional attributes like "selected" or "disabled">)]
+          translateButton =
+            add_attr (mkAttr "class" "eight wide column") $ unode "div" $
+              add_attrs [mkAttr "value" "Translate"] submitButton
+      in  add_attrs [ mkAttr "name" "translation-form", mkAttr "method" "get"]
+            $ add_attr (mkAttr "class" "ui form")
+            $ unode "form"
+            $ add_attr (mkAttr "class" "ui relaxed grid container left aligned")
+            $ unode "div"
+            $ add_attr (mkAttr "class" "row")
+            $ unode "div" [selectElement, translateButton]
 
 {- | displays translated theory -}
 showtransTh :: DGraph -> Int -> G_theory -> AnyComorphism -> Int -> String -> IO String

--- a/PGIP/Server.hs
+++ b/PGIP/Server.hs
@@ -1478,7 +1478,12 @@ showNodeXml opts ga lenv dg n = let
 and select proving options -}
 showGlobalTh :: DGraph -> Int -> G_theory -> Int -> String -> IO String
 showGlobalTh dg i gTh sessId fstLine = case simplifyTh gTh of
-  sGTh@(G_theory lid _ (ExtSign sig _) _ thsens _) -> let
+  sGTh@(G_theory lid _ (ExtSign sig _) _ thsens _) -> do
+   comorProvers <- getFullComorphList dg
+   let
+    comorSelection = map (\ (ps,cm) -> let c = showComorph cm in
+                             (c, c, [])
+                         ) comorProvers
     ga = globalAnnos dg
     -- links to translations and provers xml view
     transBt = linkButtonElement ('/' : show sessId ++ "?translations=" ++ show i)

--- a/PGIP/Server.hs
+++ b/PGIP/Server.hs
@@ -1548,7 +1548,7 @@ showGlobalTh dg i gTh sessId fstLine isTrans = case simplifyTh gTh of
     translationForm comorSelection =
       let selectElement =
             add_attr (mkAttr "class" "eight wide column") $ unode "div" $
-              singleSelectionDropDown "Translation" "translation" Nothing comorSelection -- last element is list of comorphisms as [(String <label>, String <value>, [Attr] <additional attributes like "selected" or "disabled">)]
+              singleSelectionDropDown "Translation" "translation" Nothing comorSelection
         -- hidden param field with "theory=nodeid"
           hideStr = add_attrs [ mkAttr "name" "theory"
               , mkAttr "type" "hidden", mkAttr "style" "display:none;"

--- a/PGIP/Server.hs
+++ b/PGIP/Server.hs
@@ -1332,7 +1332,7 @@ getHetsResult opts updates sessRef (Query dgQ qk) format_ api pfOptions = do
                       NcCmd Query.Theory -> case api of
                           OldWebAPI -> lift $ fmap (\ t -> (htmlC, t))
                                        $ showGlobalTh dg i gTh k fstLine False
-                          RESTfulAPI -> lift $ 
+                          RESTfulAPI -> return $ 
                                           showNode opts (globalAnnos dg) libEnv dg i format_
                       NcCmd (Query.Translate x) -> do
                           -- compose the comorphisms passed in translation
@@ -1358,7 +1358,7 @@ getHetsResult opts updates sessRef (Query dgQ qk) format_ api pfOptions = do
                                           $ showGlobalTh dg n1 gTh1 k fstLine True
                             RESTfulAPI ->
                             -- show the theory of n1 in xml format
-                              lift $ showNode opts (globalAnnos dg2) libEnv dg2 n1 format_
+                              return $ showNode opts (globalAnnos dg2) libEnv dg2 n1 format_
                       NcProvers mp mt -> do
                         availableProvers <- liftIO $ getProverList mp mt subL
                         return $ case api of
@@ -1471,12 +1471,12 @@ formatResults xForm sessId i rs =
 showBool :: Bool -> String
 showBool = map toLower . show
 
-showNode :: HetcatsOpts -> GlobalAnnos -> LibEnv -> DGraph -> Int -> Maybe String -> IO (String,String)
-showNode opts ga lenv dg n format_ = do
+showNode :: HetcatsOpts -> GlobalAnnos -> LibEnv -> DGraph -> Int -> Maybe String -> (String,String)
+showNode opts ga lenv dg n format_ = 
  let lNodeN = case lab (dgBody dg) n of
        Just lNode -> lNode
        Nothing -> error $ "no node for " ++ show n
- return $ case format_ of 
+ in case format_ of 
            Just "xml" -> (xmlC,ppTopElement $ ToXml.lnode opts ga lenv (n,lNodeN)) 
            Just "json" -> (jsonC,ppJson $ ToJson.lnode opts ga lenv (n,lNodeN))
            Just str | elem str ["dol","het","text"]

--- a/PGIP/Server.hs
+++ b/PGIP/Server.hs
@@ -574,11 +574,11 @@ parseRESTful
              Nothing -> case nodeM of
                          Just x -> NodeQuery (maybe (Right x) Left $ readMaybe x)
                                    $ NcCmd Query.Theory
-                         Nothing -> error "REST: theory"
+                         Nothing -> error "development graph node missing. Please use <url>?node=<number>"
              Just tr -> case nodeM of
                          Just x -> NodeQuery (maybe (Right x) Left $ readMaybe x)
                                    $ NcCmd $ Query.Translate tr
-                         Nothing -> error "REST: theory"
+                         Nothing -> error "development graph node missing. Please specifiy ?node=<number>"
            _ -> error $ "REST: unknown " ++ newIde
          in getResponseAux newOpts . Query (NewDGQuery libIri $ cmdList
             ++ Set.toList (Set.fromList $ optFlags ++ qOpts)) $ qkind
@@ -1373,7 +1373,7 @@ getHetsResult opts updates sessRef (Query dgQ qk) format_ api pfOptions = do
                             (xmlC, formatComorphs availableComorphisms)
                           RESTfulAPI ->
                             formatTranslations format_ availableComorphisms
-                      _ -> error "getHetsResult.NodeQuery."
+                      q -> error ("getHetsResult.NodeQuery: unnkown query"++show q)
             EdgeQuery i _ ->
               case getDGLinksById (EdgeId i) dg of
               [e@(_, _, l)] ->

--- a/PGIP/Server.hs
+++ b/PGIP/Server.hs
@@ -2181,7 +2181,7 @@ sessAnsAux libName svg (sess, k) =
               , dropDownElement "Commands" (map ref globalCommands)
               , dropDownToLevelsElement "Imported Libraries" $ map libref $ Map.keys libEnv
               ]
-          , add_attr (mkAttr "class" "row") $ unode "div" $ unode "h3" "Development Graph"
+          , add_attr (mkAttr "class" "row") $ unode "div" $ unode "h3" "Development Graph (click on node or edge)"
           ]
           svg
       )

--- a/PGIP/Server.hs
+++ b/PGIP/Server.hs
@@ -1542,6 +1542,11 @@ showGlobalTh dg i gTh sessId fstLine = case simplifyTh gTh of
           , htmlRow $ unode "h4" "Theory"
           ] $ "<pre>\n" ++ sbShow ++ "\n<br />" ++ thShow ++ "\n</pre>\n"
 
+{- | displays translated theory -}
+showtransTh :: DGraph -> Int -> G_theory -> AnyComorphism -> Int -> String -> IO String
+showtransTh dg i gTh comor sessId fstLine = undefined
+
+
 -- | show window of the autoproof function
 showAutoProofWindow :: DGraph -> Int -> ProverMode
   -> ResultT IO (String, String)


### PR DESCRIPTION
Adds a "translate" button to the DOLiator web GUI (available via `hets -X`)