### PR TITLE
parser for GDOL, first attempt

### DIFF
--- a/Common/Lexer.hs
+++ b/Common/Lexer.hs
@@ -291,6 +291,10 @@ commaT = asSeparator ","
 semiT :: CharParser st Token
 semiT = pToken $ string ";" << notFollowedBy (char ';')
 
+-- a double colon
+doubleColonT :: CharParser st Token
+doubleColonT = pToken $ string "::" << notFollowedBy (char ':')
+
 oBraceT :: CharParser st Token
 oBraceT = asSeparator "{"
 

--- a/Driver/WriteFn.hs
+++ b/Driver/WriteFn.hs
@@ -302,7 +302,7 @@ writeTheory ins nam opts filePrefix ga
                   (printTheory ms OWL2 $ OWL2.prepareBasicTheory th2) "\n"
             showDiags opts ds
             when (null sy)
-                $ case parse (OWL2.basicSpec Map.empty >> eof) f owltext of
+                $ case parse ((OWL2.basicSpec True) Map.empty >> eof) f owltext of
               Left err -> putIfVerbose opts 0 $ show err
               _ -> putIfVerbose opts 3 $ "reparsed: " ++ f
             writeVerbFile opts f owltext

--- a/Logic/Logic.hs
+++ b/Logic/Logic.hs
@@ -257,6 +257,9 @@ class (Language lid, PrintTypeConv basic_spec, GetRange basic_spec,
             Just p -> makeDefault (p, pretty)
          -- | parser for basic specifications
          parse_basic_spec :: lid -> Maybe (PrefixMap -> AParser st basic_spec)
+         -- | parser for macros
+         parse_macro :: lid -> Maybe (PrefixMap -> AParser st basic_spec)
+         parse_macro _ = Nothing
          -- | parser for a single symbol returned as list
          parseSingleSymbItem :: lid -> Maybe (AParser st symb_items)
          -- | parser for symbol lists
@@ -276,6 +279,10 @@ class (Language lid, PrintTypeConv basic_spec, GetRange basic_spec,
 basicSpecParser :: Syntax lid basic_spec symbol symb_items symb_map_items
   => Maybe IRI -> lid -> Maybe (PrefixMap -> AParser st basic_spec)
 basicSpecParser sm = fmap fst . parserAndPrinter sm
+
+macroParser :: Syntax lid basic_spec symbol symb_items symb_map_items
+  => Maybe IRI -> lid -> Maybe (PrefixMap -> AParser st basic_spec)
+macroParser _ = parse_macro
 
 basicSpecPrinter :: Syntax lid basic_spec symbol symb_items symb_map_items
   => Maybe IRI -> lid -> Maybe (basic_spec -> Doc)

--- a/OWL2/AS.hs
+++ b/OWL2/AS.hs
@@ -371,6 +371,7 @@ data EntityType =
   | DataProperty
   | AnnotationProperty
   | NamedIndividual
+  | UnsolvedEntity
     deriving (Enum, Bounded, Show, Read, Eq, Ord, Typeable, Data)
 
 showEntityType :: EntityType -> String
@@ -409,7 +410,7 @@ pairSymbols (Entity lb1 k1 i1) (Entity lb2 k2 i2) =
 data TypedOrUntyped = Typed Datatype | Untyped (Maybe LanguageTag)
     deriving (Show, Eq, Ord, Typeable, Data)
 
-data Literal = Literal LexicalForm TypedOrUntyped | NumberLit FloatLit
+data Literal = Literal LexicalForm TypedOrUntyped | NumberLit FloatLit | LiteralVar IRI
     deriving (Show, Eq, Ord, Typeable, Data)
 
 -- | non-negative integers given by the sequence of digits
@@ -515,12 +516,15 @@ type InverseObjectProperty = ObjectPropertyExpression
 
 data ObjectPropertyExpression = ObjectProp ObjectProperty
   | ObjectInverseOf InverseObjectProperty
+  | ObjectPropertyVar IRI
+  | UnsolvedObjProp IRI
         deriving (Show, Eq, Ord, Typeable, Data)
 
 objPropToIRI :: ObjectPropertyExpression -> Individual
 objPropToIRI opExp = case opExp of
     ObjectProp u -> u
     ObjectInverseOf objProp -> objPropToIRI objProp
+    _ -> error "nyi"
 
 type DataPropertyExpression = DataProperty
 
@@ -533,10 +537,12 @@ data DataRange =
   | DataOneOf [Literal]
     deriving (Show, Eq, Ord, Typeable, Data)
 
--- * CLASS EXPERSSIONS
+-- * CLASS EXPRESSIONS
 
 data ClassExpression =
     Expression Class
+  | UnsolvedClass IRI
+  | VarExpression MVarOrTerm
   | ObjectJunction JunctionType [ClassExpression]
   | ObjectComplementOf ClassExpression
   | ObjectOneOf [Individual]
@@ -548,6 +554,9 @@ data ClassExpression =
   | DataHasValue DataPropertyExpression Literal
   | DataCardinality (Cardinality DataPropertyExpression DataRange)
     deriving (Show, Eq, Ord, Typeable, Data)
+
+data MVarOrTerm = MVar IRI | MUnion IRI IRI -- the name of the head and the name of the tail TODO: should be extended with other terms
+ deriving (Show, Eq, Ord, Typeable, Data)
 
 -- * ANNOTATIONS
 

--- a/OWL2/DMU2OWL2.hs
+++ b/OWL2/DMU2OWL2.hs
@@ -81,7 +81,7 @@ runOntoDMU str = if null str then return "" else do
   return out
 
 readOWL :: Monad m => String -> m (Sign, [Named Axiom])
-readOWL str = case runParser (liftM2 const (basicSpec Map.empty) eof) () "" str of
+readOWL str = case runParser (liftM2 const ((basicSpec True) Map.empty) eof) () "" str of
   Left er -> fail $ show er
   Right ontoFile -> let
     newont = function Expand (StringMap $ prefixDeclaration ontoFile) ontoFile

--- a/OWL2/Logic_OWL2.hs
+++ b/OWL2/Logic_OWL2.hs
@@ -57,6 +57,7 @@ import OWL2.Symbols
 import OWL2.Taxonomy
 import OWL2.Theorem
 import OWL2.ExtractModule
+-- import OWL2.Macros
 
 data OWL2 = OWL2
 
@@ -86,9 +87,10 @@ instance Monoid OntologyDocument where
       OntologyDocument (Map.union p1 p2) $ mappend o1 o2
 
 instance Syntax OWL2 OntologyDocument Entity SymbItems SymbMapItems where
-    parsersAndPrinters OWL2 = addSyntax "Ship" (basicSpec, ppShipOnt)
-      $ addSyntax "Manchester" (basicSpec, pretty)
-      $ makeDefault (basicSpec, pretty)
+    parsersAndPrinters OWL2 = addSyntax "Ship" (basicSpec True, ppShipOnt)
+      $ addSyntax "Manchester" (basicSpec True, pretty)
+      $ makeDefault (basicSpec True, pretty)
+    parse_macro OWL2 = Just (basicSpec False)
     parseSingleSymbItem OWL2 = Just symbItem
     parse_symb_items OWL2 = Just symbItems
     parse_symb_map_items OWL2 = Just symbMapItems
@@ -176,6 +178,7 @@ instance StaticAnalysis OWL2 OntologyDocument Axiom
 #ifdef UNI_PACKAGE
       theory_to_taxonomy OWL2 = onto2Tax
 #endif
+
 instance Logic OWL2 ProfSub OntologyDocument Axiom SymbItems SymbMapItems
                Sign
                OWLMorphism Entity RawSymb ProofTree where

--- a/OWL2/Print.hs
+++ b/OWL2/Print.hs
@@ -119,6 +119,7 @@ instance Pretty Literal where
               Nothing -> empty
               Just tag2 -> text asP <> text tag2
         NumberLit f -> text (show f)
+        _ -> error "nyi"
 
 instance Pretty ObjectPropertyExpression where
     pretty = printObjPropExp
@@ -127,6 +128,8 @@ printObjPropExp :: ObjectPropertyExpression -> Doc
 printObjPropExp obExp = case obExp of
     ObjectProp ou -> pretty ou
     ObjectInverseOf iopExp -> keyword inverseS <+> printObjPropExp iopExp
+    ObjectPropertyVar ou -> text "var" <+> pretty ou
+    UnsolvedObjProp ou -> text "unsolved" <+> pretty ou
 
 printFV :: (ConstrainingFacet, RestrictionValue) -> Doc
 printFV (facet, restValue) = pretty (fromCF facet) <+> pretty restValue
@@ -159,6 +162,7 @@ printDataRange dr = case dr of
 instance Pretty ClassExpression where
   pretty desc = case desc of
    Expression ocUri -> printIRI ocUri
+   UnsolvedClass anIri -> text "unsolved" <+> printIRI anIri
    ObjectJunction ty ds -> let
       (k, p) = case ty of
           UnionOf -> (orS, pretty)

--- a/OWL2/StaticAnalysis.hs
+++ b/OWL2/StaticAnalysis.hs
@@ -38,6 +38,8 @@ import Control.Monad
 
 import Logic.Logic
 
+import Debug.Trace
+
 -- | Error messages for static analysis
 failMsg :: Entity -> ClassExpression -> Result a
 failMsg (Entity _ ty e) desc =
@@ -96,7 +98,8 @@ checkObjPropList s ol = do
     unless (and ls) $ fail $ "undeclared object properties:\n" ++
                       showDoc (map (\o -> case o of
                                      ObjectProp _ -> o
-                                     ObjectInverseOf x -> x) ol) ""
+                                     ObjectInverseOf x -> x
+                                     _ -> error "unsolved string or variable") ol) ""
 
 checkDataPropList :: Sign -> [DataPropertyExpression] -> Result ()
 checkDataPropList s dl = do
@@ -181,6 +184,7 @@ checkClassExpression s desc =
             Nothing -> return desc
             Just d -> checkDataRange s d >> return desc
         else datErr dExp
+    _ -> error "unsolved string or class variable"
 
 checkFact :: Sign -> Fact -> Result ()
 checkFact s f = case f of
@@ -400,9 +404,9 @@ generateLabelMap sig = foldr (\ (Frame ext fbl) -> case ext of
 
 -- | adding annotations for theorems
 anaAxiom :: Axiom -> Named Axiom
-anaAxiom ax = findImplied ax $ makeNamed name ax
+anaAxiom ax = findImplied ax $ makeNamed nm ax
    where names = getNames ax
-         name = concat $ intersperse "_" names
+         nm = concat $ intersperse "_" names
          
 findImplied :: Axiom -> Named Axiom -> Named Axiom
 findImplied ax sent =

--- a/Syntax/AS_Library.der.hs
+++ b/Syntax/AS_Library.der.hs
@@ -82,7 +82,12 @@ data LIB_ITEM = Spec_defn SPEC_NAME GENERICITY (Annoted SPEC) Range
               -- pos:  "newlogic", Logic_name, "=", opt "end"
               | Newcomorphism_defn ComorphismDef Range
               -- pos: "newcomorphism", Comorphism_name, "=", opt "end"
+              | Pattern_defn SPEC_NAME [PatternParam] IMPORTED LocalOrSpec Range
                 deriving (Show, Typeable)
+
+data LocalOrSpec = Local_pattern [LIB_ITEM] (Annoted SPEC) | 
+                   Spec_pattern (Annoted SPEC)
+                  deriving (Show, Typeable)
 
 data AlignSem = SingleDomain | GlobalDomain | ContextualizedDomain
   deriving (Show, Typeable, Bounded, Enum)
@@ -109,6 +114,12 @@ addDownloadAux unique j =
   in Download_items (iriLibName i)
     (if unique then UniqueItem i else ItemMaps [ItemNameMap i Nothing])
     $ iriPos i
+
+data PatternParam = OntoParam Bool (Annoted SPEC) | ListParam OntoList 
+  deriving (Show, Typeable)
+ -- the bool flag is true for optional parameters
+
+data OntoList = EmptyParamList | OntoListCons [Annoted SPEC] deriving (Show, Typeable)
 
 data GENERICITY = Genericity PARAMS IMPORTED Range deriving (Show, Typeable)
                   -- pos: many of "[","]" opt ("given", commas)

--- a/Syntax/AS_Structured.der.hs
+++ b/Syntax/AS_Structured.der.hs
@@ -75,6 +75,7 @@ data SPEC = Basic_spec G_basic_spec Range
             -- pos: "combine"
           | Apply IRI G_basic_spec Range
             -- pos: "apply", use a basic spec parser to parse a sentence
+          | UnsolvedName IRI Range
             deriving (Show, Typeable)
 
 data Network = Network [LABELED_ONTO_OR_INTPR_REF] [IRI] Range

--- a/Syntax/Parse_AS_Architecture.hs
+++ b/Syntax/Parse_AS_Architecture.hs
@@ -119,7 +119,7 @@ unitSpec l =
      NOTE: this can also be a spec name. If this is the case, this unit spec
            will be converted on the static analysis stage.
            See Static.AnalysisArchitecture.ana_UNIT_SPEC. -}
-    do gps@(gs : gss, _) <- annoParser (caslGroupSpec l) `separatedBy` crossT
+    do gps@(gs : gss, _) <- annoParser (caslGroupSpec l True) `separatedBy` crossT
        let rest = unitRestType l gps
        if null gss then
             option ( {- case item gs of
@@ -130,7 +130,7 @@ unitSpec l =
 unitRestType :: LogicGraph -> ([Annoted SPEC], [Token]) -> AParser st UNIT_SPEC
 unitRestType l (gs, ps) = do
     a <- asKey funS -- see Note
-    g <- annoParser $ caslGroupSpec l
+    g <- annoParser $ caslGroupSpec l True -- TODO: if wrong here and line 122, set True to False
     return (Unit_type gs g $ catRange (ps ++ [a]))
 
 {- Note: the minus from funS (and crossT) would be misinterpreted as

--- a/Syntax/Parse_AS_Library.hs
+++ b/Syntax/Parse_AS_Library.hs
@@ -41,6 +41,8 @@ import Control.Monad
 
 import Framework.AS
 
+import Debug.Trace
+
 lGAnnos :: LogicGraph -> AParser st (LogicGraph, [Annotation])
 lGAnnos lG = do
   as <- annos
@@ -119,7 +121,7 @@ specDefn l = do
     n <- hetIRI l
     g <- generics l
     e <- equalT
-    a <- aSpec l
+    a <- aSpec l True -- OMS, not macros
     q <- optEnd
     return . Spec_defn n g a
       . catRange $ [s, e] ++ maybeToList q
@@ -166,9 +168,9 @@ queryDefn l = do
   lg <- lookupCurrentLogic "query-defn" l
   (vs, cs) <- parseItemsList lg
   w <- asKey whereS
-  Basic_spec bs _ <- lookupCurrentSyntax "query-defn" l >>= basicSpec l
+  Basic_spec bs _ <- lookupCurrentSyntax "query-defn" l >>= basicSpec l True
   i <- asKey inS
-  oms <- aSpec l
+  oms <- aSpec l True
   mt <- optionMaybe $ asKey "along" >> hetIRI l
   o <- optEnd
   return . Query_defn n vs bs oms mt . catRange
@@ -214,7 +216,7 @@ libItem l = specDefn l
        s2 <- colonT
        et <- equivType l
        s3 <- equalT
-       sp <- fmap MkOms $ aSpec l
+       sp <- fmap MkOms $ aSpec l True
        ep <- optEnd
        return . Equiv_defn en et sp
          . catRange $ s1 : s2 : s3 : maybeToList ep
@@ -305,11 +307,37 @@ libItem l = specDefn l
            (catRange ([s1, s2, s3, s4, s5, s6, s7, s8] ++ maybeToList q)))
   <|> -- just a spec (turned into "spec spec = sp")
      do p1 <- getPos
-        a <- aSpec l
+        a <- aSpec l True
         p2 <- getPos
         if p1 == p2 then fail "cannot parse spec" else
           return (Spec_defn nullIRI
                (Genericity (Params []) (Imported []) nullRange) a nullRange)
+  <|> -- pattern defn
+      patternParser l
+
+patternParser :: LogicGraph -> AParser st LIB_ITEM
+patternParser l = do 
+        s1 <- asKey "pattern"
+        n <- hetIRI l
+        (pars, ps1) <- macroParams l
+        (imp, ps2) <- option ([], nullRange) (imports l)
+        s2 <- equalT
+        a <- localOrSpec l 
+        q <- optEnd
+        let pattern = Pattern_defn n pars (Imported imp) a nullRange
+        trace ("pattern:" ++ show pattern) $ return .  Pattern_defn n pars (Imported imp) a 
+         . catRange $ [s1, s2] ++ maybeToList q
+
+localOrSpec :: LogicGraph -> AParser st LocalOrSpec
+localOrSpec l = do
+       _s1 <- asKey "let"
+       (locals, _) <- separatedBy (patternParser l) skip -- this might have problems
+       _s2 <- asKey "in"
+       a <- aSpec l False
+       return $ Local_pattern locals a 
+     <|> do
+       a <- aSpec l False -- TODO: this makes sure that the bodies are parsed as macros and not as ontologies
+       return $ Spec_pattern a
 
 downloadItems :: LogicGraph -> AParser st (DownloadItems, [Token])
 downloadItems l = do
@@ -332,12 +360,12 @@ entailType l = do
               i <- asKey inS
               nw <- parseNetwork l
               r <- asKey entailsS
-              g <- groupSpec l
+              g <- groupSpec l True
               return . OMSInNetwork n nw g $ catRange [i, r]
             _ -> fail "OMSName expected"
 
 omsOrNetwork :: LogicGraph -> AParser st OmsOrNetwork
-omsOrNetwork l = fmap (MkOms . emptyAnno) $ groupSpec l
+omsOrNetwork l = fmap (MkOms . emptyAnno) $ groupSpec l True -- no macros in networks
 
 equivType :: LogicGraph -> AParser st EQUIV_TYPE
 equivType l = do
@@ -361,16 +389,16 @@ alignArity = choice $ map (\ a -> asKey (showAlignArity a) >> return a)
 -- | Parse view type also used in alignments
 viewType :: LogicGraph -> AParser st VIEW_TYPE
 viewType l = do
-    sp1 <- annoParser (groupSpec l)
+    sp1 <- annoParser (groupSpec l True)
     s <- asKey toS
-    sp2 <- annoParser (groupSpec l)
+    sp2 <- annoParser (groupSpec l True)
     return $ View_type sp1 sp2 $ tokPos s
 
 moduleType :: LogicGraph -> AParser st MODULE_TYPE
 moduleType l = do
-  sp1 <- aSpec l
+  sp1 <- aSpec l True
   s <- asKey ofS
-  sp2 <- aSpec l
+  sp2 <- aSpec l True
   return $ Module_type sp1 sp2 (tokPos s)
 
 restrictionSignature :: LogicGraph -> AParser st G_symb_items_list
@@ -415,14 +443,38 @@ params l = do
 param :: LogicGraph -> AParser st (Annoted SPEC, Range)
 param l = do
     b <- oBracketT
-    pa <- aSpec l
+    pa <- aSpec l True 
+    -- macros not allowed in params of CASL generic specs
     c <- cBracketT
     return (pa, toRange b [] c)
+
+macroParams :: LogicGraph -> AParser st ([PatternParam], Range)
+macroParams l = do 
+  _o <- oBracketT  
+  (pars, _ps) <- separatedBy (macroParam l) semiT
+  _c <- cBracketT
+  return (pars, nullRange) --TODO: get the range right
+
+
+macroParam :: LogicGraph -> AParser st PatternParam
+macroParam l = do
+ (elems, _ps) <- separatedBy (elemParser l) doubleColonT
+ case elems of
+  [(x, isOpt)] -> return $ OntoParam isOpt x
+  _ -> return $ ListParam $ OntoListCons $ map fst elems
+
+elemParser :: LogicGraph -> AParser st (Annoted SPEC, Bool)
+elemParser lg =  do
+  optParam <- option nullTok $ asKey "?"
+  a <- aSpec lg True
+  return (a, (optParam /= nullTok))
+ -- TODO: always True, macros not allowed as parameters 
+ -- TODO: for now, but we need to handle the empty list
 
 imports :: LogicGraph -> AParser st ([Annoted SPEC], Range)
 imports l = do
     s <- asKey givenS
-    (sps, ps) <- separatedBy (annoParser $ groupSpec l) anComma
+    (sps, ps) <- separatedBy (annoParser $ groupSpec l True) anComma -- macro not allowed in imports, always True
     return (sps, catRange (s : ps))
 
 newlogicP :: AParser st (IRI, Token)


### PR DESCRIPTION
Not intended for merging, ignore any style issue or use of tracing messages.
Issues:
```logic OWL

pattern ValSet [Class: Val;  {Individual: v0} :: vS; ? ObjectProperty: greater] 
= %% all individuals vi from v0::vS become members of Val
let pattern OrderStep [Individual: vi; {Individual: vj} :: vS] =
     Individual: vj Types: Val Facts: greater vi
    then OrderStep[vj; vS]
    end
in   Individual: v0 Types: Val
then SimpleOrder[greater; Val] and OrderStep[v0; vS]
then { DifferentIndividuals: vs, vS
       Class: Val EquivalentTo: {vj, vS} } 
```
gives a parse error because the list is not the last element in the list of parameters. Moving the optional argument before it makes the example go through. The fact that the parameter following the list is optional has no relevance (removing the ? still gives an error).
I would have the same problem in instantiations `P[A; X::Xs; B]` so I have not implemented this yet.
```
logic OWL 

pattern GradedRels 
  [Class: S; Class: T; 
   ObjectProperty: p Domain: S Range: T; 
   Class: Val;
   {Individual: v Types: Val} :: valS  ]
= %% a sheaf of graded relations p[vi], one for each vi in v::valS
let pattern Step[Individual: x :: xs] =
     ObjectProperty: p[x] Domain: S Range: T SubPropertyOf: p 
     then Step[xs]
    end
    pattern Test [Class: C] =
     Class: C SubClassOf: S
    end
in Onto and Step[v::valS] and 
   { ObjectProperty: has[Val] Domain: T Range: Val } and Test[S]
```
goes through, but removing the optional end after the local patterns makes the parser fail (`skip` as a separator most likely not the best idea). At the level of `libItem`s, that also have an optional end, these are parsed with a recursive function that also tries to parse annotation. Should follow the same approach here?
```
logic OWL

pattern P[Class: C; ?ObjectProperty: p; Class: D] =
 Class: C SubClassOf: p only D
end
ontology O = P[A; ;B] 
```
How should I parse the missing optional parameter?
```
logic OWL
pattern SimpleOrder [Class: C] =
 TransitiveRelation[greater[C]; C] 
```
Using `hetIRI` to parse `greater[C]` does not work. I have used `compoundIriCurie`. But I wonder if `hetIRI` does what it should.