### PR TITLE
1905 lossy translation

### DIFF
--- a/CASL/Sublogic.hs
+++ b/CASL/Sublogic.hs
@@ -34,6 +34,7 @@ module CASL.Sublogic
     , top
     , caslTop
     , cFol
+    , fol
     , cPrenex
     , sublogics_max
     , comp_list
@@ -181,6 +182,13 @@ cFol :: Lattice a => CASL_SL a
 cFol = caslTop
   { sub_features = NoSub -- no subsorting
   , has_part = False -- no partiality
+  }
+
+fol :: Lattice a => CASL_SL a
+fol = caslTop
+  { sub_features = NoSub -- no subsorting
+  , has_part = False -- no partiality
+  , cons_features = NoSortGen -- no sort generation constraints 
   }
 
 cPrenex :: Lattice a => CASL_SL a

--- a/CMDL/DataTypesUtils.hs
+++ b/CMDL/DataTypesUtils.hs
@@ -176,7 +176,7 @@ getTh useTrans x st
               case fn x of
                Nothing -> Nothing
                Just sth ->
-                case mapG_theory cm sth of
+                case mapG_theory False cm sth of
                   Result _ Nothing -> Just sth
                   Result _ (Just sth') -> Just sth'
 

--- a/Comorphisms/SuleCFOL2SoftFOL.hs
+++ b/Comorphisms/SuleCFOL2SoftFOL.hs
@@ -166,6 +166,9 @@ instance Show a => Comorphism (GenSuleCFOL2SoftFOL a)
                       { sub_features = LocFilSub
                       , cons_features = emptyMapConsFeature
                       , has_empty_sorts = show a == show PlainSoftFOL }
+    sourceSublogicLossy (GenSuleCFOL2SoftFOL a) = SL.fol
+                      { sub_features = LocFilSub
+                      , has_empty_sorts = show a == show PlainSoftFOL }
     targetLogic (GenSuleCFOL2SoftFOL _) = SoftFOL
     mapSublogic cid sl =
         if isSubElem sl $ sourceSublogic cid

--- a/Comorphisms/SuleCFOL2TPTP.hs
+++ b/Comorphisms/SuleCFOL2TPTP.hs
@@ -75,9 +75,8 @@ instance Comorphism GenSuleCFOL2TPTP
                TPTP.Logic_TPTP.TPTP Sublogic TAS.BASIC_SPEC Sentence () ()
                TSign.Sign TMorphism.Morphism TSign.Symbol () ProofTree where
     sourceLogic GenSuleCFOL2TPTP = CASL
-    sourceSublogic GenSuleCFOL2TPTP = SL.cFol
+    sourceSublogic GenSuleCFOL2TPTP = SL.fol
                       { sub_features = LocFilSub
-                      , cons_features = emptyMapConsFeature
                       , has_empty_sorts = True }
     targetLogic GenSuleCFOL2TPTP = TPTP.Logic_TPTP.TPTP
     mapSublogic _ _ = Just FOF

--- a/Comorphisms/SuleCFOL2TPTP.hs
+++ b/Comorphisms/SuleCFOL2TPTP.hs
@@ -110,7 +110,7 @@ translateNamedFormula :: (FormExtension f, Eq f)
                       => SignWithRenamings f e
                       -> Named (FORMULA f) -> Result (Named TSign.Sentence)
 translateNamedFormula signWithRenamings x = do
-  let nameS = toAlphaNum (map toLower $ senAttr x)
+  let nameS = "ax_" ++ toAlphaNum (map toLower $ senAttr x)
   translated <-
     translateFormula signWithRenamings nameS (isAxiom x) $
       AS_Annotation.sentence x

--- a/Comorphisms/SuleCFOL2TPTP.hs
+++ b/Comorphisms/SuleCFOL2TPTP.hs
@@ -75,7 +75,11 @@ instance Comorphism GenSuleCFOL2TPTP
                TPTP.Logic_TPTP.TPTP Sublogic TAS.BASIC_SPEC Sentence () ()
                TSign.Sign TMorphism.Morphism TSign.Symbol () ProofTree where
     sourceLogic GenSuleCFOL2TPTP = CASL
-    sourceSublogic GenSuleCFOL2TPTP = SL.fol
+    sourceSublogic GenSuleCFOL2TPTP = SL.cFol
+                       { sub_features = LocFilSub
+                      , cons_features = emptyMapConsFeature
+                       , has_empty_sorts = True }
+    sourceSublogicLossy GenSuleCFOL2TPTP = SL.fol
                       { sub_features = LocFilSub
                       , has_empty_sorts = True }
     targetLogic GenSuleCFOL2TPTP = TPTP.Logic_TPTP.TPTP

--- a/Comorphisms/SuleCFOL2TPTP.hs
+++ b/Comorphisms/SuleCFOL2TPTP.hs
@@ -209,7 +209,10 @@ translateFormula signWithRenamings nameS isAxiom' formula = do
                  FOFPAF_predicate (predicateOfSort sort) [fofTerm]
       -- Sort_gen_ax cannot be translated. Fail:
       -- See https://github.com/spechub/Hets/issues/1706
-      Sort_gen_ax _ _ -> fail "SuleCFOL2TPTP: Sort generation axioms are not yet supported."
+      Sort_gen_ax _ _ ->
+        justWarn (FOFUF_atomic $ FOFAT_defined $ FOFDAF_plain $
+                  FOFDPF_proposition $ TPTP_true)
+                 "SuleCFOL2TPTP: Sort generation axioms are not yet supported."
       -- There is no Definedness in SuleCFOL
       -- There is no Mixfix_formula - it only occurs during parsing
       -- There is no Unparsed_formula

--- a/Driver/Options.hs
+++ b/Driver/Options.hs
@@ -113,6 +113,7 @@ outdirS = "output-dir"
 amalgS = "casl-amalg"
 namedSpecsS = "named-specs"
 transS = "translation"
+lossyTransS = "lossy"
 recursiveS = "recursive"
 interactiveS = "interactive"
 connectS = "connect"
@@ -196,6 +197,7 @@ data HetcatsOpts = HcOpt     -- for comments see usage info
   , infiles :: [FilePath] -- ^ files to be read
   , specNames :: [SIMPLE_ID] -- ^ specs to be processed
   , transNames :: [SIMPLE_ID] -- ^ comorphism to be processed
+  , lossyTrans :: Bool                
   , viewNames :: [SIMPLE_ID] -- ^ views to be processed
   , intype :: InType
   , libdirs :: [FilePath]
@@ -256,6 +258,7 @@ defaultHetcatsOpts = HcOpt
   , infiles = []
   , specNames = []
   , transNames = []
+  , lossyTrans = False  
   , viewNames = []
   , intype = GuessIn
   , libdirs = []
@@ -363,6 +366,7 @@ instance Show HetcatsOpts where
     ++ showFlag computeNormalForm normalFormS
     ++ showEqOpt namedSpecsS (intercalate "," $ map show $ specNames opts)
     ++ showEqOpt transS (intercalate ":" $ map show $ transNames opts)
+    ++ showFlag lossyTrans lossyTransS
     ++ showEqOpt viewS (intercalate "," $ map show $ viewNames opts)
     ++ showEqOpt amalgS (tail $ init $ show $
                                       case caslAmalg opts of
@@ -400,6 +404,7 @@ data Flag =
   | DatabaseReanalyze
   | Specs [SIMPLE_ID]
   | Trans [SIMPLE_ID]
+  | LossyTrans   
   | Views [SIMPLE_ID]
   | CASLAmalg [CASLAmalgOpt]
   | Interactive
@@ -458,6 +463,7 @@ makeOpts opts flg =
     NormalForm -> opts { computeNormalForm = True }
     Specs x -> opts { specNames = x }
     Trans x -> opts { transNames = x }
+    LossyTrans -> opts { lossyTrans = True }
     Views x -> opts { viewNames = x }
     Verbose x -> opts { verbose = x }
     DefaultLogic x -> opts { defLogic = x }
@@ -872,6 +878,8 @@ options = let
       ("translation option " ++ crS ++
           "is a colon-separated list" ++
           crS ++ "of one or more from: SIMPLE-ID")
+    , Option "Y" [lossyTransS] (NoArg LossyTrans)
+      "apply translations in a lossy way"
     , Option "a" [amalgS] (ReqArg parseCASLAmalg "ANALYSIS")
       ("CASL amalgamability analysis options" ++ crS ++ cslst ++
        crS ++ joinBar (map show caslAmalgOpts)),

--- a/Driver/Options.hs
+++ b/Driver/Options.hs
@@ -95,7 +95,7 @@ bracket :: String -> String
 bracket s = "[" ++ s ++ "]"
 
 -- use the same strings for parsing and printing!
-verboseS, intypeS, outtypesS, skipS, justStructuredS, transS,
+verboseS, intypeS, outtypesS, skipS, justStructuredS, transS, lossyTransS,
      guiS, libdirsS, outdirS, amalgS, recursiveS, namedSpecsS,
      interactiveS, modelSparQS, counterSparQS, connectS, xmlS, dbS, listenS,
      applyAutomaticRuleS, normalFormS, unlitS, pidFileS :: String

--- a/Driver/WriteFn.hs
+++ b/Driver/WriteFn.hs
@@ -361,7 +361,7 @@ writeTheoryFiles opts specOutTypes filePrefix lenv ga ln i n =
             let tr = transNames opts
                 Result es mTh = if null tr then return (raw_gTh0, "") else do
                    comor <- lookupCompComorphism (map tokStr tr) logicGraph
-                   tTh <- mapG_theory comor raw_gTh0
+                   tTh <- mapG_theory True comor raw_gTh0
                    return (tTh, "Translated using comorphism " ++ show comor)
                 (raw_gTh, tStr) =
                   fromMaybe (raw_gTh0, "Keeping untranslated theory") mTh

--- a/Driver/WriteFn.hs
+++ b/Driver/WriteFn.hs
@@ -361,7 +361,7 @@ writeTheoryFiles opts specOutTypes filePrefix lenv ga ln i n =
             let tr = transNames opts
                 Result es mTh = if null tr then return (raw_gTh0, "") else do
                    comor <- lookupCompComorphism (map tokStr tr) logicGraph
-                   tTh <- mapG_theory True comor raw_gTh0
+                   tTh <- mapG_theory (lossyTrans opts) comor raw_gTh0
                    return (tTh, "Translated using comorphism " ++ show comor)
                 (raw_gTh, tStr) =
                   fromMaybe (raw_gTh0, "Keeping untranslated theory") mTh

--- a/Logic/Comorphism.hs
+++ b/Logic/Comorphism.hs
@@ -28,6 +28,7 @@ module Logic.Comorphism
     , targetSublogic
     , map_sign
     , wrapMapTheory
+    , wrapMapTheoryPossiblyLossy
     , mkTheoryMapping
     , AnyComorphism (..)
     , idComorphism
@@ -180,14 +181,14 @@ errMapSymbol :: Comorphism cid
 errMapSymbol cid _ _ = error $ "no symbol mapping for " ++ show cid
 
 -- | use this function instead of 'mapMarkedTheory'
-wrapMapTheory :: Comorphism cid
+wrapMapTheoryPossiblyLossy :: Comorphism cid
             lid1 sublogics1 basic_spec1 sentence1 symb_items1 symb_map_items1
                 sign1 morphism1 symbol1 raw_symbol1 proof_tree1
             lid2 sublogics2 basic_spec2 sentence2 symb_items2 symb_map_items2
                 sign2 morphism2 symbol2 raw_symbol2 proof_tree2
-            => cid -> (sign1, [Named sentence1])
+            => Bool -> cid -> (sign1, [Named sentence1])
                    -> Result (sign2, [Named sentence2])
-wrapMapTheory cid (sign, sens) =
+wrapMapTheoryPossiblyLossy lossy cid (sign, sens) =
   let res = mapMarkedTheory cid (sign, sens)
       lid1 = sourceLogic cid
       thDoc = show (vcat $ pretty sign : map (print_named lid1) sens)
@@ -209,6 +210,15 @@ wrapMapTheory cid (sign, sens) =
                            sublogicName senLog ++
                            "' with signature sublogic '" ++
                            sublogicName sigLog ++ "'") nullRange] Nothing
+
+wrapMapTheory :: Comorphism cid
+            lid1 sublogics1 basic_spec1 sentence1 symb_items1 symb_map_items1
+                sign1 morphism1 symbol1 raw_symbol1 proof_tree1
+            lid2 sublogics2 basic_spec2 sentence2 symb_items2 symb_map_items2
+                sign2 morphism2 symbol2 raw_symbol2 proof_tree2
+            => cid -> (sign1, [Named sentence1])
+                   -> Result (sign2, [Named sentence2])
+wrapMapTheory = wrapMapTheoryPossiblyLossy False
 
 mkTheoryMapping :: Monad m => (sign1 -> m (sign2, [Named sentence2]))
                    -> (sign1 -> sentence1 -> m sentence2)

--- a/Logic/Comorphism.hs
+++ b/Logic/Comorphism.hs
@@ -78,6 +78,10 @@ class (Language cid,
     sourceLogic :: cid -> lid1
     sourceSublogic :: cid -> sublogics1
     sourceSublogic cid = top_sublogic $ sourceLogic cid
+    {- needed for lossy translations. Is stricter than sourceSublogic.
+       Should be merged with sourceSublogic once #1706 has been fixed. -}
+    sourceSublogicLossy :: cid -> sublogics1
+    sourceSublogicLossy = sourceSublogic
     minSourceTheory :: cid -> Maybe (LibName, String)
     minSourceTheory _ = Nothing
     targetLogic :: cid -> lid2
@@ -195,7 +199,7 @@ wrapMapTheoryPossiblyLossy lossy cid (sign, sens) =
   in
   if isIdComorphism $ Comorphism cid
   then res
-  else let sub = sourceSublogic cid 
+  else let sub = if lossy then sourceSublogicLossy cid else sourceSublogic cid
            sigLog = minSublogic sign
            senLog = foldl lub sigLog $ map (minSublogic . sentence) sens
            isInSub s = isSubElem (minSublogic $ sentence s) sub 

--- a/PGIP/Server.hs
+++ b/PGIP/Server.hs
@@ -1339,7 +1339,7 @@ getHetsResult opts updates sessRef (Query dgQ qk) format_ api pfOptions = do
                           let coms = map getCom $ splitOn ',' x
                           com <- foldM compComorphism (head coms) $ tail coms
                           -- translate the theory of i along com
-                          gTh1 <- liftR $ mapG_theory com gTh
+                          gTh1 <- liftR $ mapG_theory False com gTh
                           -- insert the translation of i in dg
                           let n1 = getNewNodeDG dg
                               labN1 = newInfoNodeLab

--- a/Static/GTheory.hs
+++ b/Static/GTheory.hs
@@ -139,13 +139,14 @@ simplifyTh (G_theory lid gsyn sigma@(ExtSign s _) ind1 sens ind2) =
       (OMap.map (mapValue $ simplify_sen lid s) sens) ind2
 
 -- | apply a comorphism to a theory
-mapG_theory :: AnyComorphism -> G_theory -> Result G_theory
-mapG_theory (Comorphism cid) (G_theory lid _ (ExtSign sign _) ind1 sens ind2) =
+mapG_theory :: Bool -> AnyComorphism -> G_theory -> Result G_theory
+mapG_theory lossy (Comorphism cid) (G_theory lid _ (ExtSign sign _)
+            ind1 sens ind2) =
   do
   bTh <- coerceBasicTheory lid (sourceLogic cid)
     ("unapplicable comorphism '" ++ language_name cid ++ "'\n")
     (sign, toNamedList sens)
-  (sign', sens') <- wrapMapTheory cid bTh
+  (sign', sens') <- wrapMapTheoryPossiblyLossy lossy cid bTh
   return $ G_theory (targetLogic cid) Nothing (mkExtSign sign')
          ind1 (toThSens sens') ind2
 

--- a/Static/WACocone.hs
+++ b/Static/WACocone.hs
@@ -299,7 +299,7 @@ computeCoeqs graph funDesc (n1, gt1) (n2, gt2)
  com1 <- compComorphism (Comorphism cid1) (Comorphism cid3)
  com2 <- compComorphism (Comorphism cid1) (Comorphism cid3)
  if com1 /= com2 then fail "Unable to compute coequalizer" else do
-   _gtM@(G_theory lidM _ signM _idxM _ _) <- mapG_theory com1 gt
+   _gtM@(G_theory lidM _ signM _idxM _ _) <- mapG_theory False com1 gt
    s1 <- coerceSign lidM tlid "coequalizers" signM
    mor3' <- coerceMorphism (targetLogic cid3) (sourceLogic cid1) "coeqs" mor3
    mor4' <- coerceMorphism (targetLogic cid4) (sourceLogic cid2) "coeqs" mor4
@@ -394,9 +394,9 @@ buildSpan graph
           n n1 n2
           maxNodes
            = do
- sig@(G_theory _lid0 _ _sign0 _ _ _) <- mapG_theory d gt -- phi^d(Sigma)
- sig1 <- mapG_theory e1 gt1 -- phi^e1(Sigma1)
- sig2 <- mapG_theory e2 gt2 -- phi^e2(Sigma2)
+ sig@(G_theory _lid0 _ _sign0 _ _ _) <- mapG_theory False d gt -- phi^d(Sigma)
+ sig1 <- mapG_theory False e1 gt1 -- phi^e1(Sigma1)
+ sig2 <- mapG_theory False e2 gt2 -- phi^e2(Sigma2)
  mor1' <- coerceMorphism (targetLogic cid1) (sourceLogic cidE1) "buildSpan" mor1
  eps1 <- map_morphism cidE1 mor1' -- phi^e1(sigma1)
  sign' <- coerceSign lid (sourceLogic $ sourceComorphism cidM1) "buildSpan" sign


### PR DESCRIPTION
solves #1905 by providing a lossy flag `-Y` that makes translations to just leave out untranslatable axioms.
Note that #1706 must be solved before this one can be merged - otherwise, the proof support for CASL theories with sort generation constraints will be gone. 