### PR TITLE
1940 aterms

### DIFF
--- a/atermlib/aterm.cabal
+++ b/atermlib/aterm.cabal
@@ -3,7 +3,7 @@ version:         0.1.0.2
 license:         GPL-2
 license-file:    LICENSE.txt
 author:          Klaus Luettich, Christian Maeder
-maintainer:      Christian Maeder <chr.maedere@web.de>
+maintainer:      Christian Maeder <chr.maeder@web.de>
 homepage:        https://github.com/spechub/Hets/tree/master/atermlib
 description:     Efficient serialisation via annotated terms.
                  Typeable Haskell values may be converted to and from aterms.

--- a/atermlib/aterm.cabal
+++ b/atermlib/aterm.cabal
@@ -1,10 +1,10 @@
 name:            aterm
-version:         0.1.0.1
+version:         0.1.0.2
 license:         GPL-2
 license-file:    LICENSE.txt
 author:          Klaus Luettich, Christian Maeder
-maintainer:      Christian Maeder <Christian Maeder@dfki.de>
-homepage:        https://svn-agbkb.informatik.uni-bremen.de/Hets/trunk/atermlib
+maintainer:      Christian Maeder <chr.maedere@web.de>
+homepage:        https://github.com/spechub/Hets/tree/master/atermlib
 description:     Efficient serialisation via annotated terms.
                  Typeable Haskell values may be converted to and from aterms.
 synopsis:        serialisation for Haskell values with sharing support
@@ -12,7 +12,7 @@ category:        Data, Parsing
 stability:       provisional
 build-type:      Simple
 cabal-version:   >= 1.4
-tested-with:     GHC ==6.10.4, GHC ==6.12.3, GHC ==7.0.4
+tested-with:     GHC ==8.6.5
 
 library
 
@@ -30,6 +30,6 @@ library
     , ATerm.SimpPretty
     , ATerm.Unshared
 
-  extensions: MagicHash
+  extensions: CPP, MagicHash
 
   ghc-options: -Wall

--- a/atermlib/aterm.cabal
+++ b/atermlib/aterm.cabal
@@ -11,7 +11,7 @@ synopsis:        serialisation for Haskell values with sharing support
 category:        Data, Parsing
 stability:       provisional
 build-type:      Simple
-cabal-version:   >= 1.4
+cabal-version:   >= 1.10
 tested-with:     GHC ==8.6.5
 
 library
@@ -30,6 +30,8 @@ library
     , ATerm.SimpPretty
     , ATerm.Unshared
 
-  extensions: CPP, MagicHash
+  other-extensions: CPP, MagicHash
+
+  default-language: Haskell98
 
   ghc-options: -Wall

--- a/atermlib/src/ATerm/AbstractSyntax.hs
+++ b/atermlib/src/ATerm/AbstractSyntax.hs
@@ -27,6 +27,7 @@ module ATerm.AbstractSyntax
 import qualified Data.Map as Map
 import qualified Data.Map as IntMap
 import Data.Dynamic
+import Data.Typeable
 import Data.Array
 import System.Mem.StableName
 import GHC.Prim
@@ -63,7 +64,7 @@ data Key = Key Int EqKey
 mkKey :: Typeable a => a -> IO Key
 mkKey t = do
     s <- makeStableName t
-    return $ Key (hashStableName s) $ EqKey (unsafeCoerce # s) $ typeOf t
+    return $ Key (hashStableName s) $ EqKey (unsafeCoerce# s) $ typeOf t
 
 data ATermTable = ATT
     (IntMap.Map Int [(EqKey, Int)])

--- a/atermlib/src/ATerm/ReadWrite.hs
+++ b/atermlib/src/ATerm/ReadWrite.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {- |
 Module      :  ./atermlib/src/ATerm/ReadWrite.hs
 Description :  read and write ATerms to and from strings
@@ -46,6 +47,10 @@ module ATerm.ReadWrite (
 
         accidental support for the empty aterm: ShAAppl "" [] []
 -}
+
+#if __GLASGOW_HASKELL__ >= 803
+import Prelude hiding ((<>))
+#endif
 
 import ATerm.AbstractSyntax
 import ATerm.SimpPretty

--- a/atermlib/src/ATerm/SimpPretty.hs
+++ b/atermlib/src/ATerm/SimpPretty.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {- |
 Module      :  ./atermlib/src/ATerm/SimpPretty.hs
 Description :  simple pretty printing combinators
@@ -37,6 +38,10 @@ module ATerm.SimpPretty (
 
         render, fullRender, writeFileSDoc
   ) where
+
+#if __GLASGOW_HASKELL__ >= 803
+import Prelude hiding ((<>))
+#endif
 
 import System.IO
 


### PR DESCRIPTION
avoid to drop aterms just because the sources no longer compile with newer ghcs. Version 0.1.0.2. is also uploaded to https://hackage.haskell.org/package/aterm .The current ghc also works with this change.