### PR TITLE
1924 tptp cons checkers

### DIFF
--- a/Comorphisms/SuleCFOL2SoftFOL.hs
+++ b/Comorphisms/SuleCFOL2SoftFOL.hs
@@ -16,6 +16,7 @@ module Comorphisms.SuleCFOL2SoftFOL
   ( suleCFOL2SoftFOL
   , suleCFOL2SoftFOLInduction
   , suleCFOL2SoftFOLInduction2
+  , extractCASLModel
   ) where
 
 import Control.Exception (assert)

--- a/Comorphisms/SuleCFOL2TPTP.hs
+++ b/Comorphisms/SuleCFOL2TPTP.hs
@@ -51,8 +51,6 @@ import TPTP.Sublogic
 
 import qualified Comorphisms.SuleCFOL2SoftFOL as CASL2SoftFOL
 
-import Debug.Trace
-
 data TPTP_FOF = TPTP_FOF
 
 instance Show TPTP_FOF where
@@ -90,7 +88,6 @@ instance Comorphism GenSuleCFOL2TPTP
     mapSublogic _ _ = Just FOF
     map_theory GenSuleCFOL2TPTP = transTheory
     has_model_expansion GenSuleCFOL2TPTP = True
-    extractModel GenSuleCFOL2TPTP s pt = trace ("pt:"++show pt) $  CASL2SoftFOL.extractCASLModel s pt
 
 transTheory :: (FormExtension f, Eq f)
             => (CSign.Sign f e, [Named (FORMULA f)])

--- a/Comorphisms/SuleCFOL2TPTP.hs
+++ b/Comorphisms/SuleCFOL2TPTP.hs
@@ -49,6 +49,10 @@ import TPTP.Sign as TSign
 import TPTP.Logic_TPTP
 import TPTP.Sublogic
 
+import qualified Comorphisms.SuleCFOL2SoftFOL as CASL2SoftFOL
+
+import Debug.Trace
+
 data TPTP_FOF = TPTP_FOF
 
 instance Show TPTP_FOF where
@@ -86,6 +90,7 @@ instance Comorphism GenSuleCFOL2TPTP
     mapSublogic _ _ = Just FOF
     map_theory GenSuleCFOL2TPTP = transTheory
     has_model_expansion GenSuleCFOL2TPTP = True
+    extractModel GenSuleCFOL2TPTP s pt = trace ("pt:"++show pt) $  CASL2SoftFOL.extractCASLModel s pt
 
 transTheory :: (FormExtension f, Eq f)
             => (CSign.Sign f e, [Named (FORMULA f)])

--- a/SoftFOL/Logic_SoftFOL.hs
+++ b/SoftFOL/Logic_SoftFOL.hs
@@ -93,5 +93,5 @@ instance Logic SoftFOL () [TPTP] Sentence () ()
 #endif
            ++ map darwinProver tptpProvers
            ++ [metisProver, hyperProver]
-         cons_checkers SoftFOL = map darwinConsChecker tptpProvers
-           ++ [hyperConsChecker]
+         cons_checkers SoftFOL = [] -- map darwinConsChecker tptpProvers
+           -- ++ [hyperConsChecker]

--- a/SoftFOL/Logic_SoftFOL.hs
+++ b/SoftFOL/Logic_SoftFOL.hs
@@ -93,5 +93,5 @@ instance Logic SoftFOL () [TPTP] Sentence () ()
 #endif
            ++ map darwinProver tptpProvers
            ++ [metisProver, hyperProver]
-         cons_checkers SoftFOL = [] -- map darwinConsChecker tptpProvers
-           -- ++ [hyperConsChecker]
+         cons_checkers SoftFOL = map darwinConsChecker tptpProvers
+           ++ [hyperConsChecker]

--- a/SoftFOL/ProveDarwin.hs
+++ b/SoftFOL/ProveDarwin.hs
@@ -19,6 +19,7 @@ module SoftFOL.ProveDarwin
   , runDarwinProcess
   , ProverBinary (..)
   , darwinExe
+  , proverBinary
   , tptpProvers
   , eproverOpts
   ) where

--- a/SoftFOL/ProveDarwin.hs
+++ b/SoftFOL/ProveDarwin.hs
@@ -16,9 +16,11 @@ module SoftFOL.ProveDarwin
   ( darwinProver
   , darwinCMDLautomaticBatch
   , darwinConsChecker
+  , runDarwinProcess
   , ProverBinary (..)
   , darwinExe
   , tptpProvers
+  , eproverOpts
   ) where
 
 -- preliminary hacks for display of CASL models

--- a/TPTP/ConsChecker.hs
+++ b/TPTP/ConsChecker.hs
@@ -58,7 +58,7 @@ extras b cons tl = let
   in case b of
     "eprover" -> Darwin.eproverOpts (if cons then "-s" else "") ++ tl
     "leo" -> "-t " ++ tl
-    "darwin" -> darOpt ++ tOut
+    "darwin" -> fdOpt ++ tOut
     -- "DarwinFD" -> fdOpt ++ tOut
     "e-darwin" -> fdOpt ++ " -eq Axioms" ++ tOut
     "iproveropt" -> "--time_out_real " ++ tl ++ " --sat_mode true"

--- a/TPTP/ConsChecker.hs
+++ b/TPTP/ConsChecker.hs
@@ -56,12 +56,12 @@ extras b cons tl = let
   darOpt = "-pc false"
   fdOpt = darOpt ++ (if cons then " -pmtptp true" else "") ++ " -fd true"
   in case b of
-    "EProver" -> Darwin.eproverOpts (if cons then "-s" else "") ++ tl
-    "Leo" -> "-t " ++ tl
+    "eprover" -> Darwin.eproverOpts (if cons then "-s" else "") ++ tl
+    "leo" -> "-t " ++ tl
     "darwin" -> darOpt ++ tOut
-    "DarwinFD" -> fdOpt ++ tOut
-    "EDarwin" -> fdOpt ++ " -eq Axioms" ++ tOut
-    "IProver" -> "--time_out_real " ++ tl ++ " --sat_mode true"
+    -- "DarwinFD" -> fdOpt ++ tOut
+    "e-darwin" -> fdOpt ++ " -eq Axioms" ++ tOut
+    "iproveropt" -> "--time_out_real " ++ tl ++ " --sat_mode true"
 
 {- | Runs the Darwin service. The tactic script only contains a string for the
   time limit. -}

--- a/TPTP/ConsChecker.hs
+++ b/TPTP/ConsChecker.hs
@@ -1,17 +1,12 @@
 {- |
 Module      :  ./TPTP/ConsChecker.hs
-Description :  Interface to the theorem prover e-krhyper in CASC-mode.
-Copyright   :  (c) Dominik Luecke, Uni Bremen 2010
+Description :  Interface to consistency checkers
+Copyright   :  (c) (c) Otto-von-Guericke University of Magdeburg, 2020
 License     :  GPLv2 or higher, see LICENSE.txt
-Maintainer  :  luecke@informatik.uni-bremen.de
+Maintainer  :  mscodescu@gmail.com
 Stability   :  provisional
 Portability :  needs POSIX
 
-Check out
-http://www.uni-koblenz.de/~bpelzer/ekrhyper/
-for details. For the ease of maintenance we are using e-krhyper in
-its CASC-mode, aka tptp-input. It works for single input files and
-fof-style.
 -}
 
 module TPTP.ConsChecker

--- a/TPTP/ConsChecker.hs
+++ b/TPTP/ConsChecker.hs
@@ -1,0 +1,95 @@
+{- |
+Module      :  ./TPTP/ConsChecker.hs
+Description :  Interface to the theorem prover e-krhyper in CASC-mode.
+Copyright   :  (c) Dominik Luecke, Uni Bremen 2010
+License     :  GPLv2 or higher, see LICENSE.txt
+Maintainer  :  luecke@informatik.uni-bremen.de
+Stability   :  provisional
+Portability :  needs POSIX
+
+Check out
+http://www.uni-koblenz.de/~bpelzer/ekrhyper/
+for details. For the ease of maintenance we are using e-krhyper in
+its CASC-mode, aka tptp-input. It works for single input files and
+fof-style.
+-}
+
+module TPTP.ConsChecker
+    where
+
+import Logic.Prover
+
+import Common.ProofTree
+import qualified Common.Result as Result
+import Common.AS_Annotation as AS_Anno
+import Common.SZSOntology
+import Common.Timing
+import Common.Utils
+
+import TPTP.Sign
+import TPTP.Morphism
+import TPTP.Translate
+import TPTP.Prover.ProverState
+import TPTP.Sublogic
+
+import GUI.GenericATP
+import Proofs.BatchProcessing
+import Interfaces.GenericATPState
+
+import System.Directory
+
+import Control.Monad (when)
+import qualified Control.Concurrent as Concurrent
+
+import Data.Char
+import Data.List
+import Data.Maybe
+
+import Data.Time.LocalTime (TimeOfDay, midnight)
+import Data.Time (timeToTimeOfDay)
+import Data.Time.Clock (secondsToDiffTime)
+import qualified SoftFOL.ProveDarwin as Darwin
+
+extras :: String -> Bool -> String -> String
+extras b cons tl = let
+  tOut = " -to " ++ tl
+  darOpt = "-pc false"
+  fdOpt = darOpt ++ (if cons then " -pmtptp true" else "") ++ " -fd true"
+  in case b of
+    "EProver" -> Darwin.eproverOpts (if cons then "-s" else "") ++ tl
+    "Leo" -> "-t " ++ tl
+    "darwin" -> darOpt ++ tOut
+    "DarwinFD" -> fdOpt ++ tOut
+    "EDarwin" -> fdOpt ++ " -eq Axioms" ++ tOut
+    "IProver" -> "--time_out_real " ++ tl ++ " --sat_mode true"
+
+{- | Runs the Darwin service. The tactic script only contains a string for the
+  time limit. -}
+consCheck
+  :: String
+  -> String
+  -> TacticScript
+  -> TheoryMorphism Sign Sentence Morphism ProofTree
+  -> [FreeDefMorphism Sentence Morphism] -- ^ freeness constraints
+  -> IO (CCStatus ProofTree)
+consCheck b thName (TacticScript tl) tm freedefs = case tTarget tm of
+    Theory sig nSens -> do
+        let proverStateI = tptpProverState sig (toNamedList nSens) freedefs
+        prob <- showTPTPProblemM thName proverStateI []
+        (exitCode, out, tUsed) <-
+          Darwin.runDarwinProcess b False (extras b True tl) thName prob
+        let outState = CCStatus
+               { ccResult = Just True
+               , ccProofTree = ProofTree $ unlines $ exitCode : out
+               , ccUsedTime = timeToTimeOfDay $ secondsToDiffTime
+                            $ toInteger tUsed }
+        return $ if szsProved exitCode then outState else
+                    outState
+                    { ccResult = if szsDisproved exitCode then Just False
+                                 else Nothing }
+
+darwinConsChecker
+  :: String -> ConsChecker Sign Sentence Sublogic Morphism ProofTree
+darwinConsChecker binary =
+  (mkUsableConsChecker binary binary FOF $ consCheck binary)
+  { ccNeedsTimer = False }

--- a/TPTP/Logic_TPTP.hs
+++ b/TPTP/Logic_TPTP.hs
@@ -33,6 +33,7 @@ import TPTP.Prover.Vampire
 import TPTP.Sign
 import TPTP.Sublogic as Sublogic
 import TPTP.StaticAnalysis
+import TPTP.ProveHyper
 
 import ATC.ProofTree ()
 import Common.DefaultMorphism
@@ -82,6 +83,7 @@ instance Logic TPTP Sublogic BASIC_SPEC Sentence () () Sign Morphism Symbol () P
     all_sublogics TPTP = [CNF, FOF, TFF, THF]
     provers TPTP = [cvc4, darwin, eprover, geo3, isabelle, leo2, satallax,
                     spass, vampire]
+    cons_checkers TPTP = [hyperConsChecker]
 
 
 instance SublogicName Sublogic where

--- a/TPTP/Logic_TPTP.hs
+++ b/TPTP/Logic_TPTP.hs
@@ -84,7 +84,7 @@ instance Logic TPTP Sublogic BASIC_SPEC Sentence () () Sign Morphism Symbol () P
     all_sublogics TPTP = [CNF, FOF, TFF, THF]
     provers TPTP = [cvc4, darwin, eprover, geo3, isabelle, leo2, satallax,
                     spass, vampire]
-    cons_checkers TPTP = [hyperConsChecker, darwinConsChecker "darwin"] 
+    cons_checkers TPTP = [hyperConsChecker] ++ map darwinConsChecker ["darwin", "eprover", "iproveropt", "edarwin", "leo"] 
 
 
 instance SublogicName Sublogic where

--- a/TPTP/Logic_TPTP.hs
+++ b/TPTP/Logic_TPTP.hs
@@ -34,6 +34,7 @@ import TPTP.Sign
 import TPTP.Sublogic as Sublogic
 import TPTP.StaticAnalysis
 import TPTP.ProveHyper
+import TPTP.ConsChecker
 
 import ATC.ProofTree ()
 import Common.DefaultMorphism
@@ -83,7 +84,7 @@ instance Logic TPTP Sublogic BASIC_SPEC Sentence () () Sign Morphism Symbol () P
     all_sublogics TPTP = [CNF, FOF, TFF, THF]
     provers TPTP = [cvc4, darwin, eprover, geo3, isabelle, leo2, satallax,
                     spass, vampire]
-    cons_checkers TPTP = [hyperConsChecker]
+    cons_checkers TPTP = [hyperConsChecker, darwinConsChecker "darwin"] 
 
 
 instance SublogicName Sublogic where

--- a/TPTP/Logic_TPTP.hs
+++ b/TPTP/Logic_TPTP.hs
@@ -43,6 +43,7 @@ import Logic.Logic as Logic
 
 import Data.Monoid
 import qualified Data.Set as Set
+import qualified SoftFOL.ProveDarwin as Darwin
 
 data TPTP = TPTP deriving (Show, Ord, Eq)
 
@@ -84,7 +85,8 @@ instance Logic TPTP Sublogic BASIC_SPEC Sentence () () Sign Morphism Symbol () P
     all_sublogics TPTP = [CNF, FOF, TFF, THF]
     provers TPTP = [cvc4, darwin, eprover, geo3, isabelle, leo2, satallax,
                     spass, vampire]
-    cons_checkers TPTP = [hyperConsChecker] ++ map darwinConsChecker ["darwin", "eprover", "iproveropt", "edarwin", "leo"] 
+    cons_checkers TPTP = [hyperConsChecker] ++ 
+                         map darwinConsChecker Darwin.tptpProvers 
 
 
 instance SublogicName Sublogic where

--- a/TPTP/ProveHyper.hs
+++ b/TPTP/ProveHyper.hs
@@ -1,9 +1,9 @@
 {- |
 Module      :  ./TPTP/ProveHyper.hs
 Description :  Interface to the theorem prover e-krhyper in CASC-mode.
-Copyright   :  (c) Dominik Luecke, Uni Bremen 2010
+Copyright   :  (c) Otto-von-Guericke University of Magdeburg, 2020
 License     :  GPLv2 or higher, see LICENSE.txt
-Maintainer  :  luecke@informatik.uni-bremen.de
+Maintainer  :  mscodescu@gmail.com
 Stability   :  provisional
 Portability :  needs POSIX
 

--- a/TPTP/ProveHyper.hs
+++ b/TPTP/ProveHyper.hs
@@ -117,7 +117,7 @@ hyperCMDLautomaticBatch inclProvedThs saveProblem_batch resultMVar
 prelTxt :: String -> String
 prelTxt t =
     "% only print essential output\n" ++
-    "#(set_verbosity(1)).\n\n" ++
+    "#(set_verbosity(2)).\n\n" ++
     "% assume all input to be in tptp-syntax\n" ++
     "#(set_parameter(input_type, 2)).\n\n" ++
     "% To prevent blowing up my memory\n" ++

--- a/TPTP/ProveHyper.hs
+++ b/TPTP/ProveHyper.hs
@@ -1,0 +1,302 @@
+{- |
+Module      :  ./TPTP/ProveHyper.hs
+Description :  Interface to the theorem prover e-krhyper in CASC-mode.
+Copyright   :  (c) Dominik Luecke, Uni Bremen 2010
+License     :  GPLv2 or higher, see LICENSE.txt
+Maintainer  :  luecke@informatik.uni-bremen.de
+Stability   :  provisional
+Portability :  needs POSIX
+
+Check out
+http://www.uni-koblenz.de/~bpelzer/ekrhyper/
+for details. For the ease of maintenance we are using e-krhyper in
+its CASC-mode, aka tptp-input. It works for single input files and
+fof-style.
+-}
+
+module TPTP.ProveHyper (hyperS, hyperProver, hyperConsChecker)
+    where
+
+import Logic.Prover
+
+import Common.ProofTree
+import qualified Common.Result as Result
+import Common.AS_Annotation as AS_Anno
+import Common.SZSOntology
+import Common.Timing
+import Common.Utils
+
+import TPTP.Sign
+import TPTP.Morphism
+import TPTP.Translate
+import TPTP.Prover.ProverState
+import TPTP.Sublogic
+
+import GUI.GenericATP
+import Proofs.BatchProcessing
+import Interfaces.GenericATPState
+
+import System.Directory
+
+import Control.Monad (when)
+import qualified Control.Concurrent as Concurrent
+
+import Data.Char
+import Data.List
+import Data.Maybe
+
+import Data.Time.LocalTime (TimeOfDay, midnight)
+
+-- Prover
+
+hyperS :: String
+hyperS = "ekrh"
+
+sublogics :: Sublogic
+sublogics = FOF
+
+-- | The Prover implementation.
+hyperProver :: Prover Sign Sentence Morphism Sublogic ProofTree
+hyperProver =
+  mkAutomaticProver hyperS hyperS sublogics hyperGUI hyperCMDLautomaticBatch
+
+{- |
+  Record for prover specific functions. This is used by both GUI and command
+  line interface.
+-}
+atpFun :: String -- ^ theory name
+  -> ATPFunctions Sign Sentence Morphism ProofTree ProverState
+atpFun thName = ATPFunctions
+  { initialProverState = tptpProverState
+  , atpTransSenName = transSenName
+  , atpInsertSentence = insertSentenceIntoProverState
+  , goalOutput = ioShowTPTPProblem thName
+  , proverHelpText = "for more information visit " ++
+                     "http://www.uni-koblenz.de/~bpelzer/ekrhyper/"
+  , batchTimeEnv = "HETS_HYPER_BATCH_TIME_LIMIT"
+  , fileExtensions = FileExtensions
+      { problemOutput = ".tptp"
+      , proverOutput = ".hyper"
+      , theoryConfiguration = ".hypcf" }
+  , runProver = runHyper
+  , createProverOptions = extraOpts }
+
+{- |
+  Invokes the generic prover GUI.
+-}
+hyperGUI :: String -- ^ theory name
+           -> Theory Sign Sentence ProofTree
+           -> [FreeDefMorphism Sentence Morphism] -- ^ freeness constraints
+           -> IO [ProofStatus ProofTree] -- ^ proof status for each goal
+hyperGUI thName th freedefs =
+    genericATPgui (atpFun thName) True hyperS thName th
+                  freedefs emptyProofTree
+
+{- |
+  Implementation of 'Logic.Prover.proveCMDLautomaticBatch' which provides an
+  automatic command line interface to the prover.
+-}
+hyperCMDLautomaticBatch ::
+           Bool -- ^ True means include proved theorems
+        -> Bool -- ^ True means save problem file
+        -> Concurrent.MVar (Result.Result [ProofStatus ProofTree])
+           -- ^ used to store the result of the batch run
+        -> String -- ^ theory name
+        -> TacticScript -- ^ default tactic script
+        -> Theory Sign Sentence ProofTree -- ^ input theory
+        -> [FreeDefMorphism Sentence Morphism] -- ^ freeness constraints
+        -> IO (Concurrent.ThreadId, Concurrent.MVar ())
+           {- ^ fst: identifier of the batch thread for killing it
+           snd: MVar to wait for the end of the thread -}
+hyperCMDLautomaticBatch inclProvedThs saveProblem_batch resultMVar
+                        thName defTS th freedefs =
+    genericCMDLautomaticBatch (atpFun thName) inclProvedThs saveProblem_batch
+        resultMVar hyperS thName
+        (parseTacticScript batchTimeLimit [] defTS) th freedefs emptyProofTree
+
+prelTxt :: String -> String
+prelTxt t =
+    "% only print essential output\n" ++
+    "#(set_verbosity(1)).\n\n" ++
+    "% assume all input to be in tptp-syntax\n" ++
+    "#(set_parameter(input_type, 2)).\n\n" ++
+    "% To prevent blowing up my memory\n" ++
+    "#(set_memory_limit(500)).\n\n" ++
+    "% produce SZS results\n" ++
+    "#(set_flag(szs_output_flag, true)).\n\n" ++
+    "% do not use special evaluable symbols\n" ++
+    "#(clear_builtins).\n\n" ++
+    "% initial term weight bound, 3 recommended for TPTP-problems\n" ++
+    "#(set_parameter(max_weight_initial, 3)).\n\n" ++
+    "% Terminate if out of memory\n" ++
+    "#(set_parameter(limit_termination_method,0)).\n\n" ++
+    "% Terminate if out of time\n" ++
+    "#(set_parameter(timeout_termination_method,0)).\n\n" ++
+    "% Start timer\n" ++
+    "#(start_wallclock_timer(" ++ t ++ ".0)).\n"
+
+checkOption :: String -> Bool
+checkOption a = isPrefixOf "#(" a && isSuffixOf ")." a
+
+uniteOptions :: [String] -> [String]
+uniteOptions opts =
+    case opts of
+      a : b : cs ->
+          if checkOption a
+           then
+               a : uniteOptions (b : cs)
+           else
+               (a ++ b) : uniteOptions cs
+      _ -> opts
+
+runTxt :: String
+runTxt =
+    "% start derivation with the input received so far\n" ++
+    "#(run).\n\n" ++
+    "% print normal E-KRHyper proof\n" ++
+    "%#(print_proof).\n\n" ++
+    "% print result and proof using SZS terminology;\n" ++
+    "% requires postprocessing with post_szs script for proper legibility\n" ++
+    "#(print_szs_proof).\n"
+
+runHyper :: ProverState
+           {- ^ logical part containing the input Sign and axioms and possibly
+           goals that have been proved earlier as additional axioms -}
+           -> GenericConfig ProofTree -- ^ configuration to use
+           -> Bool -- ^ True means save TPTP file
+           -> String -- ^ name of the theory in the DevGraph
+           -> AS_Anno.Named Sentence -- ^ goal to prove
+           -> IO (ATPRetval, GenericConfig ProofTree)
+           -- ^ (retval, configuration with proof status and complete output)
+runHyper sps cfg saveTPTP thName nGoal =
+    let
+        saveFile = basename thName ++ '_' : AS_Anno.senAttr nGoal ++ ".tptp"
+        simpleOptions = uniteOptions $ extraOpts cfg
+        tl = configTimeLimit cfg
+        tScript = TacticScript $ show ATPTacticScript
+          { tsTimeLimit = tl
+          , tsExtraOpts = filter (isPrefixOf "#")
+              $ lines $ prelTxt (show tl) ++ runTxt }
+        defProofStat = (openProofStatus
+          (senAttr nGoal)
+          hyperS
+          emptyProofTree) { tacticScript = tScript }
+    in
+        if all checkOption simpleOptions
+         then
+           do
+             prob <- ioShowTPTPProblem thName sps nGoal []
+             when saveTPTP (writeFile saveFile prob)
+             (stdoutC, stderrC, t_u) <- runHyperProcess prob saveFile (show tl)
+               ('\n' : unlines simpleOptions) runTxt
+             let (pStat, ret) = examineProof sps stdoutC stderrC
+                   defProofStat { usedTime = t_u }
+             return (pStat, cfg
+                              { proofStatus = ret
+                              , resultOutput = lines (stdoutC ++ stderrC)
+                              , timeUsed = usedTime ret })
+         else return
+                    (ATPError "Syntax error in options"
+                    , cfg
+                     { proofStatus = defProofStat
+                     , resultOutput = ["Parse Error"]
+                     , timeUsed = midnight
+                     })
+
+-- | call ekrh
+runHyperProcess
+  :: String -- ^ problem
+  -> String -- ^ file name template
+  -> String -- ^ time limit
+  -> String -- ^ extra options
+  -> String -- ^ run text
+  -> IO (String, String, TimeOfDay) -- ^ out, err, diff time
+runHyperProcess prob saveFile tl opts runTxtA = do
+  stpTmpFile <- getTempFile prob saveFile
+  let stpPrelFile = stpTmpFile ++ ".prelude.tme"
+      stpRunFile = stpTmpFile ++ ".run.tme"
+  writeFile stpPrelFile $ prelTxt tl ++ opts
+  writeFile stpRunFile runTxtA
+  t_start <- getHetsTime
+  (_, stdoutC, stderrC) <- executeProcess hyperS
+    [stpPrelFile, stpTmpFile, stpRunFile] ""
+  t_end <- getHetsTime
+  removeFile stpPrelFile
+  removeFile stpRunFile
+  removeFile stpTmpFile
+  return (stdoutC, stderrC, diffHetsTime t_end t_start)
+
+-- | Mapping type from SZS to Hets
+data HyperResult = HProved | HDisproved | HTimeout | HError | HMemout
+
+getHyperResult :: [String] -> HyperResult
+getHyperResult out = case map (takeWhile isAlpha . dropWhile isSpace)
+    $ mapMaybe (stripPrefix "% SZS status ") out of
+  [s] | szsProved s -> HProved
+    | szsDisproved s -> HDisproved
+    | szsTimeout s -> HTimeout
+    | szsMemoryOut s -> HMemout
+  _ -> HError
+
+-- | examine SZS output
+examineProof :: ProverState
+             -> String
+             -> String
+             -> ProofStatus ProofTree
+             -> (ATPRetval, ProofStatus ProofTree)
+examineProof sps stdoutC stderrC defStatus =
+    let outText = "\nOutput was:\n\n" ++ stdoutC ++ stderrC
+        provenStat = defStatus
+          { usedAxioms = getAxioms sps
+          , proofTree = ProofTree stdoutC }
+     in case getHyperResult $ lines stdoutC of
+               HProved -> (ATPSuccess, provenStat { goalStatus = Proved True })
+               HTimeout -> (ATPTLimitExceeded, defStatus)
+               HDisproved -> (ATPSuccess, provenStat { goalStatus = Disproved })
+               HMemout -> (ATPError ("Out of Memory." ++ outText), defStatus)
+               HError -> ( ATPError ("Internal Error in ekrhyper." ++ outText)
+                         , defStatus)
+
+-- Consistency Checker
+
+hyperConsChecker :: ConsChecker Sign Sentence Sublogic Morphism ProofTree
+hyperConsChecker = (mkUsableConsChecker hyperS hyperS sublogics consCheck)
+  { ccNeedsTimer = False }
+
+{- |
+  Runs the krhyper cons-chcker. The tactic script only contains a string for the
+  time limit.
+-}
+
+runTxtC :: String
+runTxtC =
+    "% start derivation with the input received so far\n" ++
+    "#(run).\n\n" ++
+    "% print Hyper proof\n" ++
+    "%#(print_proof).\n\n" ++
+    "% print result and proof using SZS terminology;\n" ++
+    "% requires postprocessing with post_szs script for proper legibility\n" ++
+    "%#(print_szs_proof).\n\n" ++
+    "% Show the model\n" ++
+    "#(print_model).\n"
+
+consCheck :: String
+          -> TacticScript
+          -> TheoryMorphism Sign Sentence Morphism ProofTree
+          -> [FreeDefMorphism Sentence Morphism] -- ^ freeness constraints
+          -> IO (CCStatus ProofTree)
+consCheck thName (TacticScript tl) tm freedefs =
+    case tTarget tm of
+      Theory sig nSens -> do
+          let proverStateI = tptpProverState sig (toNamedList nSens) freedefs
+              saveFile = basename thName ++ ".tptp"
+          prob <- showTPTPProblemM thName proverStateI []
+          (stdoutC, stderrC, t_u) <-
+            runHyperProcess prob saveFile tl "" runTxtC
+          return CCStatus
+            { ccResult = case getHyperResult $ lines stdoutC of
+                HProved -> Just True
+                HDisproved -> Just False
+                _ -> Nothing
+            , ccProofTree = ProofTree $ stdoutC ++ stderrC
+            , ccUsedTime = t_u }

--- a/TPTP/Prover/ProverState.hs
+++ b/TPTP/Prover/ProverState.hs
@@ -17,6 +17,7 @@ module TPTP.Prover.ProverState ( ProverState (..)
                                , getAxioms
                                , insertSentenceIntoProverState
                                , ioShowTPTPProblem
+                               , showTPTPProblemM
                                , tptpProverState
                                ) where
 
@@ -97,6 +98,17 @@ generateTPTPProblem pLogicalPart mNewGoal = PProblem
     { identifier = "hets_exported"
     , logicalPart = maybe pLogicalPart (insertSentence pLogicalPart) mNewGoal
     }
+
+showTPTPProblemM
+    :: String -- ^ theory name
+    -> ProverState -- ^ prover state containing initial logical part
+    -> [String] -- ^ extra options
+    -> IO String -- ^ formatted output of the goal
+showTPTPProblemM thName pst _opts = do
+  let problem = generateTPTPProblem
+                  (psLogicalPart pst)
+                   Nothing
+  return $ show $ printTPTPProblem thName problem
 
 {- |
   Pretty printing TPTP goal in TPTP format.


### PR DESCRIPTION
In the GUI, we first select a prover and only then a comorphism path. On the paths to SoftFOL I get an error - `(Logic SoftFOL expected, but TPTP found)`. Perhaps we should have different options, e.g. Darwin-TPTP and Darwin-SoftFOL? Otherwise the code should be ready for review.