### PR TITLE
profiling via make variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@
 #
 # If the following environment variables are set, their values get passed to
 # the corresponding tool as is: GHC_PKG_FLAGS (ghc-pkg), GHC_FLAGS (ghc).
+# For profiling, call make with PROFILE=on 
 
 include var.mk
 

--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,6 @@ include var.mk
 NO_BIND_WARNING := -fno-warn-unused-do-bind
 HC_WARN := -Wall -fwarn-tabs \
   -fwarn-unrecognised-pragmas -fno-warn-orphans $(NO_BIND_WARNING)
-# uncomment HC_PROF for profiling (and comment out packages in var.mk)
-# call resulting binary with a final +RTS -p to get a file <binary>.prof
-#HC_PROF := -prof -auto-all -osuf p_o +RTS -K100m -RTS
 HC_OPTS += $(HC_WARN) $(HC_PROF) $(GHC_FLAGS)
 # -ddump-minimal-imports
 # uncomment the above line to generate .imports files for displayDependencyGraph
@@ -37,15 +34,15 @@ doc: doc/UserGuide.pdf
 
 # Upgrade haskell-stack
 stack_upgrade:
-	$(STACK) $(STACK_OPTS) upgrade
-	$(STACK_EXEC) -- ghc-pkg recache
+	$(STACK) $(STACK_OPTS) $(STACK_PROF) upgrade
+	$(STACK_EXEC) $(STACK_PROF) -- ghc-pkg recache
 # Create the build environment
 stack: $(STACK_UPGRADE_TARGET)
-	$(STACK) $(STACK_OPTS) build --install-ghc --only-dependencies $(STACK_DEPENDENCIES_FLAGS)
+	$(STACK) $(STACK_OPTS) build $(STACK_PROF) --install-ghc --only-dependencies $(STACK_DEPENDENCIES_FLAGS)
 	touch stack
 restack:
 	rm -f stack
-	$(STACK) $(STACK_OPTS) build --install-ghc --only-dependencies $(STACK_DEPENDENCIES_FLAGS)
+	$(STACK) $(STACK_OPTS) build $(STACK_PROF) --install-ghc --only-dependencies $(STACK_DEPENDENCIES_FLAGS)
 	touch stack
 
 SED := $(shell [ "$(OSNAME)" = 'SunOS' ] && printf 'gsed' || printf 'sed')

--- a/var.mk
+++ b/var.mk
@@ -1,7 +1,7 @@
 # to be included by Makefile
 
 PROFILE :=
-# call make with PROFILE=on (and comment out packages in var.mk)
+# for profiling, call make with PROFILE=on 
 # call resulting binary with a final +RTS -p to get a file <binary>.prof
 ifeq ($(PROFILE),on)
 	HC_PROF := -prof -auto-all -osuf p_o +RTS -K100m -RTS

--- a/var.mk
+++ b/var.mk
@@ -1,5 +1,16 @@
 # to be included by Makefile
 
+PROFILE :=
+# call make with PROFILE=on (and comment out packages in var.mk)
+# call resulting binary with a final +RTS -p to get a file <binary>.prof
+ifeq ($(PROFILE),on)
+	HC_PROF := -prof -auto-all -osuf p_o +RTS -K100m -RTS
+        STACK_PROF := --profile
+else
+	HC_PROF := 
+        STACK_PROF := 
+endif
+
 SHELL := $(shell [ -x /bin/ksh93 ] && echo '/bin/ksh93' || echo '/bin/bash' )
 OSNAME := $(shell uname -s)
 OSVERS := $(shell uname -v 2>/dev/null)
@@ -21,7 +32,7 @@ STACK_TARGET :=
 STACK_UPGRADE_TARGET :=
 STACK_DEPENDENCIES_FLAGS :=
 ifneq ($(STACK),)
-    STACK_EXEC := $(STACK) exec --
+    STACK_EXEC := $(STACK) exec $(STACK_PROF) --
     # Upgrade Haskell-Stack if the version requirement of 1.4.0 is not met
     STACK_VERSION := $(call version, $(shell stack --numeric-version))
     STACK_TARGET := stack
@@ -130,10 +141,12 @@ endif
 HC_OPTS_WITHOUTGTK = $(PARSEC_FLAG) \
   $(TIME_PACKAGE) $(TAR_PACKAGE) $(HTTP_PACKAGE) $(WGET) $(UNIX_PACKAGE) \
   $(UNI_PACKAGE) $(HASKELINE_PACKAGE) $(HEXPAT_PACKAGE) \
-  $(PFE_FLAGS) $(SERVER_FLAG) $(HAXML_PACKAGE) $(HAXML_PACKAGE_COMPAT) \
-  -DRDFLOGIC -DCASLEXTENSIONS
+  $(PFE_FLAGS) $(SERVER_FLAG) $(HAXML_PACKAGE)
+ifneq ($(PROFILE),on)
+  HC_OPTS_WITHOUTGTK += $(HAXML_PACKAGE_COMPAT) -DRDFLOGIC -DCASLEXTENSIONS
+endif
 
-# for profiling (or a minimal hets) comment out the previous two package lines
-# and the $(GTK_PACKAGE) below
-
-HC_OPTS = $(HC_OPTS_WITHOUTGTK) $(GTK_PACKAGE)
+HC_OPTS = $(HC_OPTS_WITHOUTGTK)
+ifneq ($(PROFILE),on)
+  HC_OPTS += $(GTK_PACKAGE)
+endif


### PR DESCRIPTION
This should make profiling easier. Keep `Makefile` and `var.mk` as they are. For compiling Hets with profiling, use
```
make PROFILE=on restack
make PROFILE=on hets         # or hets_server
```
The first line installs dependencies, the second line compiles Hets.