### PR TITLE
Make compilable under newer glib versions

### DIFF
--- a/GUI/Glade/GenericATP.glade
+++ b/GUI/Glade/GenericATP.glade
@@ -1,167 +1,172 @@
 <?xml version="1.0"?>
-<glade-interface>
+<interface>
+  <object class="GtkAdjustment" id="adjustment1">
+    <property name="value">20</property>
+    <property name="lower">1</property>
+    <property name="upper">3600</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">0</property>
+    <property name="page_size">0</property>
+  </object>
   <!-- interface-requires gtk+ 2.8 -->
   <!-- interface-naming-policy project-wide -->
-  <widget class="GtkWindow" id="GenericATP">
+  <object class="GtkWindow" id="GenericATP">
     <property name="default_width">450</property>
     <child>
-      <widget class="GtkVBox" id="vbox15">
+      <object class="GtkVBox" id="vbox15">
         <property name="visible">True</property>
         <child>
-          <widget class="GtkHBox" id="hbox5">
+          <object class="GtkHBox" id="hbox5">
             <property name="visible">True</property>
             <child>
-              <widget class="GtkFrame" id="frame8">
+              <object class="GtkFrame" id="frame8">
                 <property name="visible">True</property>
                 <property name="label_xalign">0</property>
                 <property name="shadow_type">none</property>
                 <child>
-                  <widget class="GtkAlignment" id="alignment10">
+                  <object class="GtkAlignment" id="alignment10">
                     <property name="visible">True</property>
                     <property name="top_padding">3</property>
                     <property name="left_padding">6</property>
                     <child>
-                      <widget class="GtkScrolledWindow" id="scrolledwindow6">
+                      <object class="GtkScrolledWindow" id="scrolledwindow6">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="hscrollbar_policy">automatic</property>
                         <property name="vscrollbar_policy">automatic</property>
                         <child>
-                          <widget class="GtkTreeView" id="trvGoals">
+                          <object class="GtkTreeView" id="trvGoals">
                             <property name="height_request">100</property>
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
-                          </widget>
+                          </object>
                         </child>
-                      </widget>
+                      </object>
                     </child>
-                  </widget>
+                  </object>
                 </child>
-                <child>
-                  <widget class="GtkLabel" id="label6">
+                <child type="label">
+                  <object class="GtkLabel" id="label6">
                     <property name="visible">True</property>
                     <property name="label" translatable="yes">Goals:</property>
                     <property name="use_markup">True</property>
-                  </widget>
-                  <packing>
-                    <property name="type">label_item</property>
-                  </packing>
+                  </object>
                 </child>
-              </widget>
+              </object>
               <packing>
                 <property name="position">0</property>
               </packing>
             </child>
             <child>
-              <widget class="GtkVBox" id="vbox9">
+              <object class="GtkVBox" id="vbox9">
                 <property name="visible">True</property>
                 <child>
-                  <widget class="GtkFrame" id="frame9">
+                  <object class="GtkFrame" id="frame9">
                     <property name="visible">True</property>
                     <property name="label_xalign">0</property>
                     <property name="shadow_type">none</property>
                     <child>
-                      <widget class="GtkAlignment" id="alignment11">
+                      <object class="GtkAlignment" id="alignment11">
                         <property name="visible">True</property>
                         <property name="top_padding">3</property>
                         <property name="bottom_padding">3</property>
                         <property name="left_padding">6</property>
                         <child>
-                          <widget class="GtkVBox" id="vbox10">
+                          <object class="GtkVBox" id="vbox10">
                             <property name="visible">True</property>
                             <child>
-                              <widget class="GtkHBox" id="hbox8">
+                              <object class="GtkHBox" id="hbox8">
                                 <property name="visible">True</property>
                                 <child>
-                                  <widget class="GtkLabel" id="label10">
+                                  <object class="GtkLabel" id="label10">
                                     <property name="visible">True</property>
                                     <property name="xalign">0</property>
                                     <property name="label" translatable="yes">Timeout:</property>
-                                  </widget>
+                                  </object>
                                   <packing>
                                     <property name="position">0</property>
                                   </packing>
                                 </child>
                                 <child>
-                                  <widget class="GtkSpinButton" id="sbTimeout">
+                                  <object class="GtkSpinButton" id="sbTimeout">
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="invisible_char">&#x25CF;</property>
-                                    <property name="adjustment">20 1 3600 1 0 0</property>
-                                  </widget>
+                                    <property name="adjustment">adjustment1</property>
+                                  </object>
                                   <packing>
                                     <property name="expand">False</property>
                                     <property name="pack_type">end</property>
                                     <property name="position">1</property>
                                   </packing>
                                 </child>
-                              </widget>
+                              </object>
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="position">0</property>
                               </packing>
                             </child>
                             <child>
-                              <widget class="GtkLabel" id="label11">
+                              <object class="GtkLabel" id="label11">
                                 <property name="visible">True</property>
                                 <property name="xalign">0</property>
                                 <property name="label" translatable="yes">Extra Options:</property>
                                 <property name="use_markup">True</property>
-                              </widget>
+                              </object>
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="position">1</property>
                               </packing>
                             </child>
                             <child>
-                              <widget class="GtkEntry" id="entryOptions">
+                              <object class="GtkEntry" id="entryOptions">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="invisible_char">&#x25CF;</property>
-                              </widget>
+                              </object>
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="position">2</property>
                               </packing>
                             </child>
                             <child>
-                              <widget class="GtkCheckButton" id="cbIncludeProven">
+                              <object class="GtkCheckButton" id="cbIncludeProven">
                                 <property name="label" translatable="yes">Include preceding proven
 theorems in next proof attempt</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">False</property>
                                 <property name="draw_indicator">True</property>
-                              </widget>
+                              </object>
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="position">3</property>
                               </packing>
                             </child>
                             <child>
-                              <widget class="GtkCheckButton" id="cbSaveBatch">
+                              <object class="GtkCheckButton" id="cbSaveBatch">
                                 <property name="label" translatable="yes">Save problem batch</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">False</property>
                                 <property name="draw_indicator">True</property>
-                              </widget>
+                              </object>
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="position">4</property>
                               </packing>
                             </child>
                             <child>
-                              <widget class="GtkHButtonBox" id="hbuttonbox9">
+                              <object class="GtkHButtonBox" id="hbuttonbox9">
                                 <property name="visible">True</property>
                                 <property name="layout_style">end</property>
                                 <child>
-                                  <widget class="GtkButton" id="btnStop">
+                                  <object class="GtkButton" id="btnStop">
                                     <property name="label" translatable="yes">Stop</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="receives_default">True</property>
-                                  </widget>
+                                  </object>
                                   <packing>
                                     <property name="expand">False</property>
                                     <property name="fill">False</property>
@@ -169,12 +174,12 @@ theorems in next proof attempt</property>
                                   </packing>
                                 </child>
                                 <child>
-                                  <widget class="GtkButton" id="btnProveSelected">
+                                  <object class="GtkButton" id="btnProveSelected">
                                     <property name="label" translatable="yes">Prove</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="receives_default">True</property>
-                                  </widget>
+                                  </object>
                                   <packing>
                                     <property name="expand">False</property>
                                     <property name="fill">False</property>
@@ -182,137 +187,134 @@ theorems in next proof attempt</property>
                                   </packing>
                                 </child>
                                 <child>
-                                  <widget class="GtkButton" id="btnProveAll">
+                                  <object class="GtkButton" id="btnProveAll">
                                     <property name="label" translatable="yes">Prove all</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="receives_default">True</property>
-                                  </widget>
+                                  </object>
                                   <packing>
                                     <property name="expand">False</property>
                                     <property name="fill">False</property>
                                     <property name="position">2</property>
                                   </packing>
                                 </child>
-                              </widget>
+                              </object>
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="position">5</property>
                               </packing>
                             </child>
-                          </widget>
+                          </object>
                         </child>
-                      </widget>
+                      </object>
                     </child>
-                    <child>
-                      <widget class="GtkLabel" id="label7">
+                    <child type="label">
+                      <object class="GtkLabel" id="label7">
                         <property name="visible">True</property>
                         <property name="label" translatable="yes">Options:</property>
                         <property name="use_markup">True</property>
-                      </widget>
-                      <packing>
-                        <property name="type">label_item</property>
-                      </packing>
+                      </object>
                     </child>
-                  </widget>
+                  </object>
                   <packing>
                     <property name="expand">False</property>
                     <property name="position">0</property>
                   </packing>
                 </child>
                 <child>
-                  <widget class="GtkFrame" id="frame10">
+                  <object class="GtkFrame" id="frame10">
                     <property name="visible">True</property>
                     <property name="label_xalign">0</property>
                     <property name="shadow_type">none</property>
                     <child>
-                      <widget class="GtkAlignment" id="alignment13">
+                      <object class="GtkAlignment" id="alignment13">
                         <property name="visible">True</property>
                         <property name="top_padding">3</property>
                         <property name="left_padding">6</property>
                         <child>
-                          <widget class="GtkVBox" id="vbox11">
+                          <object class="GtkVBox" id="vbox11">
                             <property name="visible">True</property>
                             <child>
-                              <widget class="GtkHBox" id="hbox6">
+                              <object class="GtkHBox" id="hbox6">
                                 <property name="visible">True</property>
                                 <child>
-                                  <widget class="GtkLabel" id="label13">
+                                  <object class="GtkLabel" id="label13">
                                     <property name="visible">True</property>
                                     <property name="xalign">0</property>
                                     <property name="label" translatable="yes">Status:</property>
-                                  </widget>
+                                  </object>
                                   <packing>
                                     <property name="expand">False</property>
                                     <property name="position">0</property>
                                   </packing>
                                 </child>
                                 <child>
-                                  <widget class="GtkLabel" id="lblStatus">
+                                  <object class="GtkLabel" id="lblStatus">
                                     <property name="visible">True</property>
                                     <property name="xalign">0</property>
                                     <property name="xpad">3</property>
                                     <property name="label" translatable="yes">Open</property>
                                     <property name="use_markup">True</property>
-                                  </widget>
+                                  </object>
                                   <packing>
                                     <property name="position">1</property>
                                   </packing>
                                 </child>
-                              </widget>
+                              </object>
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="position">0</property>
                               </packing>
                             </child>
                             <child>
-                              <widget class="GtkLabel" id="label12">
+                              <object class="GtkLabel" id="label12">
                                 <property name="visible">True</property>
                                 <property name="xalign">0</property>
                                 <property name="label" translatable="yes">Used Axioms:</property>
                                 <property name="use_markup">True</property>
-                              </widget>
+                              </object>
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="position">1</property>
                               </packing>
                             </child>
                             <child>
-                              <widget class="GtkAlignment" id="alignment12">
+                              <object class="GtkAlignment" id="alignment12">
                                 <property name="visible">True</property>
                                 <property name="top_padding">6</property>
                                 <property name="bottom_padding">6</property>
                                 <child>
-                                  <widget class="GtkScrolledWindow" id="scrolledwindow7">
+                                  <object class="GtkScrolledWindow" id="scrolledwindow7">
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="hscrollbar_policy">automatic</property>
                                     <property name="vscrollbar_policy">automatic</property>
                                     <child>
-                                      <widget class="GtkTreeView" id="trvAxioms">
+                                      <object class="GtkTreeView" id="trvAxioms">
                                         <property name="height_request">100</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
-                                      </widget>
+                                      </object>
                                     </child>
-                                  </widget>
+                                  </object>
                                 </child>
-                              </widget>
+                              </object>
                               <packing>
                                 <property name="position">2</property>
                               </packing>
                             </child>
                             <child>
-                              <widget class="GtkHButtonBox" id="hbuttonbox10">
+                              <object class="GtkHButtonBox" id="hbuttonbox10">
                                 <property name="visible">True</property>
                                 <property name="layout_style">end</property>
                                 <child>
-                                  <widget class="GtkButton" id="btnSaveProblem">
+                                  <object class="GtkButton" id="btnSaveProblem">
                                     <property name="label" translatable="yes">Save Problem File</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="receives_default">True</property>
-                                  </widget>
+                                  </object>
                                   <packing>
                                     <property name="expand">False</property>
                                     <property name="fill">False</property>
@@ -320,58 +322,55 @@ theorems in next proof attempt</property>
                                   </packing>
                                 </child>
                                 <child>
-                                  <widget class="GtkButton" id="btnShowDetails">
+                                  <object class="GtkButton" id="btnShowDetails">
                                     <property name="label" translatable="yes">Show Details</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="receives_default">True</property>
-                                  </widget>
+                                  </object>
                                   <packing>
                                     <property name="expand">False</property>
                                     <property name="fill">False</property>
                                     <property name="position">1</property>
                                   </packing>
                                 </child>
-                              </widget>
+                              </object>
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="position">3</property>
                               </packing>
                             </child>
-                          </widget>
+                          </object>
                         </child>
-                      </widget>
+                      </object>
                     </child>
-                    <child>
-                      <widget class="GtkLabel" id="label9">
+                    <child type="label">
+                      <object class="GtkLabel" id="label9">
                         <property name="visible">True</property>
                         <property name="label" translatable="yes">Results:</property>
                         <property name="use_markup">True</property>
-                      </widget>
-                      <packing>
-                        <property name="type">label_item</property>
-                      </packing>
+                      </object>
                     </child>
-                  </widget>
+                  </object>
                   <packing>
                     <property name="position">1</property>
                   </packing>
                 </child>
-              </widget>
+              </object>
               <packing>
                 <property name="expand">False</property>
                 <property name="position">1</property>
               </packing>
             </child>
-          </widget>
+          </object>
           <packing>
             <property name="position">0</property>
           </packing>
         </child>
         <child>
-          <widget class="GtkHSeparator" id="hseparator3">
+          <object class="GtkHSeparator" id="hseparator3">
             <property name="visible">True</property>
-          </widget>
+          </object>
           <packing>
             <property name="expand">False</property>
             <property name="padding">3</property>
@@ -379,15 +378,15 @@ theorems in next proof attempt</property>
           </packing>
         </child>
         <child>
-          <widget class="GtkHButtonBox" id="hbuttonbox11">
+          <object class="GtkHButtonBox" id="hbuttonbox11">
             <property name="visible">True</property>
             <child>
-              <widget class="GtkButton" id="btnHelp">
+              <object class="GtkButton" id="btnHelp">
                 <property name="label" translatable="yes">Help</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-              </widget>
+              </object>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">False</property>
@@ -395,12 +394,12 @@ theorems in next proof attempt</property>
               </packing>
             </child>
             <child>
-              <widget class="GtkButton" id="btnSaveConfig">
+              <object class="GtkButton" id="btnSaveConfig">
                 <property name="label" translatable="yes">Save config</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-              </widget>
+              </object>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">False</property>
@@ -408,12 +407,12 @@ theorems in next proof attempt</property>
               </packing>
             </child>
             <child>
-              <widget class="GtkButton" id="btnClose">
+              <object class="GtkButton" id="btnClose">
                 <property name="label" translatable="yes">Close</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-              </widget>
+              </object>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">False</property>
@@ -421,14 +420,14 @@ theorems in next proof attempt</property>
                 <property name="position">2</property>
               </packing>
             </child>
-          </widget>
+          </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">False</property>
             <property name="position">2</property>
           </packing>
         </child>
-      </widget>
+      </object>
     </child>
-  </widget>
-</glade-interface>
+  </object>
+</interface>

--- a/GUI/Glade/LinkTypeChoice.glade
+++ b/GUI/Glade/LinkTypeChoice.glade
@@ -1,124 +1,115 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE glade-interface SYSTEM "glade-2.0.dtd">
+<?xml version="1.0"?>
 <!--Generated with glade3 3.4.5 on Wed Oct 15 16:11:39 2008 -->
-<glade-interface>
-  <widget class="GtkWindow" id="linktypechoice">
+<interface>
+  <object class="GtkWindow" id="linktypechoice">
     <child>
-      <widget class="GtkVBox" id="vbox3">
+      <object class="GtkVBox" id="vbox3">
         <property name="visible">True</property>
         <child>
-          <widget class="GtkHBox" id="hbox2">
+          <object class="GtkHBox" id="hbox2">
             <property name="visible">True</property>
             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
             <property name="homogeneous">True</property>
             <child>
-              <widget class="GtkVBox" id="vbox2">
+              <object class="GtkVBox" id="vbox2">
                 <property name="visible">True</property>
                 <property name="homogeneous">True</property>
                 <child>
-                  <widget class="GtkFrame" id="frame1">
+                  <object class="GtkFrame" id="frame1">
                     <property name="visible">True</property>
                     <property name="label_xalign">0</property>
                     <property name="shadow_type">GTK_SHADOW_NONE</property>
                     <child>
-                      <widget class="GtkAlignment" id="alignment1">
+                      <object class="GtkAlignment" id="alignment1">
                         <property name="visible">True</property>
                         <property name="left_padding">12</property>
                         <child>
-                          <widget class="GtkVButtonBox" id="vbuttonbox2">
+                          <object class="GtkVButtonBox" id="vbuttonbox2">
                             <property name="visible">True</property>
                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                             <property name="layout_style">GTK_BUTTONBOX_START</property>
                             <child>
-                              <widget class="GtkCheckButton" id="cbGlobalDef">
+                              <object class="GtkCheckButton" id="cbGlobalDef">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                 <property name="label" translatable="yes">Homogen Global Definition</property>
-                                <property name="response_id">0</property>
                                 <property name="active">True</property>
                                 <property name="draw_indicator">True</property>
-                              </widget>
+                              </object>
                             </child>
                             <child>
-                              <widget class="GtkCheckButton" id="cbHetDef">
+                              <object class="GtkCheckButton" id="cbHetDef">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                 <property name="label" translatable="yes">Heterogen Global Definition</property>
-                                <property name="response_id">0</property>
                                 <property name="active">True</property>
                                 <property name="draw_indicator">True</property>
-                              </widget>
+                              </object>
                               <packing>
                                 <property name="position">1</property>
                               </packing>
                             </child>
                             <child>
-                              <widget class="GtkCheckButton" id="cbLocalDef">
+                              <object class="GtkCheckButton" id="cbLocalDef">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                 <property name="label" translatable="yes">Local Definition</property>
-                                <property name="response_id">0</property>
                                 <property name="active">True</property>
                                 <property name="draw_indicator">True</property>
-                              </widget>
+                              </object>
                               <packing>
                                 <property name="position">2</property>
                               </packing>
                             </child>
                             <child>
-                              <widget class="GtkCheckButton" id="cbHidingDef">
+                              <object class="GtkCheckButton" id="cbHidingDef">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                 <property name="label" translatable="yes">Hiding Definition</property>
-                                <property name="response_id">0</property>
                                 <property name="active">True</property>
                                 <property name="draw_indicator">True</property>
-                              </widget>
+                              </object>
                               <packing>
                                 <property name="position">3</property>
                               </packing>
                             </child>
                             <child>
-                              <widget class="GtkCheckButton" id="cbDef">
+                              <object class="GtkCheckButton" id="cbDef">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                 <property name="label" translatable="yes">Free or Cofree Definition</property>
-                                <property name="response_id">0</property>
                                 <property name="active">True</property>
                                 <property name="draw_indicator">True</property>
-                              </widget>
+                              </object>
                               <packing>
                                 <property name="position">4</property>
                               </packing>
                             </child>
-                          </widget>
+                          </object>
                         </child>
-                      </widget>
+                      </object>
                     </child>
-                    <child>
-                      <widget class="GtkLabel" id="label1">
+                    <child type="label">
+                      <object class="GtkLabel" id="label1">
                         <property name="visible">True</property>
                         <property name="label" translatable="yes">&lt;b&gt;Definition links&lt;/b&gt;</property>
                         <property name="use_markup">True</property>
-                      </widget>
-                      <packing>
-                        <property name="type">label_item</property>
-                      </packing>
+                      </object>
                     </child>
-                  </widget>
+                  </object>
                 </child>
                 <child>
-                  <widget class="GtkFrame" id="frame4">
+                  <object class="GtkFrame" id="frame4">
                     <property name="visible">True</property>
                     <property name="label_xalign">0</property>
                     <property name="shadow_type">GTK_SHADOW_NONE</property>
                     <child>
-                      <widget class="GtkAlignment" id="alignment4">
+                      <object class="GtkAlignment" id="alignment4">
                         <property name="visible">True</property>
                         <property name="xalign">0</property>
                         <property name="yalign">0</property>
@@ -126,29 +117,27 @@
                         <property name="left_padding">12</property>
                         <property name="right_padding">100</property>
                         <child>
-                          <widget class="GtkVBox" id="vbox4">
+                          <object class="GtkVBox" id="vbox4">
                             <property name="visible">True</property>
                             <child>
-                              <widget class="GtkButton" id="btnSelect">
+                              <object class="GtkButton" id="btnSelect">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">True</property>
                                 <property name="label" translatable="yes">Select all</property>
-                                <property name="response_id">0</property>
-                              </widget>
+                              </object>
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">False</property>
                               </packing>
                             </child>
                             <child>
-                              <widget class="GtkButton" id="btnDeselect">
+                              <object class="GtkButton" id="btnDeselect">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">True</property>
                                 <property name="label" translatable="yes">Deselect all</property>
-                                <property name="response_id">0</property>
-                              </widget>
+                              </object>
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">False</property>
@@ -156,308 +145,284 @@
                               </packing>
                             </child>
                             <child>
-                              <widget class="GtkButton" id="btnInvert">
+                              <object class="GtkButton" id="btnInvert">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">True</property>
                                 <property name="label" translatable="yes">Invert</property>
-                                <property name="response_id">0</property>
-                              </widget>
+                              </object>
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">False</property>
                                 <property name="position">2</property>
                               </packing>
                             </child>
-                          </widget>
+                          </object>
                         </child>
-                      </widget>
+                      </object>
                     </child>
-                    <child>
-                      <widget class="GtkLabel" id="label4">
+                    <child type="label">
+                      <object class="GtkLabel" id="label4">
                         <property name="visible">True</property>
                         <property name="label" translatable="yes">&lt;b&gt;Modifications&lt;/b&gt;</property>
                         <property name="use_markup">True</property>
-                      </widget>
-                      <packing>
-                        <property name="type">label_item</property>
-                      </packing>
+                      </object>
                     </child>
-                  </widget>
+                  </object>
                   <packing>
                     <property name="expand">False</property>
                     <property name="position">1</property>
                   </packing>
                 </child>
-              </widget>
+              </object>
             </child>
             <child>
-              <widget class="GtkVBox" id="vbox1">
+              <object class="GtkVBox" id="vbox1">
                 <property name="visible">True</property>
                 <child>
-                  <widget class="GtkFrame" id="frame2">
+                  <object class="GtkFrame" id="frame2">
                     <property name="visible">True</property>
                     <property name="label_xalign">0</property>
                     <property name="shadow_type">GTK_SHADOW_NONE</property>
                     <child>
-                      <widget class="GtkAlignment" id="alignment2">
+                      <object class="GtkAlignment" id="alignment2">
                         <property name="visible">True</property>
                         <property name="left_padding">12</property>
                         <child>
-                          <widget class="GtkVButtonBox" id="vbuttonbox1">
+                          <object class="GtkVButtonBox" id="vbuttonbox1">
                             <property name="visible">True</property>
                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                             <property name="layout_style">GTK_BUTTONBOX_START</property>
                             <child>
-                              <widget class="GtkCheckButton" id="cbGlobalProvenThm">
+                              <object class="GtkCheckButton" id="cbGlobalProvenThm">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                 <property name="label" translatable="yes">Homogen Global Theorem</property>
-                                <property name="response_id">0</property>
                                 <property name="active">True</property>
                                 <property name="draw_indicator">True</property>
-                              </widget>
+                              </object>
                             </child>
                             <child>
-                              <widget class="GtkCheckButton" id="cbHetProvenThm">
+                              <object class="GtkCheckButton" id="cbHetProvenThm">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                 <property name="label" translatable="yes">Heterogen Global Theorem</property>
-                                <property name="response_id">0</property>
                                 <property name="active">True</property>
                                 <property name="draw_indicator">True</property>
-                              </widget>
+                              </object>
                               <packing>
                                 <property name="position">1</property>
                               </packing>
                             </child>
                             <child>
-                              <widget class="GtkCheckButton" id="cbLocalProvenThm">
+                              <object class="GtkCheckButton" id="cbLocalProvenThm">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                 <property name="label" translatable="yes">Homogen Local Theorem</property>
-                                <property name="response_id">0</property>
                                 <property name="active">True</property>
                                 <property name="draw_indicator">True</property>
-                              </widget>
+                              </object>
                               <packing>
                                 <property name="position">2</property>
                               </packing>
                             </child>
                             <child>
-                              <widget class="GtkCheckButton" id="cbHetLocalProvenThm">
+                              <object class="GtkCheckButton" id="cbHetLocalProvenThm">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                 <property name="label" translatable="yes">Heterogen Local Theorem</property>
-                                <property name="response_id">0</property>
                                 <property name="active">True</property>
                                 <property name="draw_indicator">True</property>
-                              </widget>
+                              </object>
                               <packing>
                                 <property name="position">3</property>
                               </packing>
                             </child>
                             <child>
-                              <widget class="GtkCheckButton" id="cbProvenHidingThm">
+                              <object class="GtkCheckButton" id="cbProvenHidingThm">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                 <property name="label" translatable="yes">Hiding Theorem</property>
-                                <property name="response_id">0</property>
                                 <property name="active">True</property>
                                 <property name="draw_indicator">True</property>
-                              </widget>
+                              </object>
                               <packing>
                                 <property name="position">4</property>
                               </packing>
                             </child>
                             <child>
-                              <widget class="GtkCheckButton" id="cbProvenThm">
+                              <object class="GtkCheckButton" id="cbProvenThm">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                 <property name="label" translatable="yes">(Co)Free Theorem</property>
-                                <property name="response_id">0</property>
                                 <property name="active">True</property>
                                 <property name="draw_indicator">True</property>
-                              </widget>
+                              </object>
                               <packing>
                                 <property name="position">5</property>
                               </packing>
                             </child>
-                          </widget>
+                          </object>
                         </child>
-                      </widget>
+                      </object>
                     </child>
-                    <child>
-                      <widget class="GtkLabel" id="label2">
+                    <child type="label">
+                      <object class="GtkLabel" id="label2">
                         <property name="visible">True</property>
                         <property name="label" translatable="yes">&lt;b&gt;Theorem links proven&lt;/b&gt;</property>
                         <property name="use_markup">True</property>
-                      </widget>
-                      <packing>
-                        <property name="type">label_item</property>
-                      </packing>
+                      </object>
                     </child>
-                  </widget>
+                  </object>
                 </child>
                 <child>
-                  <widget class="GtkFrame" id="frame3">
+                  <object class="GtkFrame" id="frame3">
                     <property name="visible">True</property>
                     <property name="label_xalign">0</property>
                     <property name="shadow_type">GTK_SHADOW_NONE</property>
                     <child>
-                      <widget class="GtkAlignment" id="alignment3">
+                      <object class="GtkAlignment" id="alignment3">
                         <property name="visible">True</property>
                         <property name="left_padding">12</property>
                         <child>
-                          <widget class="GtkVButtonBox" id="vbuttonbox3">
+                          <object class="GtkVButtonBox" id="vbuttonbox3">
                             <property name="visible">True</property>
                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                             <property name="layout_style">GTK_BUTTONBOX_START</property>
                             <child>
-                              <widget class="GtkCheckButton" id="cbGlobalUnprovenThm">
+                              <object class="GtkCheckButton" id="cbGlobalUnprovenThm">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                 <property name="label" translatable="yes">Homogen Global Theorem</property>
-                                <property name="response_id">0</property>
                                 <property name="active">True</property>
                                 <property name="draw_indicator">True</property>
-                              </widget>
+                              </object>
                             </child>
                             <child>
-                              <widget class="GtkCheckButton" id="cbHetUnprovenThm">
+                              <object class="GtkCheckButton" id="cbHetUnprovenThm">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                 <property name="label" translatable="yes">Heterogen Global Theorem</property>
-                                <property name="response_id">0</property>
                                 <property name="active">True</property>
                                 <property name="draw_indicator">True</property>
-                              </widget>
+                              </object>
                               <packing>
                                 <property name="position">1</property>
                               </packing>
                             </child>
                             <child>
-                              <widget class="GtkCheckButton" id="cbLocalUnprovenThm">
+                              <object class="GtkCheckButton" id="cbLocalUnprovenThm">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                 <property name="label" translatable="yes">Homogen Local Theorem</property>
-                                <property name="response_id">0</property>
                                 <property name="active">True</property>
                                 <property name="draw_indicator">True</property>
-                              </widget>
+                              </object>
                               <packing>
                                 <property name="position">2</property>
                               </packing>
                             </child>
                             <child>
-                              <widget class="GtkCheckButton" id="cbHetLocalUnprovenThm">
+                              <object class="GtkCheckButton" id="cbHetLocalUnprovenThm">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                 <property name="label" translatable="yes">Heterogen Local Theorem</property>
-                                <property name="response_id">0</property>
                                 <property name="active">True</property>
                                 <property name="draw_indicator">True</property>
-                              </widget>
+                              </object>
                               <packing>
                                 <property name="position">3</property>
                               </packing>
                             </child>
                             <child>
-                              <widget class="GtkCheckButton" id="cbUnprovenHidingThm">
+                              <object class="GtkCheckButton" id="cbUnprovenHidingThm">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                 <property name="label" translatable="yes">Hiding Theorem</property>
-                                <property name="response_id">0</property>
                                 <property name="active">True</property>
                                 <property name="draw_indicator">True</property>
-                              </widget>
+                              </object>
                               <packing>
                                 <property name="position">4</property>
                               </packing>
                             </child>
                             <child>
-                              <widget class="GtkCheckButton" id="cbUnprovenThm">
+                              <object class="GtkCheckButton" id="cbUnprovenThm">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                 <property name="label" translatable="yes">(Co)Free Theorem</property>
-                                <property name="response_id">0</property>
                                 <property name="active">True</property>
                                 <property name="draw_indicator">True</property>
-                              </widget>
+                              </object>
                               <packing>
                                 <property name="position">5</property>
                               </packing>
                             </child>
-                          </widget>
+                          </object>
                         </child>
-                      </widget>
+                      </object>
                     </child>
-                    <child>
-                      <widget class="GtkLabel" id="label3">
+                    <child type="label">
+                      <object class="GtkLabel" id="label3">
                         <property name="visible">True</property>
                         <property name="label" translatable="yes">&lt;b&gt;Theorem links unproven&lt;/b&gt;</property>
                         <property name="use_markup">True</property>
-                      </widget>
-                      <packing>
-                        <property name="type">label_item</property>
-                      </packing>
+                      </object>
                     </child>
-                  </widget>
+                  </object>
                   <packing>
                     <property name="position">1</property>
                   </packing>
                 </child>
-              </widget>
+              </object>
               <packing>
                 <property name="position">1</property>
               </packing>
             </child>
-          </widget>
+          </object>
         </child>
         <child>
-          <widget class="GtkHButtonBox" id="hbuttonbox1">
+          <object class="GtkHButtonBox" id="hbuttonbox1">
             <property name="visible">True</property>
             <property name="spacing">5</property>
             <property name="layout_style">GTK_BUTTONBOX_END</property>
             <child>
-              <widget class="GtkButton" id="btnCancel">
+              <object class="GtkButton" id="btnCancel">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
                 <property name="label" translatable="yes">Cancel</property>
-                <property name="response_id">0</property>
-              </widget>
+              </object>
             </child>
             <child>
-              <widget class="GtkButton" id="btnOk">
+              <object class="GtkButton" id="btnOk">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
                 <property name="label" translatable="yes">Ok</property>
-                <property name="response_id">0</property>
-              </widget>
+              </object>
               <packing>
                 <property name="position">1</property>
               </packing>
             </child>
-          </widget>
+          </object>
           <packing>
             <property name="position">1</property>
           </packing>
         </child>
-      </widget>
+      </object>
     </child>
-  </widget>
-</glade-interface>
+  </object>
+</interface>

--- a/GUI/Glade/NodeChecker.glade
+++ b/GUI/Glade/NodeChecker.glade
@@ -1,56 +1,61 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<glade-interface>
+<?xml version="1.0"?>
+<interface>
+  <object class="GtkAdjustment" id="adjustment1">
+    <property name="value">20</property>
+    <property name="lower">1</property>
+    <property name="upper">3600</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">0</property>
+    <property name="page_size">0</property>
+  </object>
   <!-- interface-requires gtk+ 2.16 -->
   <!-- interface-naming-policy project-wide -->
-  <widget class="GtkWindow" id="ModelView">
+  <object class="GtkWindow" id="ModelView">
     <property name="can_focus">False</property>
     <child>
-      <widget class="GtkVBox" id="vbox5">
+      <object class="GtkVBox" id="vbox5">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <child>
-          <widget class="GtkHBox" id="hbox2">
+          <object class="GtkHBox" id="hbox2">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <child>
-              <widget class="GtkFrame" id="frResNodes">
+              <object class="GtkFrame" id="frResNodes">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="label_xalign">0</property>
                 <property name="shadow_type">none</property>
                 <child>
-                  <widget class="GtkAlignment" id="alignment9">
+                  <object class="GtkAlignment" id="alignment9">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="left_padding">6</property>
                     <child>
-                      <widget class="GtkScrolledWindow" id="scrolledwindow3">
+                      <object class="GtkScrolledWindow" id="scrolledwindow3">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="hscrollbar_policy">automatic</property>
                         <property name="vscrollbar_policy">automatic</property>
                         <child>
-                          <widget class="GtkTreeView" id="trvResNodes">
+                          <object class="GtkTreeView" id="trvResNodes">
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
-                          </widget>
+                          </object>
                         </child>
-                      </widget>
+                      </object>
                     </child>
-                  </widget>
+                  </object>
                 </child>
-                <child>
-                  <widget class="GtkLabel" id="label7">
+                <child type="label">
+                  <object class="GtkLabel" id="label7">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="label" translatable="yes">Nodes:</property>
                     <property name="use_markup">True</property>
-                  </widget>
-                  <packing>
-                    <property name="type">label_item</property>
-                  </packing>
+                  </object>
                 </child>
-              </widget>
+              </object>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
@@ -58,51 +63,48 @@
               </packing>
             </child>
             <child>
-              <widget class="GtkFrame" id="frame4">
+              <object class="GtkFrame" id="frame4">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="label_xalign">0</property>
                 <property name="shadow_type">none</property>
                 <child>
-                  <widget class="GtkAlignment" id="alignment10">
+                  <object class="GtkAlignment" id="alignment10">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="left_padding">6</property>
                     <child>
-                      <widget class="GtkScrolledWindow" id="scrolledwindow4">
+                      <object class="GtkScrolledWindow" id="scrolledwindow4">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="hscrollbar_policy">automatic</property>
                         <property name="vscrollbar_policy">automatic</property>
                         <child>
-                          <widget class="GtkTextView" id="tvResModel">
+                          <object class="GtkTextView" id="tvResModel">
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
-                          </widget>
+                          </object>
                         </child>
-                      </widget>
+                      </object>
                     </child>
-                  </widget>
+                  </object>
                 </child>
-                <child>
-                  <widget class="GtkLabel" id="label8">
+                <child type="label">
+                  <object class="GtkLabel" id="label8">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="label" translatable="yes">Result:</property>
                     <property name="use_markup">True</property>
-                  </widget>
-                  <packing>
-                    <property name="type">label_item</property>
-                  </packing>
+                  </object>
                 </child>
-              </widget>
+              </object>
               <packing>
                 <property name="expand">True</property>
                 <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
-          </widget>
+          </object>
           <packing>
             <property name="expand">True</property>
             <property name="fill">True</property>
@@ -110,10 +112,10 @@
           </packing>
         </child>
         <child>
-          <widget class="GtkHSeparator" id="hseparator2">
+          <object class="GtkHSeparator" id="hseparator2">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-          </widget>
+          </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
@@ -121,56 +123,56 @@
           </packing>
         </child>
         <child>
-          <widget class="GtkHButtonBox" id="hbuttonbox5">
+          <object class="GtkHButtonBox" id="hbuttonbox5">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="layout_style">end</property>
             <child>
-              <widget class="GtkButton" id="btnResClose">
+              <object class="GtkButton" id="btnResClose">
                 <property name="label" translatable="yes">Close</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
                 <property name="use_action_appearance">False</property>
-              </widget>
+              </object>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">False</property>
                 <property name="position">0</property>
               </packing>
             </child>
-          </widget>
+          </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
             <property name="position">2</property>
           </packing>
         </child>
-      </widget>
+      </object>
     </child>
-  </widget>
-  <widget class="GtkWindow" id="NodeChecker">
+  </object>
+  <object class="GtkWindow" id="NodeChecker">
     <property name="can_focus">False</property>
     <child>
-      <widget class="GtkVBox" id="vbox3">
+      <object class="GtkVBox" id="vbox3">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <child>
-          <widget class="GtkHBox" id="hbox1">
+          <object class="GtkHBox" id="hbox1">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <child>
-              <widget class="GtkVBox" id="vbox4">
+              <object class="GtkVBox" id="vbox4">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <child>
-                  <widget class="GtkFrame" id="frame2">
+                  <object class="GtkFrame" id="frame2">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="label_xalign">0</property>
                     <property name="shadow_type">none</property>
                     <child>
-                      <widget class="GtkAlignment" id="alignment2">
+                      <object class="GtkAlignment" id="alignment2">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="top_padding">6</property>
@@ -178,33 +180,30 @@
                         <property name="left_padding">6</property>
                         <property name="right_padding">6</property>
                         <child>
-                          <widget class="GtkScrolledWindow" id="scrolledwindow2">
+                          <object class="GtkScrolledWindow" id="scrolledwindow2">
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="hscrollbar_policy">automatic</property>
                             <property name="vscrollbar_policy">automatic</property>
                             <child>
-                              <widget class="GtkTreeView" id="trvNodes">
+                              <object class="GtkTreeView" id="trvNodes">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
-                              </widget>
+                              </object>
                             </child>
-                          </widget>
+                          </object>
                         </child>
-                      </widget>
+                      </object>
                     </child>
-                    <child>
-                      <widget class="GtkLabel" id="label2">
+                    <child type="label">
+                      <object class="GtkLabel" id="label2">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="label" translatable="yes">Nodes or goals:</property>
                         <property name="use_markup">True</property>
-                      </widget>
-                      <packing>
-                        <property name="type">label_item</property>
-                      </packing>
+                      </object>
                     </child>
-                  </widget>
+                  </object>
                   <packing>
                     <property name="expand">True</property>
                     <property name="fill">True</property>
@@ -212,18 +211,18 @@
                   </packing>
                 </child>
                 <child>
-                  <widget class="GtkHButtonBox" id="hbuttonbox6">
+                  <object class="GtkHButtonBox" id="hbuttonbox6">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="layout_style">start</property>
                     <child>
-                      <widget class="GtkButton" id="btnNodesAll">
+                      <object class="GtkButton" id="btnNodesAll">
                         <property name="label" translatable="yes">All</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
                         <property name="use_action_appearance">False</property>
-                      </widget>
+                      </object>
                       <packing>
                         <property name="expand">False</property>
                         <property name="fill">False</property>
@@ -231,13 +230,13 @@
                       </packing>
                     </child>
                     <child>
-                      <widget class="GtkButton" id="btnNodesNone">
+                      <object class="GtkButton" id="btnNodesNone">
                         <property name="label" translatable="yes">None</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
                         <property name="use_action_appearance">False</property>
-                      </widget>
+                      </object>
                       <packing>
                         <property name="expand">False</property>
                         <property name="fill">False</property>
@@ -245,20 +244,20 @@
                       </packing>
                     </child>
                     <child>
-                      <widget class="GtkButton" id="btnNodesInvert">
+                      <object class="GtkButton" id="btnNodesInvert">
                         <property name="label" translatable="yes">Invert</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
                         <property name="use_action_appearance">False</property>
-                      </widget>
+                      </object>
                       <packing>
                         <property name="expand">False</property>
                         <property name="fill">False</property>
                         <property name="position">2</property>
                       </packing>
                     </child>
-                  </widget>
+                  </object>
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
@@ -266,18 +265,18 @@
                   </packing>
                 </child>
                 <child>
-                  <widget class="GtkHButtonBox" id="hbuttonbox4">
+                  <object class="GtkHButtonBox" id="hbuttonbox4">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="layout_style">start</property>
                     <child>
-                      <widget class="GtkButton" id="btnNodesUnchecked">
+                      <object class="GtkButton" id="btnNodesUnchecked">
                         <property name="label" translatable="yes">Unchecked</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
                         <property name="use_action_appearance">False</property>
-                      </widget>
+                      </object>
                       <packing>
                         <property name="expand">False</property>
                         <property name="fill">False</property>
@@ -285,27 +284,27 @@
                       </packing>
                     </child>
                     <child>
-                      <widget class="GtkButton" id="btnNodesTimeout">
+                      <object class="GtkButton" id="btnNodesTimeout">
                         <property name="label" translatable="yes">Timedout</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
                         <property name="use_action_appearance">False</property>
-                      </widget>
+                      </object>
                       <packing>
                         <property name="expand">False</property>
                         <property name="fill">False</property>
                         <property name="position">1</property>
                       </packing>
                     </child>
-                  </widget>
+                  </object>
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
                     <property name="position">2</property>
                   </packing>
                 </child>
-              </widget>
+              </object>
               <packing>
                 <property name="expand">True</property>
                 <property name="fill">True</property>
@@ -313,36 +312,36 @@
               </packing>
             </child>
             <child>
-              <widget class="GtkVBox" id="vbox1">
+              <object class="GtkVBox" id="vbox1">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <child>
-                  <widget class="GtkFrame" id="frame3">
+                  <object class="GtkFrame" id="frame3">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="label_xalign">0</property>
                     <property name="shadow_type">none</property>
                     <child>
-                      <widget class="GtkAlignment" id="alignment7">
+                      <object class="GtkAlignment" id="alignment7">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="top_padding">3</property>
                         <property name="bottom_padding">6</property>
                         <property name="left_padding">12</property>
                         <child>
-                          <widget class="GtkVBox" id="vbox2">
+                          <object class="GtkVBox" id="vbox2">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <child>
-                              <widget class="GtkHBox" id="hbox4">
+                              <object class="GtkHBox" id="hbox4">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <child>
-                                  <widget class="GtkLabel" id="label6">
+                                  <object class="GtkLabel" id="label6">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Timeout:</property>
-                                  </widget>
+                                  </object>
                                   <packing>
                                     <property name="expand">False</property>
                                     <property name="fill">True</property>
@@ -350,20 +349,20 @@
                                   </packing>
                                 </child>
                                 <child>
-                                  <widget class="GtkAlignment" id="alignment8">
+                                  <object class="GtkAlignment" id="alignment8">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="left_padding">10</property>
                                     <child>
-                                      <widget class="GtkSpinButton" id="sbTimeout">
+                                      <object class="GtkSpinButton" id="sbTimeout">
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
                                         <property name="width_chars">5</property>
-                                        <property name="adjustment">20 1 3600 1 0 0</property>
+                                        <property name="adjustment">adjustment1</property>
                                         <property name="climb_rate">1</property>
-                                      </widget>
+                                      </object>
                                     </child>
-                                  </widget>
+                                  </object>
                                   <packing>
                                     <property name="expand">False</property>
                                     <property name="fill">True</property>
@@ -371,7 +370,7 @@
                                     <property name="position">1</property>
                                   </packing>
                                 </child>
-                              </widget>
+                              </object>
                               <packing>
                                 <property name="expand">True</property>
                                 <property name="fill">True</property>
@@ -379,7 +378,7 @@
                               </packing>
                             </child>
                             <child>
-                              <widget class="GtkCheckButton" id="cbInclThms">
+                              <object class="GtkCheckButton" id="cbInclThms">
                                 <property name="label" translatable="yes">Include Theorems</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
@@ -387,7 +386,7 @@
                                 <property name="use_action_appearance">False</property>
                                 <property name="active">True</property>
                                 <property name="draw_indicator">True</property>
-                              </widget>
+                              </object>
                               <packing>
                                 <property name="expand">True</property>
                                 <property name="fill">True</property>
@@ -395,18 +394,18 @@
                               </packing>
                             </child>
                             <child>
-                              <widget class="GtkHButtonBox" id="hbuttonbox2">
+                              <object class="GtkHButtonBox" id="hbuttonbox2">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="layout_style">end</property>
                                 <child>
-                                  <widget class="GtkButton" id="btnStop">
+                                  <object class="GtkButton" id="btnStop">
                                     <property name="label" translatable="yes">Stop</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="receives_default">True</property>
                                     <property name="use_action_appearance">False</property>
-                                  </widget>
+                                  </object>
                                   <packing>
                                     <property name="expand">False</property>
                                     <property name="fill">False</property>
@@ -414,13 +413,13 @@
                                   </packing>
                                 </child>
                                 <child>
-                                  <widget class="GtkButton" id="btnCheck">
+                                  <object class="GtkButton" id="btnCheck">
                                     <property name="label" translatable="yes">Check</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="receives_default">True</property>
                                     <property name="use_action_appearance">False</property>
-                                  </widget>
+                                  </object>
                                   <packing>
                                     <property name="expand">False</property>
                                     <property name="fill">False</property>
@@ -428,29 +427,26 @@
                                     <property name="position">1</property>
                                   </packing>
                                 </child>
-                              </widget>
+                              </object>
                               <packing>
                                 <property name="expand">True</property>
                                 <property name="fill">True</property>
                                 <property name="position">2</property>
                               </packing>
                             </child>
-                          </widget>
+                          </object>
                         </child>
-                      </widget>
+                      </object>
                     </child>
-                    <child>
-                      <widget class="GtkLabel" id="label4">
+                    <child type="label">
+                      <object class="GtkLabel" id="label4">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="label" translatable="yes">Checker Configuration:</property>
                         <property name="use_markup">True</property>
-                      </widget>
-                      <packing>
-                        <property name="type">label_item</property>
-                      </packing>
+                      </object>
                     </child>
-                  </widget>
+                  </object>
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
@@ -458,20 +454,20 @@
                   </packing>
                 </child>
                 <child>
-                  <widget class="GtkFrame" id="frame6">
+                  <object class="GtkFrame" id="frame6">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="label_xalign">0</property>
                     <property name="shadow_type">none</property>
                     <child>
-                      <widget class="GtkAlignment" id="alignment4">
+                      <object class="GtkAlignment" id="alignment4">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="top_padding">3</property>
                         <property name="bottom_padding">6</property>
                         <property name="left_padding">12</property>
                         <child>
-                          <widget class="GtkLabel" id="lblSublogic">
+                          <object class="GtkLabel" id="lblSublogic">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="xalign">0</property>
@@ -480,22 +476,19 @@
                             <property name="use_markup">True</property>
                             <property name="selectable">True</property>
                             <property name="max_width_chars">30</property>
-                          </widget>
+                          </object>
                         </child>
-                      </widget>
+                      </object>
                     </child>
-                    <child>
-                      <widget class="GtkLabel" id="label5">
+                    <child type="label">
+                      <object class="GtkLabel" id="label5">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="label" translatable="yes">Sublogic of selected theories:</property>
                         <property name="use_markup">True</property>
-                      </widget>
-                      <packing>
-                        <property name="type">label_item</property>
-                      </packing>
+                      </object>
                     </child>
-                  </widget>
+                  </object>
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
@@ -503,46 +496,43 @@
                   </packing>
                 </child>
                 <child>
-                  <widget class="GtkFrame" id="frame1">
+                  <object class="GtkFrame" id="frame1">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="label_xalign">0</property>
                     <property name="shadow_type">none</property>
                     <child>
-                      <widget class="GtkAlignment" id="alignment1">
+                      <object class="GtkAlignment" id="alignment1">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="bottom_padding">6</property>
                         <property name="left_padding">6</property>
                         <child>
-                          <widget class="GtkScrolledWindow" id="scrolledwindow1">
+                          <object class="GtkScrolledWindow" id="scrolledwindow1">
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="hscrollbar_policy">automatic</property>
                             <property name="vscrollbar_policy">automatic</property>
                             <child>
-                              <widget class="GtkTreeView" id="trvFinder">
-				<property name="height_request">80</property>
+                              <object class="GtkTreeView" id="trvFinder">
+                                <property name="height_request">80</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
-                              </widget>
+                              </object>
                             </child>
-                          </widget>
+                          </object>
                         </child>
-                      </widget>
+                      </object>
                     </child>
-                    <child>
-                      <widget class="GtkLabel" id="label1">
+                    <child type="label">
+                      <object class="GtkLabel" id="label1">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="label" translatable="yes">Pick Model finder:</property>
                         <property name="use_markup">True</property>
-                      </widget>
-                      <packing>
-                        <property name="type">label_item</property>
-                      </packing>
+                      </object>
                     </child>
-                  </widget>
+                  </object>
                   <packing>
                     <property name="expand">True</property>
                     <property name="fill">True</property>
@@ -550,52 +540,49 @@
                   </packing>
                 </child>
                 <child>
-                  <widget class="GtkFrame" id="frame5">
+                  <object class="GtkFrame" id="frame5">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="label_xalign">0</property>
                     <property name="shadow_type">none</property>
                     <child>
-                      <widget class="GtkAlignment" id="alignment3">
+                      <object class="GtkAlignment" id="alignment3">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="bottom_padding">6</property>
                         <property name="left_padding">6</property>
                         <child>
-                          <widget class="GtkComboBox" id="cbComorphism">
+                          <object class="GtkComboBox" id="cbComorphism">
                             <property name="width_request">220</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                          </widget>
+                          </object>
                         </child>
-                      </widget>
+                      </object>
                     </child>
-                    <child>
-                      <widget class="GtkLabel" id="label3">
+                    <child type="label">
+                      <object class="GtkLabel" id="label3">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="label" translatable="yes">Select comorphism path:</property>
                         <property name="use_markup">True</property>
-                      </widget>
-                      <packing>
-                        <property name="type">label_item</property>
-                      </packing>
+                      </object>
                     </child>
-                  </widget>
+                  </object>
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
                     <property name="position">3</property>
                   </packing>
                 </child>
-              </widget>
+              </object>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
             </child>
-          </widget>
+          </object>
           <packing>
             <property name="expand">True</property>
             <property name="fill">True</property>
@@ -603,10 +590,10 @@
           </packing>
         </child>
         <child>
-          <widget class="GtkHSeparator" id="hseparator1">
+          <object class="GtkHSeparator" id="hseparator1">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-          </widget>
+          </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
@@ -614,18 +601,18 @@
           </packing>
         </child>
         <child>
-          <widget class="GtkHButtonBox" id="hbuttonbox1">
+          <object class="GtkHButtonBox" id="hbuttonbox1">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="layout_style">end</property>
             <child>
-              <widget class="GtkButton" id="btnResults">
+              <object class="GtkButton" id="btnResults">
                 <property name="label" translatable="yes">View results</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
                 <property name="use_action_appearance">False</property>
-              </widget>
+              </object>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">False</property>
@@ -634,27 +621,27 @@
               </packing>
             </child>
             <child>
-              <widget class="GtkButton" id="btnClose">
+              <object class="GtkButton" id="btnClose">
                 <property name="label" translatable="yes">Close</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
                 <property name="use_action_appearance">False</property>
-              </widget>
+              </object>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">False</property>
                 <property name="position">1</property>
               </packing>
             </child>
-          </widget>
+          </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
             <property name="position">2</property>
           </packing>
         </child>
-      </widget>
+      </object>
     </child>
-  </widget>
-</glade-interface>
+  </object>
+</interface>

--- a/GUI/Glade/ProverGUI.glade
+++ b/GUI/Glade/ProverGUI.glade
@@ -1,75 +1,72 @@
 <?xml version="1.0"?>
-<glade-interface>
+<interface>
   <!-- interface-requires gtk+ 2.8 -->
   <!-- interface-naming-policy project-wide -->
-  <widget class="GtkWindow" id="ProverGUI">
+  <object class="GtkWindow" id="ProverGUI">
     <child>
-      <widget class="GtkVBox" id="vbox1">
+      <object class="GtkVBox" id="vbox1">
         <property name="visible">True</property>
         <child>
-          <widget class="GtkHBox" id="hbox2">
+          <object class="GtkHBox" id="hbox2">
             <property name="visible">True</property>
             <child>
-              <widget class="GtkVBox" id="vbox3">
+              <object class="GtkVBox" id="vbox3">
                 <property name="visible">True</property>
                 <child>
-                  <widget class="GtkFrame" id="frame3">
+                  <object class="GtkFrame" id="frame3">
                     <property name="visible">True</property>
                     <property name="label_xalign">0</property>
                     <property name="shadow_type">none</property>
                     <child>
-                      <widget class="GtkAlignment" id="alignment1">
+                      <object class="GtkAlignment" id="alignment1">
                         <property name="visible">True</property>
                         <property name="top_padding">6</property>
                         <property name="bottom_padding">6</property>
                         <property name="left_padding">6</property>
                         <property name="right_padding">6</property>
                         <child>
-                          <widget class="GtkScrolledWindow" id="scrolledwindow1">
+                          <object class="GtkScrolledWindow" id="scrolledwindow1">
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="hscrollbar_policy">automatic</property>
                             <property name="vscrollbar_policy">automatic</property>
                             <child>
-                              <widget class="GtkTreeView" id="trvGoals">
+                              <object class="GtkTreeView" id="trvGoals">
                                 <property name="height_request">100</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
-                              </widget>
+                              </object>
                             </child>
-                          </widget>
+                          </object>
                         </child>
-                      </widget>
+                      </object>
                     </child>
-                    <child>
-                      <widget class="GtkLabel" id="lblGoals">
+                    <child type="label">
+                      <object class="GtkLabel" id="lblGoals">
                         <property name="visible">True</property>
                         <property name="label" translatable="yes">Goals:</property>
                         <property name="use_markup">True</property>
-                      </widget>
-                      <packing>
-                        <property name="type">label_item</property>
-                      </packing>
+                      </object>
                     </child>
-                  </widget>
+                  </object>
                   <packing>
                     <property name="position">0</property>
                   </packing>
                 </child>
                 <child>
-                  <widget class="GtkVBox" id="vbox8">
+                  <object class="GtkVBox" id="vbox8">
                     <property name="visible">True</property>
                     <child>
-                      <widget class="GtkHButtonBox" id="hbuttonbox6">
+                      <object class="GtkHButtonBox" id="hbuttonbox6">
                         <property name="visible">True</property>
                         <property name="layout_style">start</property>
                         <child>
-                          <widget class="GtkButton" id="btnGoalsAll">
+                          <object class="GtkButton" id="btnGoalsAll">
                             <property name="label" translatable="yes">All</property>
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="receives_default">True</property>
-                          </widget>
+                          </object>
                           <packing>
                             <property name="expand">False</property>
                             <property name="fill">False</property>
@@ -77,12 +74,12 @@
                           </packing>
                         </child>
                         <child>
-                          <widget class="GtkButton" id="btnGoalsNone">
+                          <object class="GtkButton" id="btnGoalsNone">
                             <property name="label" translatable="yes">None</property>
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="receives_default">True</property>
-                          </widget>
+                          </object>
                           <packing>
                             <property name="expand">False</property>
                             <property name="fill">False</property>
@@ -90,82 +87,82 @@
                           </packing>
                         </child>
                         <child>
-                          <widget class="GtkButton" id="btnGoalsInvert">
+                          <object class="GtkButton" id="btnGoalsInvert">
                             <property name="label" translatable="yes">Invert</property>
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="receives_default">True</property>
-                          </widget>
+                          </object>
                           <packing>
                             <property name="expand">False</property>
                             <property name="fill">False</property>
                             <property name="position">2</property>
                           </packing>
                         </child>
-                      </widget>
+                      </object>
                       <packing>
                         <property name="expand">False</property>
                         <property name="position">0</property>
                       </packing>
                     </child>
                     <child>
-                      <widget class="GtkHButtonBox" id="hbuttonbox7">
+                      <object class="GtkHButtonBox" id="hbuttonbox7">
                         <property name="visible">True</property>
                         <property name="layout_style">start</property>
                         <child>
-                          <widget class="GtkButton" id="btnGoalsSelectOpen">
+                          <object class="GtkButton" id="btnGoalsSelectOpen">
                             <property name="label" translatable="yes">Select open goals</property>
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="receives_default">True</property>
-                          </widget>
+                          </object>
                           <packing>
                             <property name="expand">False</property>
                             <property name="fill">False</property>
                             <property name="position">0</property>
                           </packing>
                         </child>
-                      </widget>
+                      </object>
                       <packing>
                         <property name="expand">False</property>
                         <property name="position">1</property>
                       </packing>
                     </child>
-                  </widget>
+                  </object>
                   <packing>
                     <property name="expand">False</property>
                     <property name="position">1</property>
                   </packing>
                 </child>
-              </widget>
+              </object>
               <packing>
                 <property name="position">0</property>
               </packing>
             </child>
             <child>
-              <widget class="GtkVBox" id="vbox4">
+              <object class="GtkVBox" id="vbox4">
                 <property name="visible">True</property>
                 <child>
-                  <widget class="GtkFrame" id="frame2">
+                  <object class="GtkFrame" id="frame2">
                     <property name="visible">True</property>
                     <property name="label_xalign">0</property>
                     <property name="shadow_type">none</property>
                     <child>
-                      <widget class="GtkAlignment" id="alignment2">
+                      <object class="GtkAlignment" id="alignment2">
                         <property name="visible">True</property>
                         <property name="top_padding">3</property>
                         <property name="bottom_padding">6</property>
                         <property name="left_padding">6</property>
                         <child>
-                          <widget class="GtkHBox" id="hbox1">
+                          <object class="GtkHBox" id="hbox1">
                             <property name="visible">True</property>
                             <child>
-                              <widget class="GtkButton" id="btnDisplay">
+                              <object class="GtkButton" id="btnDisplay">
                                 <property name="label" translatable="yes">Display</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">True</property>
-                              </widget>
+                              </object>
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">False</property>
@@ -174,12 +171,12 @@
                               </packing>
                             </child>
                             <child>
-                              <widget class="GtkButton" id="btnProofDetails">
+                              <object class="GtkButton" id="btnProofDetails">
                                 <property name="label" translatable="yes">Proof details</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">True</property>
-                              </widget>
+                              </object>
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">False</property>
@@ -188,12 +185,12 @@
                               </packing>
                             </child>
                             <child>
-                              <widget class="GtkButton" id="btnProve">
+                              <object class="GtkButton" id="btnProve">
                                 <property name="label" translatable="yes">Prove</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">True</property>
-                              </widget>
+                              </object>
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">False</property>
@@ -201,21 +198,18 @@
                                 <property name="position">0</property>
                               </packing>
                             </child>
-                          </widget>
+                          </object>
                         </child>
-                      </widget>
+                      </object>
                     </child>
-                    <child>
-                      <widget class="GtkLabel" id="label3">
+                    <child type="label">
+                      <object class="GtkLabel" id="label3">
                         <property name="visible">True</property>
                         <property name="label" translatable="yes">Selected goal(s):</property>
                         <property name="use_markup">True</property>
-                      </widget>
-                      <packing>
-                        <property name="type">label_item</property>
-                      </packing>
+                      </object>
                     </child>
-                  </widget>
+                  </object>
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">False</property>
@@ -223,39 +217,36 @@
                   </packing>
                 </child>
                 <child>
-                  <widget class="GtkFrame" id="frame1">
+                  <object class="GtkFrame" id="frame1">
                     <property name="visible">True</property>
                     <property name="label_xalign">0</property>
                     <property name="shadow_type">none</property>
                     <child>
-                      <widget class="GtkAlignment" id="alignment4">
+                      <object class="GtkAlignment" id="alignment4">
                         <property name="visible">True</property>
                         <property name="top_padding">3</property>
                         <property name="bottom_padding">6</property>
                         <property name="left_padding">12</property>
                         <child>
-                          <widget class="GtkLabel" id="lblSublogic">
+                          <object class="GtkLabel" id="lblSublogic">
                             <property name="visible">True</property>
                             <property name="xalign">0</property>
                             <property name="yalign">0</property>
                             <property name="label" translatable="yes">No sublogic given</property>
                             <property name="use_markup">True</property>
                             <property name="selectable">True</property>
-                          </widget>
+                          </object>
                         </child>
-                      </widget>
+                      </object>
                     </child>
-                    <child>
-                      <widget class="GtkLabel" id="label5">
+                    <child type="label">
+                      <object class="GtkLabel" id="label5">
                         <property name="visible">True</property>
                         <property name="label" translatable="yes">Sublogic of currently selected theory:</property>
                         <property name="use_markup">True</property>
-                      </widget>
-                      <packing>
-                        <property name="type">label_item</property>
-                      </packing>
+                      </object>
                     </child>
-                  </widget>
+                  </object>
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">False</property>
@@ -263,98 +254,92 @@
                   </packing>
                 </child>
                 <child>
-                  <widget class="GtkFrame" id="frame4">
+                  <object class="GtkFrame" id="frame4">
                     <property name="visible">True</property>
                     <property name="label_xalign">0</property>
                     <property name="shadow_type">none</property>
                     <child>
-                      <widget class="GtkAlignment" id="alignment5">
+                      <object class="GtkAlignment" id="alignment5">
                         <property name="visible">True</property>
                         <property name="top_padding">3</property>
                         <property name="bottom_padding">6</property>
                         <property name="left_padding">6</property>
                         <child>
-                          <widget class="GtkScrolledWindow" id="scrolledwindow2">
+                          <object class="GtkScrolledWindow" id="scrolledwindow2">
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="hscrollbar_policy">automatic</property>
                             <property name="vscrollbar_policy">automatic</property>
                             <child>
-                              <widget class="GtkTreeView" id="trvProvers">
+                              <object class="GtkTreeView" id="trvProvers">
                                 <property name="height_request">100</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
-                              </widget>
+                              </object>
                             </child>
-                          </widget>
+                          </object>
                         </child>
-                      </widget>
+                      </object>
                     </child>
-                    <child>
-                      <widget class="GtkLabel" id="label2">
+                    <child type="label">
+                      <object class="GtkLabel" id="label2">
                         <property name="visible">True</property>
                         <property name="label" translatable="yes">Pick theorem prover:</property>
                         <property name="use_markup">True</property>
-                      </widget>
-                      <packing>
-                        <property name="type">label_item</property>
-                      </packing>
+                      </object>
                     </child>
-                  </widget>
+                  </object>
                   <packing>
                     <property name="position">2</property>
                   </packing>
                 </child>
                 <child>
-                  <widget class="GtkFrame" id="frame5">
+                  <object class="GtkFrame" id="frame5">
                     <property name="visible">True</property>
                     <property name="label_xalign">0</property>
                     <property name="shadow_type">none</property>
                     <child>
-                      <widget class="GtkAlignment" id="alignment3">
+                      <object class="GtkAlignment" id="alignment3">
                         <property name="visible">True</property>
                         <property name="bottom_padding">6</property>
                         <property name="left_padding">6</property>
                         <child>
-                          <widget class="GtkComboBox" id="cbComorphism">
+                          <object class="GtkComboBox" id="cbComorphism">
                             <property name="width_request">220</property>
                             <property name="visible">True</property>
-                          </widget>
+                          </object>
                         </child>
-                      </widget>
+                      </object>
                     </child>
-                    <child>
-                      <widget class="GtkLabel" id="label1">
+                    <child type="label">
+                      <object class="GtkLabel" id="label1">
                         <property name="visible">True</property>
                         <property name="label" translatable="yes">Selected comorphism path:</property>
                         <property name="use_markup">True</property>
-                      </widget>
-                      <packing>
-                        <property name="type">label_item</property>
-                      </packing>
+                      </object>
                     </child>
-                  </widget>
+                  </object>
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">False</property>
                     <property name="position">3</property>
                   </packing>
                 </child>
-              </widget>
+              </object>
               <packing>
                 <property name="expand">False</property>
                 <property name="position">1</property>
               </packing>
             </child>
-          </widget>
+          </object>
           <packing>
             <property name="position">0</property>
           </packing>
         </child>
         <child>
-          <widget class="GtkHSeparator" id="hseparator1">
+          <object class="GtkHSeparator" id="hseparator1">
             <property name="visible">True</property>
-          </widget>
+          </object>
           <packing>
             <property name="expand">False</property>
             <property name="padding">3</property>
@@ -362,82 +347,79 @@
           </packing>
         </child>
         <child>
-          <widget class="GtkVBox" id="vbox5">
+          <object class="GtkVBox" id="vbox5">
             <property name="visible">True</property>
             <child>
-              <widget class="GtkLabel" id="label4">
+              <object class="GtkLabel" id="label4">
                 <property name="visible">True</property>
                 <property name="label" translatable="yes">Fine grained composition of theory</property>
                 <property name="use_markup">True</property>
-              </widget>
+              </object>
               <packing>
                 <property name="expand">False</property>
                 <property name="position">0</property>
               </packing>
             </child>
             <child>
-              <widget class="GtkHBox" id="hbox3">
+              <object class="GtkHBox" id="hbox3">
                 <property name="visible">True</property>
                 <child>
-                  <widget class="GtkVBox" id="vbox2">
+                  <object class="GtkVBox" id="vbox2">
                     <property name="visible">True</property>
                     <child>
-                      <widget class="GtkFrame" id="frame6">
+                      <object class="GtkFrame" id="frame6">
                         <property name="visible">True</property>
                         <property name="label_xalign">0</property>
                         <property name="shadow_type">none</property>
                         <child>
-                          <widget class="GtkAlignment" id="alignment7">
+                          <object class="GtkAlignment" id="alignment7">
                             <property name="visible">True</property>
                             <property name="top_padding">3</property>
                             <property name="bottom_padding">6</property>
                             <property name="left_padding">6</property>
                             <child>
-                              <widget class="GtkScrolledWindow" id="scrolledwindow3">
+                              <object class="GtkScrolledWindow" id="scrolledwindow3">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="hscrollbar_policy">automatic</property>
                                 <property name="vscrollbar_policy">automatic</property>
                                 <child>
-                                  <widget class="GtkTreeView" id="trvAxioms">
+                                  <object class="GtkTreeView" id="trvAxioms">
                                     <property name="height_request">100</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
-                                  </widget>
+                                  </object>
                                 </child>
-                              </widget>
+                              </object>
                             </child>
-                          </widget>
+                          </object>
                         </child>
-                        <child>
-                          <widget class="GtkLabel" id="lblGoals2">
+                        <child type="label">
+                          <object class="GtkLabel" id="lblGoals2">
                             <property name="visible">True</property>
                             <property name="label" translatable="yes">Axioms to include:</property>
                             <property name="use_markup">True</property>
-                          </widget>
-                          <packing>
-                            <property name="type">label_item</property>
-                          </packing>
+                          </object>
                         </child>
-                      </widget>
+                      </object>
                       <packing>
                         <property name="position">0</property>
                       </packing>
                     </child>
                     <child>
-                      <widget class="GtkVBox" id="vbox7">
+                      <object class="GtkVBox" id="vbox7">
                         <property name="visible">True</property>
                         <child>
-                          <widget class="GtkHButtonBox" id="hbuttonbox4">
+                          <object class="GtkHButtonBox" id="hbuttonbox4">
                             <property name="visible">True</property>
                             <property name="layout_style">start</property>
                             <child>
-                              <widget class="GtkButton" id="btnAxiomsAll">
+                              <object class="GtkButton" id="btnAxiomsAll">
                                 <property name="label" translatable="yes">All</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">True</property>
-                              </widget>
+                              </object>
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">False</property>
@@ -445,12 +427,12 @@
                               </packing>
                             </child>
                             <child>
-                              <widget class="GtkButton" id="btnAxiomsNone">
+                              <object class="GtkButton" id="btnAxiomsNone">
                                 <property name="label" translatable="yes">None</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">True</property>
-                              </widget>
+                              </object>
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">False</property>
@@ -458,115 +440,112 @@
                               </packing>
                             </child>
                             <child>
-                              <widget class="GtkButton" id="btnAxiomsInvert">
+                              <object class="GtkButton" id="btnAxiomsInvert">
                                 <property name="label" translatable="yes">Invert</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">True</property>
-                              </widget>
+                              </object>
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">False</property>
                                 <property name="position">2</property>
                               </packing>
                             </child>
-                          </widget>
+                          </object>
                           <packing>
                             <property name="expand">False</property>
                             <property name="position">0</property>
                           </packing>
                         </child>
                         <child>
-                          <widget class="GtkHButtonBox" id="hbuttonbox5">
+                          <object class="GtkHButtonBox" id="hbuttonbox5">
                             <property name="visible">True</property>
                             <property name="layout_style">start</property>
                             <child>
-                              <widget class="GtkButton" id="btnAxiomsFormer">
+                              <object class="GtkButton" id="btnAxiomsFormer">
                                 <property name="label" translatable="yes">Deselect former theorems</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">True</property>
-                              </widget>
+                              </object>
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">False</property>
                                 <property name="position">0</property>
                               </packing>
                             </child>
-                          </widget>
+                          </object>
                           <packing>
                             <property name="expand">False</property>
                             <property name="position">1</property>
                           </packing>
                         </child>
-                      </widget>
+                      </object>
                       <packing>
                         <property name="expand">False</property>
                         <property name="position">1</property>
                       </packing>
                     </child>
-                  </widget>
+                  </object>
                   <packing>
                     <property name="position">0</property>
                   </packing>
                 </child>
                 <child>
-                  <widget class="GtkVBox" id="vbox6">
+                  <object class="GtkVBox" id="vbox6">
                     <property name="visible">True</property>
                     <child>
-                      <widget class="GtkFrame" id="frame7">
+                      <object class="GtkFrame" id="frame7">
                         <property name="visible">True</property>
                         <property name="label_xalign">0</property>
                         <property name="shadow_type">none</property>
                         <child>
-                          <widget class="GtkAlignment" id="alignment8">
+                          <object class="GtkAlignment" id="alignment8">
                             <property name="visible">True</property>
                             <property name="top_padding">3</property>
                             <property name="bottom_padding">6</property>
                             <property name="left_padding">6</property>
                             <child>
-                              <widget class="GtkScrolledWindow" id="scrolledwindow4">
+                              <object class="GtkScrolledWindow" id="scrolledwindow4">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="hscrollbar_policy">automatic</property>
                                 <property name="vscrollbar_policy">automatic</property>
                                 <child>
-                                  <widget class="GtkTreeView" id="trvTheorems">
+                                  <object class="GtkTreeView" id="trvTheorems">
                                     <property name="height_request">100</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
-                                  </widget>
+                                  </object>
                                 </child>
-                              </widget>
+                              </object>
                             </child>
-                          </widget>
+                          </object>
                         </child>
-                        <child>
-                          <widget class="GtkLabel" id="lblGoals1">
+                        <child type="label">
+                          <object class="GtkLabel" id="lblGoals1">
                             <property name="visible">True</property>
                             <property name="label" translatable="yes">Theorems to include if proven:</property>
                             <property name="use_markup">True</property>
-                          </widget>
-                          <packing>
-                            <property name="type">label_item</property>
-                          </packing>
+                          </object>
                         </child>
-                      </widget>
+                      </object>
                       <packing>
                         <property name="position">0</property>
                       </packing>
                     </child>
                     <child>
-                      <widget class="GtkHButtonBox" id="hbuttonbox8">
+                      <object class="GtkHButtonBox" id="hbuttonbox8">
                         <property name="visible">True</property>
                         <property name="layout_style">start</property>
                         <child>
-                          <widget class="GtkButton" id="btnTheoremsAll">
+                          <object class="GtkButton" id="btnTheoremsAll">
                             <property name="label" translatable="yes">All</property>
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="receives_default">True</property>
-                          </widget>
+                          </object>
                           <packing>
                             <property name="expand">False</property>
                             <property name="fill">False</property>
@@ -574,12 +553,12 @@
                           </packing>
                         </child>
                         <child>
-                          <widget class="GtkButton" id="btnTheoremsNone">
+                          <object class="GtkButton" id="btnTheoremsNone">
                             <property name="label" translatable="yes">None</property>
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="receives_default">True</property>
-                          </widget>
+                          </object>
                           <packing>
                             <property name="expand">False</property>
                             <property name="fill">False</property>
@@ -587,43 +566,43 @@
                           </packing>
                         </child>
                         <child>
-                          <widget class="GtkButton" id="btnTheoremsInvert">
+                          <object class="GtkButton" id="btnTheoremsInvert">
                             <property name="label" translatable="yes">Invert</property>
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="receives_default">True</property>
-                          </widget>
+                          </object>
                           <packing>
                             <property name="expand">False</property>
                             <property name="fill">False</property>
                             <property name="position">2</property>
                           </packing>
                         </child>
-                      </widget>
+                      </object>
                       <packing>
                         <property name="expand">False</property>
                         <property name="position">1</property>
                       </packing>
                     </child>
-                  </widget>
+                  </object>
                   <packing>
                     <property name="position">1</property>
                   </packing>
                 </child>
-              </widget>
+              </object>
               <packing>
                 <property name="position">1</property>
               </packing>
             </child>
-          </widget>
+          </object>
           <packing>
             <property name="position">2</property>
           </packing>
         </child>
         <child>
-          <widget class="GtkHSeparator" id="hseparator2">
+          <object class="GtkHSeparator" id="hseparator2">
             <property name="visible">True</property>
-          </widget>
+          </object>
           <packing>
             <property name="expand">False</property>
             <property name="padding">3</property>
@@ -631,20 +610,20 @@
           </packing>
         </child>
         <child>
-          <widget class="GtkHBox" id="hbox4">
+          <object class="GtkHBox" id="hbox4">
             <property name="visible">True</property>
             <child>
-              <widget class="GtkHButtonBox" id="hbuttonbox2">
+              <object class="GtkHButtonBox" id="hbuttonbox2">
                 <property name="visible">True</property>
                 <property name="spacing">5</property>
                 <property name="layout_style">start</property>
                 <child>
-                  <widget class="GtkButton" id="btnShowTheory">
+                  <object class="GtkButton" id="btnShowTheory">
                     <property name="label" translatable="yes">Show theory</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
-                  </widget>
+                  </object>
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">False</property>
@@ -652,56 +631,56 @@
                   </packing>
                 </child>
                 <child>
-                  <widget class="GtkButton" id="btnShowSelected">
+                  <object class="GtkButton" id="btnShowSelected">
                     <property name="label" translatable="yes">Show selected theory</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
-                  </widget>
+                  </object>
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">False</property>
                     <property name="position">1</property>
                   </packing>
                 </child>
-              </widget>
+              </object>
               <packing>
                 <property name="expand">False</property>
                 <property name="position">0</property>
               </packing>
             </child>
             <child>
-              <widget class="GtkHButtonBox" id="hbuttonbox1">
+              <object class="GtkHButtonBox" id="hbuttonbox1">
                 <property name="visible">True</property>
                 <property name="spacing">5</property>
                 <property name="layout_style">end</property>
                 <child>
-                  <widget class="GtkButton" id="btnClose">
+                  <object class="GtkButton" id="btnClose">
                     <property name="label" translatable="yes">Close</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
-                  </widget>
+                  </object>
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">False</property>
                     <property name="position">0</property>
                   </packing>
                 </child>
-              </widget>
+              </object>
               <packing>
                 <property name="expand">False</property>
                 <property name="pack_type">end</property>
                 <property name="position">1</property>
               </packing>
             </child>
-          </widget>
+          </object>
           <packing>
             <property name="expand">False</property>
             <property name="position">4</property>
           </packing>
         </child>
-      </widget>
+      </object>
     </child>
-  </widget>
-</glade-interface>
+  </object>
+</interface>

--- a/GUI/Glade/TextField.glade
+++ b/GUI/Glade/TextField.glade
@@ -1,42 +1,42 @@
 <?xml version="1.0"?>
-<glade-interface>
+<interface>
   <!-- interface-requires gtk+ 2.8 -->
   <!-- interface-naming-policy toplevel-contextual -->
-  <widget class="GtkWindow" id="TextField">
+  <object class="GtkWindow" id="TextField">
     <property name="default_width">500</property>
     <property name="default_height">60</property>
     <child>
-      <widget class="GtkVBox" id="vbox1">
+      <object class="GtkVBox" id="vbox1">
         <property name="visible">True</property>
         <child>
-          <widget class="GtkEntry" id="entry">
+          <object class="GtkEntry" id="entry">
             <property name="visible">True</property>
             <property name="can_focus">True</property>
-          </widget>
+          </object>
         </child>
         <child>
-          <widget class="GtkHButtonBox" id="hbuttonbox1">
+          <object class="GtkHButtonBox" id="hbuttonbox1">
             <property name="visible">True</property>
             <property name="layout_style">end</property>
             <child>
-              <widget class="GtkButton" id="abort">
+              <object class="GtkButton" id="abort">
                 <property name="label">Abort</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-              </widget>
+              </object>
             </child>
             <child>
-              <widget class="GtkButton" id="add">
+              <object class="GtkButton" id="add">
                 <property name="label">Add</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-              </widget>
+              </object>
             </child>
-          </widget>
+          </object>
         </child>
-      </widget>
+      </object>
     </child>
-  </widget>
-</glade-interface>
+  </object>
+</interface>

--- a/GUI/Glade/Utils.glade
+++ b/GUI/Glade/Utils.glade
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
-<glade-interface>
+<interface>
   <!-- interface-requires gtk+ 2.16 -->
   <!-- interface-naming-policy toplevel-contextual -->
-  <widget class="GtkDialog" id="ListView">
+  <object class="GtkDialog" id="ListView">
     <property name="border_width">5</property>
     <property name="window_position">center-on-parent</property>
     <property name="default_width">800</property>
@@ -10,29 +10,29 @@
     <property name="type_hint">dialog</property>
     <property name="has_separator">False</property>
     <child internal-child="vbox">
-      <widget class="GtkVBox" id="dialog-vbox1">
+      <object class="GtkVBox" id="dialog-vbox1">
         <property name="visible">True</property>
         <property name="spacing">2</property>
         <child>
-          <widget class="GtkScrolledWindow" id="scrolledwindow2">
+          <object class="GtkScrolledWindow" id="scrolledwindow2">
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="hscrollbar_policy">automatic</property>
             <property name="vscrollbar_policy">automatic</property>
             <child>
-              <widget class="GtkTreeView" id="trvList">
+              <object class="GtkTreeView" id="trvList">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="enable_grid_lines">horizontal</property>
-              </widget>
+              </object>
             </child>
-          </widget>
+          </object>
           <packing>
             <property name="position">1</property>
           </packing>
         </child>
         <child internal-child="action_area">
-          <widget class="GtkHButtonBox" id="dialog-action_area1">
+          <object class="GtkHButtonBox" id="dialog-action_area1">
             <property name="visible">True</property>
             <property name="layout_style">end</property>
             <child>
@@ -41,17 +41,17 @@
             <child>
               <placeholder/>
             </child>
-          </widget>
+          </object>
           <packing>
             <property name="expand">False</property>
             <property name="pack_type">end</property>
             <property name="position">0</property>
           </packing>
         </child>
-      </widget>
+      </object>
     </child>
-  </widget>
-  <widget class="GtkDialog" id="TextView">
+  </object>
+  <object class="GtkDialog" id="TextView">
     <property name="border_width">5</property>
     <property name="window_position">center-on-parent</property>
     <property name="default_width">600</property>
@@ -59,29 +59,29 @@
     <property name="type_hint">dialog</property>
     <property name="has_separator">False</property>
     <child internal-child="vbox">
-      <widget class="GtkVBox" id="dialog-vbox2">
+      <object class="GtkVBox" id="dialog-vbox2">
         <property name="visible">True</property>
         <property name="spacing">2</property>
         <child>
-          <widget class="GtkScrolledWindow" id="scrolledwindow1">
+          <object class="GtkScrolledWindow" id="scrolledwindow1">
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="hscrollbar_policy">automatic</property>
             <property name="vscrollbar_policy">automatic</property>
             <child>
-              <widget class="GtkTextView" id="tvText">
+              <object class="GtkTextView" id="tvText">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="editable">False</property>
-              </widget>
+              </object>
             </child>
-          </widget>
+          </object>
           <packing>
             <property name="position">1</property>
           </packing>
         </child>
         <child internal-child="action_area">
-          <widget class="GtkHButtonBox" id="dialog-action_area2">
+          <object class="GtkHButtonBox" id="dialog-action_area2">
             <property name="visible">True</property>
             <property name="layout_style">end</property>
             <child>
@@ -90,27 +90,27 @@
             <child>
               <placeholder/>
             </child>
-          </widget>
+          </object>
           <packing>
             <property name="expand">False</property>
             <property name="pack_type">end</property>
             <property name="position">0</property>
           </packing>
         </child>
-      </widget>
+      </object>
     </child>
-  </widget>
-  <widget class="GtkWindow" id="ProgressBar">
+  </object>
+  <object class="GtkWindow" id="ProgressBar">
     <property name="default_width">300</property>
     <property name="default_height">40</property>
     <property name="deletable">False</property>
     <child>
-      <widget class="GtkProgressBar" id="pbProgress">
+      <object class="GtkProgressBar" id="pbProgress">
         <property name="visible">True</property>
         <property name="show_text">True</property>
         <property name="text" translatable="yes">Description</property>
         <property name="discrete_blocks">100</property>
-      </widget>
+      </object>
     </child>
-  </widget>
-</glade-interface>
+  </object>
+</interface>

--- a/GUI/GtkAddSentence.hs
+++ b/GUI/GtkAddSentence.hs
@@ -14,7 +14,6 @@ This module provides a GUI to add a sentence
 module GUI.GtkAddSentence where
 
 import Graphics.UI.Gtk
-import Graphics.UI.Gtk.Glade
 
 import GUI.GtkUtils
 import qualified GUI.Glade.TextField as TextField
@@ -34,12 +33,12 @@ import Data.IORef
 
 gtkAddSentence :: GInfo -> Int -> DGraph -> IO ()
 gtkAddSentence gi n dg = postGUIAsync $ do
-  xml <- getGladeXML TextField.get
+  builder <- getGTKBuilder TextField.get
   -- get objects
-  window <- xmlGetWidget xml castToWindow "TextField"
-  btnAbort <- xmlGetWidget xml castToButton "abort"
-  btnAdd <- xmlGetWidget xml castToButton "add"
-  entry <- xmlGetWidget xml castToEntry "entry"
+  window <- builderGetObject builder castToWindow "TextField"
+  btnAbort <- builderGetObject builder castToButton "abort"
+  btnAdd <- builderGetObject builder castToButton "add"
+  entry <- builderGetObject builder castToEntry "entry"
   let lbl = labDG dg n
       name = getDGNodeName lbl
   windowSetTitle window $ "Add sentence to " ++ name

--- a/GUI/GtkAutomaticProofs.hs
+++ b/GUI/GtkAutomaticProofs.hs
@@ -16,7 +16,6 @@ module GUI.GtkAutomaticProofs
   where
 
 import Graphics.UI.Gtk
-import Graphics.UI.Gtk.Glade
 
 import qualified GUI.Glade.NodeChecker as ConsistencyChecker
 import GUI.GraphTypes
@@ -75,28 +74,28 @@ showAutomaticProofs ginf@(GInfo { libName = ln }) le = do
 -- | Displays the consistency checker window
 showProverWindow :: GInfo -> MVar LibEnv -> LibName -> LibEnv -> IO ()
 showProverWindow ginf res ln le = postGUIAsync $ do
-  xml <- getGladeXML ConsistencyChecker.get
+  builder <- getGTKBuilder ConsistencyChecker.get
   -- get objects
-  window <- xmlGetWidget xml castToWindow "NodeChecker"
-  btnClose <- xmlGetWidget xml castToButton "btnClose"
-  btnResults <- xmlGetWidget xml castToButton "btnResults"
+  window <- builderGetObject builder castToWindow "NodeChecker"
+  btnClose <- builderGetObject builder castToButton "btnClose"
+  btnResults <- builderGetObject builder castToButton "btnResults"
   -- get nodes view and buttons
-  trvNodes <- xmlGetWidget xml castToTreeView "trvNodes"
-  btnNodesAll <- xmlGetWidget xml castToButton "btnNodesAll"
-  btnNodesNone <- xmlGetWidget xml castToButton "btnNodesNone"
-  btnNodesInvert <- xmlGetWidget xml castToButton "btnNodesInvert"
-  btnNodesUnchecked <- xmlGetWidget xml castToButton "btnNodesUnchecked"
-  btnNodesTimeout <- xmlGetWidget xml castToButton "btnNodesTimeout"
-  cbInclThms <- xmlGetWidget xml castToCheckButton "cbInclThms"
+  trvNodes <- builderGetObject builder castToTreeView "trvNodes"
+  btnNodesAll <- builderGetObject builder castToButton "btnNodesAll"
+  btnNodesNone <- builderGetObject builder castToButton "btnNodesNone"
+  btnNodesInvert <- builderGetObject builder castToButton "btnNodesInvert"
+  btnNodesUnchecked <- builderGetObject builder castToButton "btnNodesUnchecked"
+  btnNodesTimeout <- builderGetObject builder castToButton "btnNodesTimeout"
+  cbInclThms <- builderGetObject builder castToCheckButton "cbInclThms"
   -- get checker view and buttons
-  cbComorphism <- xmlGetWidget xml castToComboBox "cbComorphism"
-  lblSublogic <- xmlGetWidget xml castToLabel "lblSublogic"
-  sbTimeout <- xmlGetWidget xml castToSpinButton "sbTimeout"
-  btnCheck <- xmlGetWidget xml castToButton "btnCheck"
-  btnStop <- xmlGetWidget xml castToButton "btnStop"
-  -- btnFineGrained    <- xmlGetWidget xml castToButton "btnFineGrained"
-  trvFinder <- xmlGetWidget xml castToTreeView "trvFinder"
-  toolLabel <- xmlGetWidget xml castToLabel "label1"
+  cbComorphism <- builderGetObject builder castToComboBox "cbComorphism"
+  lblSublogic <- builderGetObject builder castToLabel "lblSublogic"
+  sbTimeout <- builderGetObject builder castToSpinButton "sbTimeout"
+  btnCheck <- builderGetObject builder castToButton "btnCheck"
+  btnStop <- builderGetObject builder castToButton "btnStop"
+  -- btnFineGrained    <- builderGetObject builder castToButton "btnFineGrained"
+  trvFinder <- builderGetObject builder castToTreeView "trvFinder"
+  toolLabel <- builderGetObject builder castToLabel "label1"
   labelSetLabel toolLabel "Pick prover"
   windowSetTitle window "AutomaticProofs"
   spinButtonSetValue sbTimeout $ fromIntegral guiDefaultTimeLimit
@@ -351,13 +350,13 @@ setSelectedComorphism view list cbComorphism = do
 showModelViewAux :: MVar (IO ()) -> String -> ListStore FNode -> [FNode]
                  -> IO ()
 showModelViewAux lock title list other = do
-  xml <- getGladeXML ConsistencyChecker.get
+  builder <- getGTKBuilder ConsistencyChecker.get
   -- get objects
-  window <- xmlGetWidget xml castToWindow "ModelView"
-  btnClose <- xmlGetWidget xml castToButton "btnResClose"
-  frNodes <- xmlGetWidget xml castToFrame "frResNodes"
-  trvNodes <- xmlGetWidget xml castToTreeView "trvResNodes"
-  tvModel <- xmlGetWidget xml castToTextView "tvResModel"
+  window <- builderGetObject builder castToWindow "ModelView"
+  btnClose <- builderGetObject builder castToButton "btnResClose"
+  frNodes <- builderGetObject builder castToFrame "frResNodes"
+  trvNodes <- builderGetObject builder castToTreeView "trvResNodes"
+  tvModel <- builderGetObject builder castToTextView "tvResModel"
 
   windowSetTitle window title
 

--- a/GUI/GtkConsistencyChecker.hs
+++ b/GUI/GtkConsistencyChecker.hs
@@ -14,7 +14,6 @@ This module provides a GUI for the consistency checker.
 module GUI.GtkConsistencyChecker where
 
 import Graphics.UI.Gtk
-import Graphics.UI.Gtk.Glade
 
 import GUI.GtkUtils
 import qualified GUI.Glade.NodeChecker as ConsistencyChecker
@@ -107,26 +106,26 @@ showConsistencyCheckerMain mn (GInfo { libName = ln }) le = do
 showConsistencyCheckerAux
   :: MVar LibEnv -> Maybe Int -> LibName -> LibEnv -> IO ()
 showConsistencyCheckerAux res mn ln le = postGUIAsync $ do
-  xml <- getGladeXML ConsistencyChecker.get
+  builder <- getGTKBuilder ConsistencyChecker.get
   -- get objects
-  window <- xmlGetWidget xml castToWindow "NodeChecker"
-  btnClose <- xmlGetWidget xml castToButton "btnClose"
-  btnResults <- xmlGetWidget xml castToButton "btnResults"
+  window <- builderGetObject builder castToWindow "NodeChecker"
+  btnClose <- builderGetObject builder castToButton "btnClose"
+  btnResults <- builderGetObject builder castToButton "btnResults"
   -- get nodes view and buttons
-  trvNodes <- xmlGetWidget xml castToTreeView "trvNodes"
-  btnNodesAll <- xmlGetWidget xml castToButton "btnNodesAll"
-  btnNodesNone <- xmlGetWidget xml castToButton "btnNodesNone"
-  btnNodesInvert <- xmlGetWidget xml castToButton "btnNodesInvert"
-  btnNodesUnchecked <- xmlGetWidget xml castToButton "btnNodesUnchecked"
-  btnNodesTimeout <- xmlGetWidget xml castToButton "btnNodesTimeout"
-  cbInclThms <- xmlGetWidget xml castToCheckButton "cbInclThms"
+  trvNodes <- builderGetObject builder castToTreeView "trvNodes"
+  btnNodesAll <- builderGetObject builder castToButton "btnNodesAll"
+  btnNodesNone <- builderGetObject builder castToButton "btnNodesNone"
+  btnNodesInvert <- builderGetObject builder castToButton "btnNodesInvert"
+  btnNodesUnchecked <- builderGetObject builder castToButton "btnNodesUnchecked"
+  btnNodesTimeout <- builderGetObject builder castToButton "btnNodesTimeout"
+  cbInclThms <- builderGetObject builder castToCheckButton "cbInclThms"
   -- get checker view and buttons
-  cbComorphism <- xmlGetWidget xml castToComboBox "cbComorphism"
-  lblSublogic <- xmlGetWidget xml castToLabel "lblSublogic"
-  sbTimeout <- xmlGetWidget xml castToSpinButton "sbTimeout"
-  btnCheck <- xmlGetWidget xml castToButton "btnCheck"
-  btnStop <- xmlGetWidget xml castToButton "btnStop"
-  trvFinder <- xmlGetWidget xml castToTreeView "trvFinder"
+  cbComorphism <- builderGetObject builder castToComboBox "cbComorphism"
+  lblSublogic <- builderGetObject builder castToLabel "lblSublogic"
+  sbTimeout <- builderGetObject builder castToSpinButton "sbTimeout"
+  btnCheck <- builderGetObject builder castToButton "btnCheck"
+  btnStop <- builderGetObject builder castToButton "btnStop"
+  trvFinder <- builderGetObject builder castToTreeView "trvFinder"
 
   windowSetTitle window "Consistency Checker"
   spinButtonSetValue sbTimeout $ fromIntegral guiDefaultTimeLimit
@@ -360,13 +359,13 @@ setSelectedComorphism view list cbComorphism = do
 showModelViewAux :: MVar (IO ()) -> String -> ListStore FNode -> [FNode]
                  -> IO ()
 showModelViewAux lock title list other = do
-  xml <- getGladeXML ConsistencyChecker.get
+  builder <- getGTKBuilder ConsistencyChecker.get
   -- get objects
-  window <- xmlGetWidget xml castToWindow "ModelView"
-  btnClose <- xmlGetWidget xml castToButton "btnResClose"
-  frNodes <- xmlGetWidget xml castToFrame "frResNodes"
-  trvNodes <- xmlGetWidget xml castToTreeView "trvResNodes"
-  tvModel <- xmlGetWidget xml castToTextView "tvResModel"
+  window <- builderGetObject builder castToWindow "ModelView"
+  btnClose <- builderGetObject builder castToButton "btnResClose"
+  frNodes <- builderGetObject builder castToFrame "frResNodes"
+  trvNodes <- builderGetObject builder castToTreeView "trvResNodes"
+  tvModel <- builderGetObject builder castToTextView "tvResModel"
 
   windowSetTitle window title
 

--- a/GUI/GtkDisprove.hs
+++ b/GUI/GtkDisprove.hs
@@ -15,7 +15,6 @@ theorems.
 module GUI.GtkDisprove (disproveAtNode) where
 
 import Graphics.UI.Gtk
-import Graphics.UI.Gtk.Glade
 
 import GUI.GtkUtils
 import qualified GUI.Glade.NodeChecker as ConsistencyChecker
@@ -140,27 +139,27 @@ and holds the functionality to call the ConsistencyChecker for the
 showDisproveWindow :: MVar (Result G_theory) -> LibName -> LibEnv
                    -> DGraph -> G_theory -> [FNode] -> IO ()
 showDisproveWindow res ln le dg g_th fgoals = postGUIAsync $ do
-  xml <- getGladeXML ConsistencyChecker.get
+  builder <- getGTKBuilder ConsistencyChecker.get
   -- get objects
-  window <- xmlGetWidget xml castToWindow "NodeChecker"
-  btnClose <- xmlGetWidget xml castToButton "btnClose"
-  btnResults <- xmlGetWidget xml castToButton "btnResults"
+  window <- builderGetObject builder castToWindow "NodeChecker"
+  btnClose <- builderGetObject builder castToButton "btnClose"
+  btnResults <- builderGetObject builder castToButton "btnResults"
   -- get goals view and buttons
-  trvGoals <- xmlGetWidget xml castToTreeView "trvNodes"
-  btnNodesAll <- xmlGetWidget xml castToButton "btnNodesAll"
-  btnNodesNone <- xmlGetWidget xml castToButton "btnNodesNone"
-  btnNodesInvert <- xmlGetWidget xml castToButton "btnNodesInvert"
-  btnNodesUnchecked <- xmlGetWidget xml castToButton "btnNodesUnchecked"
-  btnNodesTimeout <- xmlGetWidget xml castToButton "btnNodesTimeout"
-  cbInclThms <- xmlGetWidget xml castToCheckButton "cbInclThms"
+  trvGoals <- builderGetObject builder castToTreeView "trvNodes"
+  btnNodesAll <- builderGetObject builder castToButton "btnNodesAll"
+  btnNodesNone <- builderGetObject builder castToButton "btnNodesNone"
+  btnNodesInvert <- builderGetObject builder castToButton "btnNodesInvert"
+  btnNodesUnchecked <- builderGetObject builder castToButton "btnNodesUnchecked"
+  btnNodesTimeout <- builderGetObject builder castToButton "btnNodesTimeout"
+  cbInclThms <- builderGetObject builder castToCheckButton "cbInclThms"
   -- get checker view and buttons
-  cbComorphism <- xmlGetWidget xml castToComboBox "cbComorphism"
-  lblSublogic <- xmlGetWidget xml castToLabel "lblSublogic"
-  sbTimeout <- xmlGetWidget xml castToSpinButton "sbTimeout"
-  btnCheck <- xmlGetWidget xml castToButton "btnCheck"
-  btnStop <- xmlGetWidget xml castToButton "btnStop"
-  trvFinder <- xmlGetWidget xml castToTreeView "trvFinder"
-  toolLabel <- xmlGetWidget xml castToLabel "label1"
+  cbComorphism <- builderGetObject builder castToComboBox "cbComorphism"
+  lblSublogic <- builderGetObject builder castToLabel "lblSublogic"
+  sbTimeout <- builderGetObject builder castToSpinButton "sbTimeout"
+  btnCheck <- builderGetObject builder castToButton "btnCheck"
+  btnStop <- builderGetObject builder castToButton "btnStop"
+  trvFinder <- builderGetObject builder castToTreeView "trvFinder"
+  toolLabel <- builderGetObject builder castToLabel "label1"
   labelSetLabel toolLabel "Pick disprover"
   windowSetTitle window "Disprove"
   spinButtonSetValue sbTimeout $ fromIntegral guiDefaultTimeLimit

--- a/GUI/GtkGenericATP.hs
+++ b/GUI/GtkGenericATP.hs
@@ -14,7 +14,6 @@ Generic Gtk GUI for automatic theorem provers.
 module GUI.GtkGenericATP ( genericATPgui ) where
 
 import Graphics.UI.Gtk
-import Graphics.UI.Gtk.Glade
 
 import GUI.GtkUtils
 import qualified GUI.Glade.GenericATP as GenericATP
@@ -52,30 +51,30 @@ genericATPgui :: (Show sentence, Ord proof_tree, Ord sentence)
 genericATPgui atpFun hasEOptions prName thName th freedefs pt = do
   result <- newEmptyMVar
   postGUIAsync $ do
-    xml <- getGladeXML GenericATP.get
+    builder <- getGTKBuilder GenericATP.get
     -- get objects
-    window <- xmlGetWidget xml castToWindow "GenericATP"
+    window <- builderGetObject builder castToWindow "GenericATP"
     -- buttons at buttom
-    btnClose <- xmlGetWidget xml castToButton "btnClose"
-    btnHelp <- xmlGetWidget xml castToButton "btnHelp"
-    btnSaveConfig <- xmlGetWidget xml castToButton "btnSaveConfig"
+    btnClose <- builderGetObject builder castToButton "btnClose"
+    btnHelp <- builderGetObject builder castToButton "btnHelp"
+    btnSaveConfig <- builderGetObject builder castToButton "btnSaveConfig"
     -- goal list
-    trvGoals <- xmlGetWidget xml castToTreeView "trvGoals"
+    trvGoals <- builderGetObject builder castToTreeView "trvGoals"
     -- options area
-    sbTimeout <- xmlGetWidget xml castToSpinButton "sbTimeout"
-    entryOptions <- xmlGetWidget xml castToEntry "entryOptions"
-    cbIncludeProven <- xmlGetWidget xml castToCheckButton "cbIncludeProven"
-    cbSaveBatch <- xmlGetWidget xml castToCheckButton "cbSaveBatch"
+    sbTimeout <- builderGetObject builder castToSpinButton "sbTimeout"
+    entryOptions <- builderGetObject builder castToEntry "entryOptions"
+    cbIncludeProven <- builderGetObject builder castToCheckButton "cbIncludeProven"
+    cbSaveBatch <- builderGetObject builder castToCheckButton "cbSaveBatch"
     -- prove buttons
-    btnStop <- xmlGetWidget xml castToButton "btnStop"
-    btnProveSelected <- xmlGetWidget xml castToButton "btnProveSelected"
-    btnProveAll <- xmlGetWidget xml castToButton "btnProveAll"
+    btnStop <- builderGetObject builder castToButton "btnStop"
+    btnProveSelected <- builderGetObject builder castToButton "btnProveSelected"
+    btnProveAll <- builderGetObject builder castToButton "btnProveAll"
     -- status and axioms
-    lblStatus <- xmlGetWidget xml castToLabel "lblStatus"
-    trvAxioms <- xmlGetWidget xml castToTreeView "trvAxioms"
+    lblStatus <- builderGetObject builder castToLabel "lblStatus"
+    trvAxioms <- builderGetObject builder castToTreeView "trvAxioms"
     -- info and save buttons
-    btnSaveProblem <- xmlGetWidget xml castToButton "btnSaveProblem"
-    btnShowDetails <- xmlGetWidget xml castToButton "btnShowDetails"
+    btnSaveProblem <- builderGetObject builder castToButton "btnSaveProblem"
+    btnShowDetails <- builderGetObject builder castToButton "btnShowDetails"
 
     windowSetTitle window $ prName ++ ": " ++ thName
 

--- a/GUI/GtkLinkTypeChoice.hs
+++ b/GUI/GtkLinkTypeChoice.hs
@@ -16,7 +16,6 @@ module GUI.GtkLinkTypeChoice
   where
 
 import Graphics.UI.Gtk
-import Graphics.UI.Gtk.Glade
 
 import GUI.GtkUtils
 import qualified GUI.Glade.LinkTypeChoice as LinkTypeChoice
@@ -36,17 +35,17 @@ mapEdgeTypesToNames = Map.fromList $ map
 -- | Displays the linktype selection window
 showLinkTypeChoice :: IORef [String] -> ([DGEdgeType] -> IO ()) -> IO ()
 showLinkTypeChoice ioRefDeselect updateFunction = postGUIAsync $ do
-  xml <- getGladeXML LinkTypeChoice.get
-  window <- xmlGetWidget xml castToWindow "linktypechoice"
-  ok <- xmlGetWidget xml castToButton "btnOk"
-  cancel <- xmlGetWidget xml castToButton "btnCancel"
-  select <- xmlGetWidget xml castToButton "btnSelect"
-  deselect <- xmlGetWidget xml castToButton "btnDeselect"
-  invert <- xmlGetWidget xml castToButton "btnInvert"
+  builder <- getGTKBuilder LinkTypeChoice.get
+  window <- builderGetObject builder castToWindow "linktypechoice"
+  ok <- builderGetObject builder castToButton "btnOk"
+  cancel <- builderGetObject builder castToButton "btnCancel"
+  select <- builderGetObject builder castToButton "btnSelect"
+  deselect <- builderGetObject builder castToButton "btnDeselect"
+  invert <- builderGetObject builder castToButton "btnInvert"
 
   deselectEdgeTypes <- readIORef ioRefDeselect
   mapM_ (\ name -> do
-          cb <- xmlGetWidget xml castToCheckButton name
+          cb <- builderGetObject builder castToCheckButton name
           toggleButtonSetActive cb False
         ) deselectEdgeTypes
 
@@ -54,7 +53,7 @@ showLinkTypeChoice ioRefDeselect updateFunction = postGUIAsync $ do
     edgeMap = mapEdgeTypesToNames
     keys = Map.keys edgeMap
     setAllTo to = mapM_ (\ name -> do
-                                cb <- xmlGetWidget xml castToCheckButton name
+                                cb <- builderGetObject builder castToCheckButton name
                                 to' <- to cb
                                 toggleButtonSetActive cb to'
                               ) keys
@@ -70,7 +69,7 @@ showLinkTypeChoice ioRefDeselect updateFunction = postGUIAsync $ do
 
   onClicked ok $ do
     edgeTypeNames <- filterM (\ name -> do
-                               cb <- xmlGetWidget xml castToCheckButton name
+                               cb <- builderGetObject builder castToCheckButton name
                                selected <- toggleButtonGetActive cb
                                return $ not selected
                              ) keys

--- a/GUI/GtkProverGUI.hs
+++ b/GUI/GtkProverGUI.hs
@@ -14,7 +14,6 @@ This module provides a GUI for the prover.
 module GUI.GtkProverGUI ( showProverGUI ) where
 
 import Graphics.UI.Gtk
-import Graphics.UI.Gtk.Glade
 
 import GUI.GtkUtils
 import qualified GUI.Glade.ProverGUI as ProverGUI
@@ -67,38 +66,38 @@ showProverGUI prGuiAcs thName warn th knownProvers comorphList = do
   state <- newMVar initState
   wait <- newEmptyMVar
   postGUIAsync $ do
-    xml <- getGladeXML ProverGUI.get
+    builder <- getGTKBuilder ProverGUI.get
     -- get objects
-    window <- xmlGetWidget xml castToWindow "ProverGUI"
+    window <- builderGetObject builder castToWindow "ProverGUI"
     -- buttons at buttom
-    btnShowTheory <- xmlGetWidget xml castToButton "btnShowTheory"
-    btnShowSelectedTheory <- xmlGetWidget xml castToButton "btnShowSelected"
-    btnClose <- xmlGetWidget xml castToButton "btnClose"
+    btnShowTheory <- builderGetObject builder castToButton "btnShowTheory"
+    btnShowSelectedTheory <- builderGetObject builder castToButton "btnShowSelected"
+    btnClose <- builderGetObject builder castToButton "btnClose"
     -- goals view
-    trvGoals <- xmlGetWidget xml castToTreeView "trvGoals"
-    btnGoalsAll <- xmlGetWidget xml castToButton "btnGoalsAll"
-    btnGoalsNone <- xmlGetWidget xml castToButton "btnGoalsNone"
-    btnGoalsInvert <- xmlGetWidget xml castToButton "btnGoalsInvert"
-    btnGoalsSelectOpen <- xmlGetWidget xml castToButton "btnGoalsSelectOpen"
+    trvGoals <- builderGetObject builder castToTreeView "trvGoals"
+    btnGoalsAll <- builderGetObject builder castToButton "btnGoalsAll"
+    btnGoalsNone <- builderGetObject builder castToButton "btnGoalsNone"
+    btnGoalsInvert <- builderGetObject builder castToButton "btnGoalsInvert"
+    btnGoalsSelectOpen <- builderGetObject builder castToButton "btnGoalsSelectOpen"
     -- axioms view
-    trvAxioms <- xmlGetWidget xml castToTreeView "trvAxioms"
-    btnAxiomsAll <- xmlGetWidget xml castToButton "btnAxiomsAll"
-    btnAxiomsNone <- xmlGetWidget xml castToButton "btnAxiomsNone"
-    btnAxiomsInvert <- xmlGetWidget xml castToButton "btnAxiomsInvert"
-    btnAxiomsFormer <- xmlGetWidget xml castToButton "btnAxiomsFormer"
+    trvAxioms <- builderGetObject builder castToTreeView "trvAxioms"
+    btnAxiomsAll <- builderGetObject builder castToButton "btnAxiomsAll"
+    btnAxiomsNone <- builderGetObject builder castToButton "btnAxiomsNone"
+    btnAxiomsInvert <- builderGetObject builder castToButton "btnAxiomsInvert"
+    btnAxiomsFormer <- builderGetObject builder castToButton "btnAxiomsFormer"
     -- theorems view
-    trvTheorems <- xmlGetWidget xml castToTreeView "trvTheorems"
-    btnTheoremsAll <- xmlGetWidget xml castToButton "btnTheoremsAll"
-    btnTheoremsNone <- xmlGetWidget xml castToButton "btnTheoremsNone"
-    btnTheoremsInvert <- xmlGetWidget xml castToButton "btnTheoremsInvert"
+    trvTheorems <- builderGetObject builder castToTreeView "trvTheorems"
+    btnTheoremsAll <- builderGetObject builder castToButton "btnTheoremsAll"
+    btnTheoremsNone <- builderGetObject builder castToButton "btnTheoremsNone"
+    btnTheoremsInvert <- builderGetObject builder castToButton "btnTheoremsInvert"
     -- status
-    btnDisplay <- xmlGetWidget xml castToButton "btnDisplay"
-    btnProofDetails <- xmlGetWidget xml castToButton "btnProofDetails"
-    btnProve <- xmlGetWidget xml castToButton "btnProve"
-    cbComorphism <- xmlGetWidget xml castToComboBox "cbComorphism"
-    lblSublogic <- xmlGetWidget xml castToLabel "lblSublogic"
+    btnDisplay <- builderGetObject builder castToButton "btnDisplay"
+    btnProofDetails <- builderGetObject builder castToButton "btnProofDetails"
+    btnProve <- builderGetObject builder castToButton "btnProve"
+    cbComorphism <- builderGetObject builder castToComboBox "cbComorphism"
+    lblSublogic <- builderGetObject builder castToLabel "lblSublogic"
     -- prover
-    trvProvers <- xmlGetWidget xml castToTreeView "trvProvers"
+    trvProvers <- builderGetObject builder castToTreeView "trvProvers"
 
     windowSetTitle window $ "Prove: " ++ thName
 

--- a/GUI/GtkUtils.hs
+++ b/GUI/GtkUtils.hs
@@ -15,7 +15,7 @@ we want to distribute them within the binary.
 -}
 
 module GUI.GtkUtils
-  ( getGladeXML
+  ( getGTKBuilder
   , startMainLoop
   , stopMainLoop
   , forkIO_
@@ -75,7 +75,6 @@ module GUI.GtkUtils
   ) where
 
 import Graphics.UI.Gtk
-import Graphics.UI.Gtk.Glade
 
 import qualified GUI.Glade.Utils as Utils
 
@@ -95,14 +94,11 @@ import System.Directory ( removeFile, doesFileExist
 import System.FilePath (takeFileName, takeDirectory)
 
 -- | Returns a GladeXML Object of a xmlstring.
-getGladeXML :: (String, String) -> IO GladeXML
-getGladeXML (name, xmlstr) = do
-  filename <- getTempFile xmlstr name
-  mxml <- xmlNew filename
-  removeFile filename
-  case mxml of
-    Just xml -> return xml
-    Nothing -> error "GtkUtils: Can't load xml string."
+getGTKBuilder :: (String, String) -> IO Builder
+getGTKBuilder (name, xmlstr) = do
+  builder <- builderNew
+  builderAddFromString builder xmlstr
+  return builder
 
 -- | Starts the gtk main event loop in a thread
 startMainLoop :: IO ()
@@ -295,10 +291,10 @@ listChoiceAux :: String -- ^ Title
               -> [a] -- ^ Rows to display
               -> IO (Maybe (Int, a)) -- ^ Selected row
 listChoiceAux title showF items = do
-  xml <- getGladeXML Utils.get
+  builder <- getGTKBuilder Utils.get
   -- get objects
-  dlg <- xmlGetWidget xml castToDialog "ListView"
-  trvList <- xmlGetWidget xml castToTreeView "trvList"
+  dlg <- builderGetObject builder castToDialog "ListView"
+  trvList <- builderGetObject builder castToTreeView "trvList"
 
   windowSetTitle dlg title
   store <- setListData trvList showF items
@@ -340,11 +336,11 @@ progressBarAux :: Bool -- ^ Percent or pulse
                -> String -- ^ Description
                -> IO (Double -> String -> IO (), IO ())
 progressBarAux isProgress title description = do
-  xml <- getGladeXML Utils.get
+  builder <- getGTKBuilder Utils.get
   -- get window
-  window <- xmlGetWidget xml castToWindow "ProgressBar"
+  window <- builderGetObject builder castToWindow "ProgressBar"
   -- get progress bar
-  bar <- xmlGetWidget xml castToProgressBar "pbProgress"
+  bar <- builderGetObject builder castToProgressBar "pbProgress"
 
   windowSetTitle window title
   progressBarSetText bar description
@@ -401,10 +397,10 @@ textView :: String -- ^ Title
          -> Maybe FilePath -- ^ Filename
          -> IO ()
 textView title message mfile = do
-  xml <- getGladeXML Utils.get
+  builder <- getGTKBuilder Utils.get
   -- get objects
-  dlg <- xmlGetWidget xml castToDialog "TextView"
-  tvText <- xmlGetWidget xml castToTextView "tvText"
+  dlg <- builderGetObject builder castToDialog "TextView"
+  tvText <- builderGetObject builder castToTextView "tvText"
 
   windowSetTitle dlg title
   buffer <- textViewGetBuffer tvText
@@ -550,7 +546,7 @@ getSelectedMultiple view list = do
 setListData :: TreeView -> (a -> String) -> [a] -> IO (ListStore a)
 setListData view getT listData = do
   store <- listStoreNew listData
-  treeViewSetModel view store
+  treeViewSetModel view (Just store)
   treeViewSetHeadersVisible view False
   ren <- cellRendererTextNew
   col <- treeViewColumnNew

--- a/Hets.cabal
+++ b/Hets.cabal
@@ -132,8 +132,7 @@ Executable hets
 
   if flag(gtkglade)
     build-depends:
-        glade >= 0.11.1
-      , gtk >= 0.11.2
+        gtk >= 0.11.2
     cpp-options: -DGTKGLADE
 
   if flag(mysql)

--- a/stack.yaml
+++ b/stack.yaml
@@ -56,6 +56,7 @@ extra-deps:
   - glib-0.13.8.1
   - gio-0.13.8.0
   - pango-0.13.8.1
+  - Cabal-2.0.1.1
   - haskeline-0.7.4.0
   - uni-events-2.2.2.0
   - uni-graphs-2.2.1.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -53,6 +53,9 @@ extra-deps:
   - protolude-0.2
   - aterm-0.1.0.1
   - glade-0.13.1
+  - glib-0.13.8.1
+  - gio-0.13.8.0
+  - pango-0.13.8.1
   - haskeline-0.7.4.0
   - uni-events-2.2.2.0
   - uni-graphs-2.2.1.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -56,6 +56,7 @@ extra-deps:
   - gio-0.13.8.0
   - pango-0.13.8.1
   - Cabal-2.0.1.1
+  - gtk-0.15.5
   - haskeline-0.7.4.0
   - uni-events-2.2.2.0
   - uni-graphs-2.2.1.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -52,7 +52,6 @@ extra-deps:
   - graphql-api-0.2.0
   - protolude-0.2
   - aterm-0.1.0.1
-  - glade-0.13.1
   - glib-0.13.8.1
   - gio-0.13.8.0
   - pango-0.13.8.1

--- a/var.mk
+++ b/var.mk
@@ -82,10 +82,10 @@ TAR_PACKAGE := $(shell [ $(TARVERSION) -gt 0 ] && echo '-DTAR_PACKAGE')
 UNIXVERSION := $(call version, $(shell $(HCPKG) latest unix))
 UNIX_PACKAGE := $(shell [ $(UNIXVERSION) -ge 2000000 ] && echo '-DUNIX')
 
-GLADEVERSION := $(call version, $(shell $(HCPKG) latest glade))
-GLADE_PACKAGE := \
-	$(shell [ $(GLADEVERSION) -ge 12000 ] && echo '-DGTKGLADE $(SUNRUNPATH)')
-GLADE_PACKAGE += $(shell [ $(GLADEVERSION) -lt 13000 ] && \
+GTKVERSION := $(call version, $(shell $(HCPKG) latest gtk))
+GTK_PACKAGE := \
+	$(shell [ $(GTKVERSION) -ge 12000 ] && echo '-DGTKGLADE $(SUNRUNPATH)')
+GTK_PACKAGE += $(shell [ $(GTKVERSION) -lt 13000 ] && \
 	[ $(FIXED_GLADE) = '0' ] && echo '-DGTK12')
 
 HASKELINEVERSION := $(call version, $(shell $(HCPKG) latest haskeline))
@@ -128,13 +128,13 @@ ifneq ($(strip $(UNI_PACKAGE)),)
   endif
 endif
 
-HC_OPTS_WITHOUTGLADE = $(PARSEC_FLAG) \
+HC_OPTS_WITHOUTGTK = $(PARSEC_FLAG) \
   $(TIME_PACKAGE) $(TAR_PACKAGE) $(HTTP_PACKAGE) $(WGET) $(UNIX_PACKAGE) \
   $(UNI_PACKAGE) $(HASKELINE_PACKAGE) $(HEXPAT_PACKAGE) \
   $(PFE_FLAGS) $(SERVER_FLAG) $(HAXML_PACKAGE) $(HAXML_PACKAGE_COMPAT) \
   -DRDFLOGIC -DCASLEXTENSIONS
 
 # for profiling (or a minimal hets) comment out the previous two package lines
-# and the $(GLADE_PACKAGE) below
+# and the $(GTK_PACKAGE) below
 
-HC_OPTS = $(HC_OPTS_WITHOUTGLADE) $(GLADE_PACKAGE)
+HC_OPTS = $(HC_OPTS_WITHOUTGTK) $(GTK_PACKAGE)


### PR DESCRIPTION
This is what I had to change to build Hets on my Fedora 32 system.
The main problem seems to have been https://github.com/gtk2hs/gtk2hs/issues/276

Todos:
- update `resolver` to get rid of the new `extra-deps` that simply shadow older versions of existing packages
  - This is complicated by the fact that the `uni-*` packages break with newer `base` versions.
- remove dependency on (lib)glade(-dev)
- add a line for installing dependencies on Fedora