### PR TITLE
consider n=0 in exact cardinality

### DIFF
--- a/OWL2/OWL22CASL.hs
+++ b/OWL2/OWL22CASL.hs
@@ -493,7 +493,8 @@ mapCard b cSig ct n prop d var = do
         maxLst = mkImpl (conjunct $ oPropsM ++ eOut)
                         $ disjunct dlstM
         exactLst' = mkImpl (conjunct $ oPropsE ++ fOut) $ disjunct dlstM
-        exactLst = mkExist qVars $ conjunct [minLst, mkForall qVarsE exactLst']
+        senAux = conjunct [minLst, mkForall qVarsE exactLst']
+        exactLst =  if null qVars then senAux else mkExist qVars senAux
         ts = uniteL $ [cSig] ++ s ++ s' ++ s''
     return $ case ct of
             MinCardinality -> (mkExist qVars minLst, ts)


### PR DESCRIPTION
Should fix the problem with obi, the error was in OWL22CASL not in the translation to TPTP.

Test with and without the change:
```
logic OWL

ontology O =
 Class: C
 ObjectProperty: r
 
 Class: A SubClassOf: r exactly 0 C
end
```