### PR TITLE
ensure that symbol names are legal in CASL via translation

### DIFF
--- a/OWL2/OWL22CASL.hs
+++ b/OWL2/OWL22CASL.hs
@@ -118,7 +118,21 @@ uriToIdM = return . uriToCaslId
 
 -- | Extracts Id from URI
 uriToCaslId :: IRI -> Id
-uriToCaslId urI =  stringToId $ showIRI urI
+uriToCaslId urI = 
+ let urS = showIRI urI
+     urS' = concatMap 
+            (\c ->  if isAlpha c || 
+                       isDigit c || 
+                       c == '\'' ||
+                       c == '_' 
+                   then [c] 
+                   else "_u" ) urS
+ in case urS of
+      x : _ -> 
+         if isDigit x then genName urS' 
+         else stringToId urS'
+      _ -> error "translating empty IRI" 
+           -- should never happen
 
 {- let
   repl a = if isAlphaNum a then [a] else if a/=':' then "_" else ""


### PR DESCRIPTION
Should fix #1895 and also replace non-CASL characters. Please let me know if I should allow more characters to remain as they are and if the solution to replace them is OK or if you would like something else.