### PR TITLE
xsd string in OWL parser

### DIFF
--- a/OWL2/Parse.hs
+++ b/OWL2/Parse.hs
@@ -276,7 +276,7 @@ stringLiteral = do
         string asP
         t <- skips $ optionMaybe languageTag
         return $ Literal s $ Untyped t
-    <|> skips (return $ Literal s $ Typed $ mkIRI stringS)
+    <|> skips (return $ Literal s $ Typed $ (mkIRI stringS) {prefixName = "xsd"} )
 
 literal :: CharParser st Literal
 literal = do


### PR DESCRIPTION
Should fix #1972. Note that using `string` instead of `xsd:string` goes through, but the datatype `string` must be declared.