### PR TITLE
display ref trees individually

### DIFF
--- a/Static/DevGraph.hs
+++ b/Static/DevGraph.hs
@@ -782,7 +782,7 @@ addSpecNodeRT :: DGraph -> UnitSig -> String -> (Node, DGraph)
 addSpecNodeRT dg usig s =
  let
   (n, dg') = addNodeRT dg usig s
-  f = Map.insert s n $ specRoots dg'
+  f = Map.insert s [n] $ specRoots dg'
  in (n, dg' {specRoots = f})
 
 updateNodeNameRT :: DGraph -> Node -> Bool -> String -> DGraph
@@ -815,7 +815,7 @@ updateSigRT dg n usig =
 updateNodeNameSpecRT :: DGraph -> Node -> String -> DGraph
 updateNodeNameSpecRT dg n s =
  let dg' = updateNodeNameRT dg n False s
- in dg' {specRoots = Map.insert s n $ specRoots dg}
+ in dg' {specRoots = Map.insert s [n] $ specRoots dg}
 
 addSubTree :: DGraph -> Maybe RTLeaves -> RTPointer -> (DGraph, RTPointer)
 addSubTree dg Nothing (NPComp h) =
@@ -930,7 +930,7 @@ data DGraph = DGraph
   , dgBody :: Tree.Gr DGNodeLab DGLinkLab  -- ^ actual 'DGraph` tree
   , currentBaseTheory :: Maybe NodeSig
   , refTree :: Tree.Gr RTNodeLab RTLinkLab -- ^ the refinement tree
-  , specRoots :: Map.Map String Node -- ^ root nodes for named specs
+  , specRoots :: Map.Map String [Node] -- ^ root nodes for named specs, several for comp ref
   , nameMap :: MapSet.MapSet String Node -- ^ all nodes by name
   , archSpecDiags :: Map.Map String Diag
       -- ^ dependency diagrams between units

--- a/Static/DgUtils.hs
+++ b/Static/DgUtils.hs
@@ -352,7 +352,7 @@ compPointer (NPBranch n1 f1) (NPComp f2) =
        NPBranch n1 (Map.unionWith (\ _ y -> y) f1 f2 )
 compPointer (NPComp f1) (NPComp f2) =
        NPComp (Map.unionWith (\ _ y -> y) f1 f2)
-compPointer x y = error $ "compPointer:" ++ show x ++ " " ++ show y
+compPointer x y = error $ "compPointer:" ++ show x ++ " composed with " ++ show y
 
 -- sources
 


### PR DESCRIPTION
Should fix #974:
 - instead of showing all refinement trees, let the user select a refinement specification and display only that tree
 - nodes that have a dependency diagram are colored blue
 - changed the way these nodes are computed to only roots of architectural specifications that have diagram stored in the development graph (e.g. the dependency diagram of an anonymous arch spec that is the specification of a unit in a larger arch spec is not stored and therefore cannot be displayed).

An example can be found here: https://ontohub.org/sandbox/RefinementExamples.casl. I've just noticed there is a bug with composition of refinement pointers, so please use this file not the one in Hets-lib.