### PR TITLE
Rolled back indivuals to IRIs

### DIFF
--- a/OWL2/AS.hs
+++ b/OWL2/AS.hs
@@ -60,12 +60,9 @@ type ObjectProperty = IRI
 type DataProperty = IRI
 type DirectlyImportsDocuments = [IRI]
 type AnnotationProperty = IRI
-data Individual =
-  NamedIndividual_ NamedIndividual |
-  AnonymousIndividual AnonymousIndividual
-  deriving (Show, Eq, Ord, Data)
+type Individual = IRI
+type AnonymousIndividual = IRI
 type NamedIndividual = IRI
-type AnonymousIndividual = String
 
 data EquivOrDisjoint = Equivalent | Disjoint
     deriving (Show, Eq, Ord, Typeable, Data)


### PR DESCRIPTION
As it turned out AnonymousIndividuals were also represented as IRIs previously and are used as such in other files. Therefore changing it back to IRIs.