### PR TITLE
1989 fixing compilation for owl 2 functional syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -189,3 +189,4 @@ TPTP/ATC_TPTP.hs
 test/*/*.th
 test/*/*.xml
 /_dependencies
+stack.yaml.lock

--- a/Comorphisms/ExtModal2OWL.hs
+++ b/Comorphisms/ExtModal2OWL.hs
@@ -55,7 +55,7 @@ instance Comorphism
     SymbMapItems    -- symbol map items codomain
     OS.Sign         -- signature codomain
     OWLMorphism     -- morphism codomain
-    Entity          -- symbol codomain
+    AS.Entity          -- symbol codomain
     RawSymb         -- rawsymbol codomain
     ProofTree       -- proof tree codomain
     where

--- a/Comorphisms/ExtModal2OWL.hs
+++ b/Comorphisms/ExtModal2OWL.hs
@@ -21,7 +21,7 @@ import Common.ProofTree
 import OWL2.Logic_OWL2
 import OWL2.MS
 import Common.IRI
-import OWL2.AS
+import qualified OWL2.AS as AS
 import OWL2.ProfilesAndSublogics
 import OWL2.ManchesterPrint ()
 import OWL2.Morphism

--- a/ExtModal/ExtModal2Ship.hs
+++ b/ExtModal/ExtModal2Ship.hs
@@ -17,7 +17,7 @@ import CASL.Fold
 import ExtModal.AS_ExtModal
 import ExtModal.Ship
 
-import OWL2.AS
+import qualified OWL2.AS as AS
 import OWL2.ShipSyntax
 import OWL2.Translate
 

--- a/ExtModal/Ship.hs
+++ b/ExtModal/Ship.hs
@@ -13,7 +13,7 @@ monitor syntax
 module ExtModal.Ship where
 
 import OWL2.ShipSyntax
-import OWL2.AS
+import qualified OWL2.AS as AS
 
 import Common.Doc
 import Common.DocUtils

--- a/OWL2/CASL2OWL.hs
+++ b/OWL2/CASL2OWL.hs
@@ -31,7 +31,7 @@ import Data.Maybe
 -- OWL = codomain
 import OWL2.Logic_OWL2
 import OWL2.MS
-import OWL2.AS
+import qualified OWL2.AS as AS
 import Common.IRI
 import OWL2.ProfilesAndSublogics
 import OWL2.ManchesterPrint ()

--- a/OWL2/ColimSign.hs
+++ b/OWL2/ColimSign.hs
@@ -16,7 +16,7 @@ module OWL2.ColimSign where
 
 import OWL2.Sign
 import OWL2.Morphism
-import OWL2.AS
+import qualified OWL2.AS as AS
 import Common.IRI
 
 import Common.SetColimit
@@ -28,14 +28,14 @@ import qualified Data.Map as Map
 signColimit :: Gr Sign (Int, OWLMorphism) ->
                (Sign, Map.Map Int OWLMorphism)
 signColimit graph = let
-   conGraph = emap (getEntityTypeMap Class) $ nmap concepts graph
-   dataGraph = emap (getEntityTypeMap Datatype) $ nmap datatypes graph
-   indGraph = emap (getEntityTypeMap NamedIndividual) $ nmap individuals graph
-   objGraph = emap (getEntityTypeMap ObjectProperty) $
+   conGraph = emap (getEntityTypeMap AS.Class) $ nmap concepts graph
+   dataGraph = emap (getEntityTypeMap AS.Datatype) $ nmap datatypes graph
+   indGraph = emap (getEntityTypeMap AS.NamedIndividual) $ nmap individuals graph
+   objGraph = emap (getEntityTypeMap AS.ObjectProperty) $
               nmap objectProperties graph
-   dataPropGraph = emap (getEntityTypeMap DataProperty) $
+   dataPropGraph = emap (getEntityTypeMap AS.DataProperty) $
                nmap dataProperties graph
-   annPropGraph = emap (getEntityTypeMap AnnotationProperty) $
+   annPropGraph = emap (getEntityTypeMap AS.AnnotationProperty) $
                nmap annotationRoles graph
    _prefixGraph = emap getPrefixMap
                     $ nmap (Map.keysSet . toQName . prefixMap) graph
@@ -47,17 +47,17 @@ signColimit graph = let
    (ap, funAP) = addIntToSymbols $ computeColimitSet annPropGraph
    -- (pf, funP) = addIntToSymbols $ computeColimitSet prefixGraph
    morFun i = foldl Map.union Map.empty
-               [ setEntityTypeMap Class $
+               [ setEntityTypeMap AS.Class $
                    Map.findWithDefault (error "maps") i funC,
-                 setEntityTypeMap Datatype $
+                 setEntityTypeMap AS.Datatype $
                    Map.findWithDefault (error "maps") i funD,
-                 setEntityTypeMap NamedIndividual $
+                 setEntityTypeMap AS.NamedIndividual $
                    Map.findWithDefault (error "maps") i funI,
-                 setEntityTypeMap ObjectProperty $
+                 setEntityTypeMap AS.ObjectProperty $
                    Map.findWithDefault (error "maps") i funO,
-                 setEntityTypeMap DataProperty $
+                 setEntityTypeMap AS.DataProperty $
                    Map.findWithDefault (error "maps") i funDP,
-                 setEntityTypeMap AnnotationProperty $
+                 setEntityTypeMap AS.AnnotationProperty $
                    Map.findWithDefault (error "maps") i funAP
                 ]
    morMaps = Map.fromAscList $
@@ -87,18 +87,18 @@ signColimit graph = let
                      ) $ labNodes graph
   in (colimSign, colimMor)
 
-getEntityTypeMap :: EntityType -> (Int, OWLMorphism)
+getEntityTypeMap :: AS.EntityType -> (Int, OWLMorphism)
                     -> (Int, Map.Map IRI IRI)
 getEntityTypeMap e (i, phi) = let
  f = Map.filterWithKey
-      (\ (Entity _ x _) _ -> x == e) $ mmaps phi
+      (\ (AS.Entity _ x _) _ -> x == e) $ mmaps phi
  in (i, Map.fromList $
-    map (\ (Entity _ _ x, y) -> (x, y)) $
+    map (\ (AS.Entity _ _ x, y) -> (x, y)) $
     Map.toAscList f)
 
-setEntityTypeMap :: EntityType -> Map.Map IRI IRI
-                    -> Map.Map Entity IRI
-setEntityTypeMap = Map.mapKeys . mkEntity
+setEntityTypeMap :: AS.EntityType -> Map.Map IRI IRI
+                    -> Map.Map AS.Entity IRI
+setEntityTypeMap = Map.mapKeys . AS.mkEntity
 
 getPrefixMap :: (Int, OWLMorphism) -> (Int, Map.Map IRI IRI)
 getPrefixMap (i, phi) = let
@@ -107,5 +107,5 @@ getPrefixMap (i, phi) = let
         map (\ (x, y) -> (mkIRI x, mkIRI y)) $
             Map.toAscList f)
 
-toQName :: PrefixMap -> Map.Map IRI String
+toQName :: AS.PrefixMap -> Map.Map IRI String
 toQName pm = Map.fromList $ map (\ (p, s) -> (mkIRI p, s)) $ Map.toList pm

--- a/OWL2/DMU2OWL2.hs
+++ b/OWL2/DMU2OWL2.hs
@@ -57,7 +57,7 @@ instance Language DMU2OWL2 -- default definition is okay
 instance Comorphism DMU2OWL2
    DMU () Text () () () Text (DefaultMorphism Text) () () ()
    OWL2 ProfSub OntologyDocument Axiom SymbItems SymbMapItems
-       Sign OWLMorphism Entity RawSymb ProofTree where
+       Sign OWLMorphism AS.Entity RawSymb ProofTree where
     sourceLogic DMU2OWL2 = DMU
     sourceSublogic DMU2OWL2 = top
     targetLogic DMU2OWL2 = OWL2

--- a/OWL2/DMU2OWL2.hs
+++ b/OWL2/DMU2OWL2.hs
@@ -30,7 +30,7 @@ import qualified Data.Map as Map
 
 import DMU.Logic_DMU
 
-import OWL2.AS
+import qualified OWL2.AS as AS
 import OWL2.MS
 import OWL2.Logic_OWL2
 import OWL2.Morphism

--- a/OWL2/Logic_OWL2.hs
+++ b/OWL2/Logic_OWL2.hs
@@ -37,7 +37,7 @@ import qualified Data.Set as Set
 import Logic.Logic
 
 import qualified OWL2.AS as AS
-import OWL2.ATC_OWL2 ()
+--import OWL2.ATC_OWL2 ()
 import OWL2.ColimSign
 import OWL2.Conservativity
 import OWL2.MS
@@ -57,8 +57,20 @@ import OWL2.Symbols
 import OWL2.Taxonomy
 import OWL2.Theorem
 import OWL2.ExtractModule
+import ATerm.Conversion
 
 data OWL2 = OWL2
+
+instance ShATermConvertible SymbItems
+instance ShATermConvertible SymbMapItems
+instance ShATermConvertible Sign
+instance ShATermConvertible Axiom
+instance ShATermConvertible OntologyDocument
+instance ShATermConvertible OWLMorphism
+instance ShATermConvertible AS.Entity
+instance ShATermConvertible ProfSub
+
+
 
 instance Show OWL2 where
   show _ = "OWL"

--- a/OWL2/Logic_OWL2.hs
+++ b/OWL2/Logic_OWL2.hs
@@ -36,7 +36,7 @@ import qualified Data.Set as Set
 
 import Logic.Logic
 
-import OWL2.AS
+import qualified OWL2.AS as AS
 import OWL2.ATC_OWL2 ()
 import OWL2.ColimSign
 import OWL2.Conservativity

--- a/OWL2/Logic_OWL2.hs
+++ b/OWL2/Logic_OWL2.hs
@@ -85,7 +85,7 @@ instance Monoid OntologyDocument where
     mappend (OntologyDocument p1 o1) (OntologyDocument p2 o2) =
       OntologyDocument (Map.union p1 p2) $ mappend o1 o2
 
-instance Syntax OWL2 OntologyDocument Entity SymbItems SymbMapItems where
+instance Syntax OWL2 OntologyDocument AS.Entity SymbItems SymbMapItems where
     parsersAndPrinters OWL2 = addSyntax "Ship" (basicSpec, ppShipOnt)
       $ addSyntax "Manchester" (basicSpec, pretty)
       $ makeDefault (basicSpec, pretty)
@@ -94,24 +94,24 @@ instance Syntax OWL2 OntologyDocument Entity SymbItems SymbMapItems where
     parse_symb_map_items OWL2 = Just symbMapItems
     symb_items_name OWL2 = symbItemsName
 
-instance Sentences OWL2 Axiom Sign OWLMorphism Entity where
+instance Sentences OWL2 Axiom Sign OWLMorphism AS.Entity where
     map_sen OWL2 = mapSen
     print_named OWL2 = printOneNamed
     sym_of OWL2 = singletonList . symOf
     symmap_of OWL2 = symMapOf
-    sym_name OWL2 = entityToId
-    sym_label OWL2 = label
+    sym_name OWL2 = AS.entityToId
+    sym_label OWL2 = AS.label
     fullSymName OWL2 s = let
-      i = cutIRI s
+      i = AS.cutIRI s
       x = showIRI i --expandedIRI i
-      in if null x then getPredefName i else x
-    symKind OWL2 = takeWhile isAlpha . showEntityType . entityKind
+      in if null x then AS.getPredefName i else x
+    symKind OWL2 = takeWhile isAlpha . AS.showEntityType . AS.entityKind
     symsOfSen OWL2 _ = Set.toList . symsOfAxiom
-    pair_symbols OWL2 = pairSymbols
+    pair_symbols OWL2 = AS.pairSymbols
 
 inducedFromToMor :: Map.Map RawSymb RawSymb -> 
-                    ExtSign Sign Entity -> 
-                    ExtSign Sign Entity -> 
+                    ExtSign Sign AS.Entity -> 
+                    ExtSign Sign AS.Entity -> 
                     Result OWLMorphism
 inducedFromToMor rm s@(ExtSign ssig _) t@(ExtSign tsig _) = 
  case Map.toList rm of
@@ -120,23 +120,23 @@ inducedFromToMor rm s@(ExtSign ssig _) t@(ExtSign tsig _) =
        mkImplMap f k = 
          case Set.toList (f tsig) of 
            [x] -> 
-              let aEntity = Entity Nothing k x
+              let aEntity = AS.Entity Nothing k x
               in Map.fromList $ 
-                    map (\y -> (ASymbol $ Entity Nothing k y, 
+                    map (\y -> (ASymbol $ AS.Entity Nothing k y, 
                                ASymbol $ aEntity)) $ 
                     Set.toList $ f ssig
            _ -> Map.empty 
        rm' = Map.unions
-                   [mkImplMap concepts Class,
-                    mkImplMap objectProperties ObjectProperty,
-                    mkImplMap dataProperties DataProperty, 
-                    mkImplMap individuals NamedIndividual]
+                   [mkImplMap concepts AS.Class,
+                    mkImplMap objectProperties AS.ObjectProperty,
+                    mkImplMap dataProperties AS.DataProperty, 
+                    mkImplMap individuals AS.NamedIndividual]
       in inducedFromToMorphismAux rm' s t 
    _ ->  inducedFromToMorphismAux rm  s t
 
 inducedFromToMorphismAux :: Map.Map RawSymb RawSymb -> 
-                    ExtSign Sign Entity -> 
-                    ExtSign Sign Entity -> 
+                    ExtSign Sign AS.Entity -> 
+                    ExtSign Sign AS.Entity -> 
                     Result OWLMorphism
 inducedFromToMorphismAux rm s@(ExtSign ssig _) t@(ExtSign tsig _) = do
     mor <- inducedFromMor rm ssig
@@ -148,7 +148,7 @@ instance StaticAnalysis OWL2 OntologyDocument Axiom
                SymbItems SymbMapItems
                Sign
                OWLMorphism
-               Entity RawSymb where
+               AS.Entity RawSymb where
       basic_analysis OWL2 = Just basicOWL2Analysis
       stat_symb_items OWL2 s = return . statSymbItems s
       stat_symb_map_items OWL2 = statSymbMapItems
@@ -178,7 +178,7 @@ instance StaticAnalysis OWL2 OntologyDocument Axiom
 #endif
 instance Logic OWL2 ProfSub OntologyDocument Axiom SymbItems SymbMapItems
                Sign
-               OWLMorphism Entity RawSymb ProofTree where
+               OWLMorphism AS.Entity RawSymb ProofTree where
          empty_proof_tree OWL2 = emptyProofTree
          -- just a selection of sublogics
          all_sublogics OWL2 = bottomS : concat allProfSubs ++ [topS]
@@ -222,7 +222,7 @@ instance MinSublogic ProfSub SymbItems where
 instance MinSublogic ProfSub SymbMapItems where
     minSublogic = const topS
 
-instance MinSublogic ProfSub Entity where
+instance MinSublogic ProfSub AS.Entity where
     minSublogic = const topS
 
 instance MinSublogic ProfSub OntologyDocument where
@@ -234,7 +234,7 @@ instance ProjectSublogicM ProfSub SymbItems where
 instance ProjectSublogicM ProfSub SymbMapItems where
     projectSublogicM = const Just
 
-instance ProjectSublogicM ProfSub Entity where
+instance ProjectSublogicM ProfSub AS.Entity where
     projectSublogicM = const Just
 
 instance ProjectSublogic ProfSub OntologyDocument where

--- a/OWL2/MS.hs
+++ b/OWL2/MS.hs
@@ -17,7 +17,7 @@ module OWL2.MS where
 
 import Common.Id
 import Common.IRI
-import OWL2.AS
+import qualified OWL2.AS as AS
 
 import Data.Data
 import qualified Data.Map as Map
@@ -25,27 +25,27 @@ import qualified Data.Set as Set
 
 {- | annotions are annotedAnnotationList that must be preceded by the keyword
   @Annotations:@ if non-empty -}
-type Annotations = [Annotation]
+type Annotations = [AS.Annotation]
 
 type AnnotatedList a = [(Annotations, a)]
 
 -- | this datatype extends the Manchester Syntax to also allow GCIs
 data Extended =
     Misc Annotations
-  | ClassEntity ClassExpression
-  | ObjectEntity ObjectPropertyExpression
-  | SimpleEntity Entity
+  | ClassEntity AS.ClassExpression
+  | ObjectEntity AS.ObjectPropertyExpression
+  | SimpleEntity AS.Entity
     deriving (Show, Eq, Ord, Typeable, Data)
 
 -- | frames with annotated lists
 data ListFrameBit =
-    AnnotationBit (AnnotatedList AnnotationProperty) -- relation
-  | ExpressionBit (AnnotatedList ClassExpression) -- relation
-  | ObjectBit (AnnotatedList ObjectPropertyExpression) -- relation
-  | DataBit (AnnotatedList DataPropertyExpression) -- relation
-  | IndividualSameOrDifferent (AnnotatedList Individual) -- relation
-  | ObjectCharacteristics (AnnotatedList Character)
-  | DataPropRange (AnnotatedList DataRange)
+    AnnotationBit (AnnotatedList AS.AnnotationProperty) -- relation
+  | ExpressionBit (AnnotatedList AS.ClassExpression) -- relation
+  | ObjectBit (AnnotatedList AS.ObjectPropertyExpression) -- relation
+  | DataBit (AnnotatedList AS.DataPropertyExpression) -- relation
+  | IndividualSameOrDifferent (AnnotatedList AS.NamedIndividual) -- relation
+  | ObjectCharacteristics (AnnotatedList AS.Character)
+  | DataPropRange (AnnotatedList AS.DataRange)
   | IndividualFacts (AnnotatedList Fact)
     deriving (Show, Eq, Ord, Typeable, Data)
 
@@ -56,19 +56,19 @@ data AnnoType = Declaration | Assertion | XmlError String
 data AnnFrameBit =
     AnnotationFrameBit AnnoType
   | DataFunctional
-  | DatatypeBit DataRange
-  | ClassDisjointUnion [ClassExpression]
-  | ClassHasKey [ObjectPropertyExpression] [DataPropertyExpression]
-  | ObjectSubPropertyChain [ObjectPropertyExpression]
+  | DatatypeBit AS.DataRange
+  | ClassDisjointUnion [AS.ClassExpression]
+  | ClassHasKey [AS.ObjectPropertyExpression] [AS.DataPropertyExpression]
+  | ObjectSubPropertyChain [AS.ObjectPropertyExpression]
     deriving (Show, Eq, Ord, Typeable, Data)
 
 data Fact =
-    ObjectPropertyFact PositiveOrNegative ObjectPropertyExpression Individual
-  | DataPropertyFact PositiveOrNegative DataPropertyExpression Literal
+    ObjectPropertyFact AS.PositiveOrNegative AS.ObjectPropertyExpression AS.NamedIndividual
+  | DataPropertyFact AS.PositiveOrNegative AS.DataPropertyExpression AS.Literal
   deriving (Show, Eq, Ord, Typeable, Data)
 
 data FrameBit =
-    ListFrameBit (Maybe Relation) ListFrameBit
+    ListFrameBit (Maybe AS.Relation) ListFrameBit
   | AnnFrameBit Annotations AnnFrameBit
     deriving (Show, Eq, Ord, Typeable, Data)
 
@@ -87,10 +87,10 @@ data Axiom = PlainAxiom
 
 -}
 
-mkExtendedEntity :: Entity -> Extended
-mkExtendedEntity e@(Entity _ ty iri) = case ty of
-  Class -> ClassEntity $ Expression iri
-  ObjectProperty -> ObjectEntity $ ObjectProp iri
+mkExtendedEntity :: AS.Entity -> Extended
+mkExtendedEntity e@(AS.Entity _ ty iri) = case ty of
+  AS.Class -> ClassEntity $ AS.Expression iri
+  AS.ObjectProperty -> ObjectEntity $ AS.ObjectProp iri
   _ -> SimpleEntity e
 
 getAxioms :: Frame -> [Axiom]
@@ -103,14 +103,14 @@ instance GetRange Axiom where
   getRange = Range . joinRanges . map rangeSpan . Set.toList . symsOfAxiom
 
 data Ontology = Ontology
-    { name :: OntologyIRI
-    , imports :: [ImportIRI]
+    { name :: AS.OntologyIRI
+    , imports :: [AS.ImportIRI]
     , ann :: [Annotations]
     , ontFrames :: [Frame]
     } deriving (Show, Eq, Ord, Typeable, Data)
 
 data OntologyDocument = OntologyDocument
-    { prefixDeclaration :: PrefixMap
+    { prefixDeclaration :: AS.PrefixMap
     , ontology :: Ontology
     } deriving (Show, Eq, Ord, Typeable, Data)
 
@@ -133,61 +133,61 @@ isEmptyOntologyDoc (OntologyDocument ns onto) =
 emptyAnnoList :: [a] -> AnnotatedList a
 emptyAnnoList = map $ \ x -> ([], x)
 
-symsOfAxiom :: Axiom -> Set.Set Entity
+symsOfAxiom :: Axiom -> Set.Set AS.Entity
 symsOfAxiom (PlainAxiom e f) = Set.union (symsOfExtended e) $ symsOfFrameBit f
 
-symsOfExtended :: Extended -> Set.Set Entity
+symsOfExtended :: Extended -> Set.Set AS.Entity
 symsOfExtended e = case e of
   Misc as -> symsOfAnnotations as
   SimpleEntity s -> Set.singleton s
   ObjectEntity o -> symsOfObjectPropertyExpression o
   ClassEntity c -> symsOfClassExpression c
 
-symsOfObjectPropertyExpression :: ObjectPropertyExpression -> Set.Set Entity
+symsOfObjectPropertyExpression :: AS.ObjectPropertyExpression -> Set.Set AS.Entity
 symsOfObjectPropertyExpression o = case o of
-  ObjectProp i -> Set.singleton $ mkEntity ObjectProperty i
-  ObjectInverseOf i -> symsOfObjectPropertyExpression i
+  AS.ObjectProp i -> Set.singleton $ AS.mkEntity AS.ObjectProperty i
+  AS.ObjectInverseOf i -> symsOfObjectPropertyExpression i
 
-symsOfClassExpression :: ClassExpression -> Set.Set Entity
+symsOfClassExpression :: AS.ClassExpression -> Set.Set AS.Entity
 symsOfClassExpression ce = case ce of
-  Expression c -> Set.singleton $ mkEntity Class c
-  ObjectJunction _ cs -> Set.unions $ map symsOfClassExpression cs
-  ObjectComplementOf c -> symsOfClassExpression c
-  ObjectOneOf is -> Set.fromList $ map (mkEntity NamedIndividual) is
-  ObjectValuesFrom _ oe c -> Set.union (symsOfObjectPropertyExpression oe)
+  AS.Expression c -> Set.singleton $ AS.mkEntity AS.Class c
+  AS.ObjectJunction _ cs -> Set.unions $ map symsOfClassExpression cs
+  AS.ObjectComplementOf c -> symsOfClassExpression c
+  AS.ObjectOneOf is -> Set.fromList $ map (AS.mkEntity AS.NamedIndividual) is
+  AS.ObjectValuesFrom _ oe c -> Set.union (symsOfObjectPropertyExpression oe)
     $ symsOfClassExpression c
-  ObjectHasValue oe i -> Set.insert (mkEntity NamedIndividual i)
+  AS.ObjectHasValue oe i -> Set.insert (AS.mkEntity AS.NamedIndividual i)
     $ symsOfObjectPropertyExpression oe
-  ObjectHasSelf oe -> symsOfObjectPropertyExpression oe
-  ObjectCardinality (Cardinality _ _ oe mc) -> Set.union
+  AS.ObjectHasSelf oe -> symsOfObjectPropertyExpression oe
+  AS.ObjectCardinality (AS.Cardinality _ _ oe mc) -> Set.union
     (symsOfObjectPropertyExpression oe)
     $ maybe Set.empty symsOfClassExpression mc
-  DataValuesFrom _ de dr -> Set.insert (mkEntity DataProperty de)
+  AS.DataValuesFrom _ de dr -> Set.union (Set.fromList $ map (AS.mkEntity AS.DataProperty) de)
     $ symsOfDataRange dr
-  DataHasValue de _ -> Set.singleton $ mkEntity DataProperty de
-  DataCardinality (Cardinality _ _ d m) -> Set.insert (mkEntity DataProperty d)
+  AS.DataHasValue de _ -> Set.singleton $ AS.mkEntity AS.DataProperty de
+  AS.DataCardinality (AS.Cardinality _ _ d m) -> Set.insert (AS.mkEntity AS.DataProperty d)
     $ maybe Set.empty symsOfDataRange m
 
-symsOfDataRange :: DataRange -> Set.Set Entity
+symsOfDataRange :: AS.DataRange -> Set.Set AS.Entity
 symsOfDataRange dr = case dr of
-  DataType t _ -> Set.singleton $ mkEntity Datatype t
-  DataJunction _ ds -> Set.unions $ map symsOfDataRange ds
-  DataComplementOf d -> symsOfDataRange d
-  DataOneOf _ -> Set.empty
+  AS.DataType t _ -> Set.singleton $ AS.mkEntity AS.Datatype t
+  AS.DataJunction _ ds -> Set.unions $ map symsOfDataRange ds
+  AS.DataComplementOf d -> symsOfDataRange d
+  AS.DataOneOf _ -> Set.empty
 
-symsOfAnnotation :: Annotation -> Set.Set Entity
-symsOfAnnotation (Annotation as p _) = Set.insert
-   (mkEntity AnnotationProperty p) $ Set.unions (map symsOfAnnotation as)
+symsOfAnnotation :: AS.Annotation -> Set.Set AS.Entity
+symsOfAnnotation (AS.Annotation as p _) = Set.insert
+   (AS.mkEntity AS.AnnotationProperty p) $ Set.unions (map symsOfAnnotation as)
 
-symsOfAnnotations :: Annotations -> Set.Set Entity
+symsOfAnnotations :: Annotations -> Set.Set AS.Entity
 symsOfAnnotations = Set.unions . map symsOfAnnotation
 
-symsOfFrameBit :: FrameBit -> Set.Set Entity
+symsOfFrameBit :: FrameBit -> Set.Set AS.Entity
 symsOfFrameBit fb = case fb of
   ListFrameBit _ lb -> symsOfListFrameBit lb
   AnnFrameBit as af -> Set.union (symsOfAnnotations as) $ symsOfAnnFrameBit af
 
-symsOfAnnFrameBit :: AnnFrameBit -> Set.Set Entity
+symsOfAnnFrameBit :: AnnFrameBit -> Set.Set AS.Entity
 symsOfAnnFrameBit af = case af of
   AnnotationFrameBit _ -> Set.empty
   DataFunctional -> Set.empty
@@ -195,29 +195,29 @@ symsOfAnnFrameBit af = case af of
   ClassDisjointUnion cs -> Set.unions $ map symsOfClassExpression cs
   ClassHasKey os ds -> Set.union
     (Set.unions $ map symsOfObjectPropertyExpression os)
-    . Set.fromList $ map (mkEntity DataProperty) ds
+    . Set.fromList $ map (AS.mkEntity AS.DataProperty) ds
   ObjectSubPropertyChain os ->
     Set.unions $ map symsOfObjectPropertyExpression os
 
-symsOfListFrameBit :: ListFrameBit -> Set.Set Entity
+symsOfListFrameBit :: ListFrameBit -> Set.Set AS.Entity
 symsOfListFrameBit lb = case lb of
   AnnotationBit l -> annotedSyms
-    (Set.singleton . mkEntity AnnotationProperty) l
+    (Set.singleton . AS.mkEntity AS.AnnotationProperty) l
   ExpressionBit l -> annotedSyms symsOfClassExpression l
   ObjectBit l -> annotedSyms symsOfObjectPropertyExpression l
-  DataBit l -> annotedSyms (Set.singleton . mkEntity DataProperty) l
+  DataBit l -> annotedSyms (Set.singleton . AS.mkEntity AS.DataProperty) l
   IndividualSameOrDifferent l -> annotedSyms
-    (Set.singleton . mkEntity NamedIndividual) l
+    (Set.singleton . AS.mkEntity AS.NamedIndividual) l
   ObjectCharacteristics l -> annotedSyms (const Set.empty) l
   DataPropRange l -> annotedSyms symsOfDataRange l
   IndividualFacts l -> annotedSyms symsOfFact l
 
-symsOfFact :: Fact -> Set.Set Entity
+symsOfFact :: Fact -> Set.Set AS.Entity
 symsOfFact fact = case fact of
-  ObjectPropertyFact _ oe i -> Set.insert (mkEntity NamedIndividual i)
+  ObjectPropertyFact _ oe i -> Set.insert (AS.mkEntity AS.NamedIndividual i)
     $ symsOfObjectPropertyExpression oe
-  DataPropertyFact _ d _ -> Set.singleton $ mkEntity DataProperty d
+  DataPropertyFact _ d _ -> Set.singleton $ AS.mkEntity AS.DataProperty d
 
-annotedSyms :: (a -> Set.Set Entity) -> AnnotatedList a -> Set.Set Entity
+annotedSyms :: (a -> Set.Set AS.Entity) -> AnnotatedList a -> Set.Set AS.Entity
 annotedSyms f l = Set.union (Set.unions $ map (symsOfAnnotations . fst) l)
   . Set.unions $ map (f . snd) l

--- a/OWL2/MS2Ship.hs
+++ b/OWL2/MS2Ship.hs
@@ -12,7 +12,7 @@ convert ontology to SHIP syntax
 
 module OWL2.MS2Ship where
 
-import OWL2.AS
+import qualified OWL2.AS
 import Common.IRI
 import OWL2.Keywords
 import OWL2.MS

--- a/OWL2/MS2Ship.hs
+++ b/OWL2/MS2Ship.hs
@@ -12,7 +12,7 @@ convert ontology to SHIP syntax
 
 module OWL2.MS2Ship where
 
-import qualified OWL2.AS
+import qualified OWL2.AS as AS
 import Common.IRI
 import OWL2.Keywords
 import OWL2.MS
@@ -46,8 +46,8 @@ frame2Boxes (Frame e bs) = case e of
     (ds, rs) = getRoleType r es
     rt = on RoleType intersectConcepts ds rs
     in Box [] (nubOrd $ map (setRoleType r rt) es) []
-  SimpleEntity (Entity _ et i) -> case et of
-    NamedIndividual -> Box [] [] $ concatMap (indFrame2Boxes $ show $ iriPath i) bs
+  SimpleEntity (AS.Entity _ et i) -> case et of
+    AS.NamedIndividual -> Box [] [] $ concatMap (indFrame2Boxes $ show $ iriPath i) bs
     _ -> Box [] [] []
   Misc _ -> catBoxes $ map miscFrame2Boxes bs
 
@@ -63,14 +63,14 @@ classAnnFrame2Boxes c fb = case fb of
   AnnotationFrameBit Declaration -> [ConceptDecl c $ ADTCons []]
   _ -> []
 
-classListFrame2Boxes :: Concept -> Maybe Relation -> ListFrameBit -> [TBox]
+classListFrame2Boxes :: Concept -> Maybe AS.Relation -> ListFrameBit -> [TBox]
 classListFrame2Boxes c mr lfb = case lfb of
   ExpressionBit l -> let cs = map (ce2Concept . snd) l in case mr of
     Just r -> case r of
-      SubClass -> map (ConceptDecl c . ConceptRel Less) cs
-      EDRelation ed -> map ((case ed of
-        Disjoint -> disC
-        Equivalent -> eqC) c) cs
+      AS.SubClass -> map (ConceptDecl c . ConceptRel Less) cs
+      AS.EDRelation ed -> map ((case ed of
+        AS.Disjoint -> disC
+        AS.Equivalent -> eqC) c) cs
       _ -> []
     _ -> []
   _ -> []
@@ -82,21 +82,21 @@ opFrame2Boxes r b = case b of
     AnnotationFrameBit Declaration -> [RoleDecl r topRT]
     _ -> []
 
-opListFrame2Boxes :: Role -> Maybe Relation -> ListFrameBit -> [RBox]
+opListFrame2Boxes :: Role -> Maybe AS.Relation -> ListFrameBit -> [RBox]
 opListFrame2Boxes r mr lfb = case mr of
     Just rel -> case rel of
-      DRRelation dr -> case lfb of
+      AS.DRRelation dr -> case lfb of
         ExpressionBit l -> let cs = map (ce2Concept . snd) l in case dr of
-          ADomain -> map (\ c -> RoleDecl r (RoleType c topC)) cs
-          ARange -> map (RoleDecl r . RoleType topC) cs
+          AS.ADomain -> map (\ c -> RoleDecl r (RoleType c topC)) cs
+          AS.ARange -> map (RoleDecl r . RoleType topC) cs
         _ -> []
       _ -> case lfb of
         ObjectBit l -> let opes = map (ope2Role . snd) l in case rel of
-          SubPropertyOf -> map (RoleRel r Less) opes
-          InverseOf -> map (RoleRel r Eq . UnOp InvR) opes
-          EDRelation er -> map ((case er of
-            Equivalent -> eqR
-            Disjoint -> disR) r) opes
+          AS.SubPropertyOf -> map (RoleRel r Less) opes
+          AS.InverseOf -> map (RoleRel r Eq . UnOp InvR) opes
+          AS.EDRelation er -> map ((case er of
+            AS.Equivalent -> eqR
+            AS.Disjoint -> disR) r) opes
           _ -> []
         _ -> []
     Nothing -> case lfb of
@@ -115,14 +115,14 @@ setRoleType r1 r b = case b of
 
 flatIntersection :: Concept -> [Concept]
 flatIntersection c = case c of
-  JoinedC (Just IntersectionOf) cs -> concatMap flatIntersection cs
+  JoinedC (Just AS.IntersectionOf) cs -> concatMap flatIntersection cs
   _ -> [c]
 
 intersectConcepts :: [Concept] -> Concept
 intersectConcepts = (\ l -> case l of
   [] -> topC
   [c] -> c
-  _ -> JoinedC (Just IntersectionOf) l)
+  _ -> JoinedC (Just AS.IntersectionOf) l)
   . Set.toList . Set.delete topC . Set.fromList . concatMap flatIntersection
 
 indFrame2Boxes :: String -> FrameBit -> [ABox]
@@ -130,18 +130,18 @@ indFrame2Boxes i b = case b of
   ListFrameBit mr lfb -> indListFrame2Boxes i mr lfb
   AnnFrameBit {} -> []
 
-indListFrame2Boxes :: String -> Maybe Relation -> ListFrameBit -> [ABox]
+indListFrame2Boxes :: String -> Maybe AS.Relation -> ListFrameBit -> [ABox]
 indListFrame2Boxes i mr lfb = case lfb of
-    ExpressionBit l | mr == Just Types ->
+    ExpressionBit l | mr == Just AS.Types ->
       map (AConcept i . ce2Concept . snd) l
     IndividualFacts l | isNothing mr ->
       concatMap (\ f -> case snd f of
         ObjectPropertyFact pn ope j ->
           [ARole i (show $ iriPath j)
-          $ (if pn == Positive then id else UnOp NotR) $ ope2Role ope]
+          $ (if pn == AS.Positive then id else UnOp NotR) $ ope2Role ope]
         DataPropertyFact {} -> []) l
     IndividualSameOrDifferent l -> case mr of
-      Just (SDRelation sd) -> map (AIndividual i sd . show . iriPath . snd) l
+      Just (AS.SDRelation sd) -> map (AIndividual i sd . show . iriPath . snd) l
       _ -> []
     _ -> []
 
@@ -150,18 +150,18 @@ miscFrame2Boxes b = case b of
     ListFrameBit mr lfb -> miscListFrame2Boxes mr lfb
     AnnFrameBit {} -> emptyBox
 
-miscListFrame2Boxes :: Maybe Relation -> ListFrameBit -> Box
+miscListFrame2Boxes :: Maybe AS.Relation -> ListFrameBit -> Box
 miscListFrame2Boxes mr lfb = case mr of
   Just jr -> case jr of
-    EDRelation ed -> case lfb of
+    AS.EDRelation ed -> case lfb of
       ExpressionBit l -> let cs = map (ce2Concept . snd) l in
-        Box (if ed == Disjoint then [DisjointCs cs] else mkCycle eqC cs) [] []
+        Box (if ed == AS.Disjoint then [DisjointCs cs] else mkCycle eqC cs) [] []
       ObjectBit l -> let opes = map (ope2Role . snd) l in
-        Box [] (if ed == Disjoint then disRs opes else mkCycle eqR opes) []
+        Box [] (if ed == AS.Disjoint then disRs opes else mkCycle eqR opes) []
       _ -> emptyBox
-    SDRelation sd -> case lfb of
+    AS.SDRelation sd -> case lfb of
       IndividualSameOrDifferent l -> let is = map (iriPath . snd) l in
-        Box [] [] $ (if sd == Same then mkCycle else pairwise)
+        Box [] [] $ (if sd == AS.Same then mkCycle else pairwise)
          (`AIndividual` sd) (map show is)
       _ -> emptyBox
     _ -> emptyBox
@@ -188,7 +188,7 @@ pairwise f l = case l of
   h : t -> map (f h) t ++ pairwise f t
 
 disR :: Role -> Role -> RBox
-disR r t = RoleRel botR Eq $ JoinedR (Just IntersectionOf) [r, t]
+disR r t = RoleRel botR Eq $ JoinedR (Just AS.IntersectionOf) [r, t]
 
 disRs :: [Role] -> [RBox]
 disRs = pairwise disR
@@ -199,26 +199,26 @@ topRT = RoleType topC topC
 i2c :: IRI -> Concept
 i2c = NominalC . show . iriPath
 
-ce2Concept :: ClassExpression -> Concept
+ce2Concept :: AS.ClassExpression -> Concept
 ce2Concept ce = case ce of
-    Expression c -> let s = show $ iriPath c in
-      if isThing c then if s == thingS then topC else NotC topC
+    AS.Expression c -> let s = show $ iriPath c in
+      if AS.isThing c then if s == thingS then topC else NotC topC
       else CName s
-    ObjectJunction t cs -> JoinedC (Just t) $ map ce2Concept cs
-    ObjectComplementOf c -> NotC $ ce2Concept c
-    ObjectOneOf is -> JoinedC (Just UnionOf) $ map i2c is
-    ObjectValuesFrom q ope c -> Quant (Left q) (ope2Role ope) $ ce2Concept c
-    ObjectHasValue ope i -> Quant (Left SomeValuesFrom) (ope2Role ope) $ i2c i
+    AS.ObjectJunction t cs -> JoinedC (Just t) $ map ce2Concept cs
+    AS.ObjectComplementOf c -> NotC $ ce2Concept c
+    AS.ObjectOneOf is -> JoinedC (Just AS.UnionOf) $ map i2c is
+    AS.ObjectValuesFrom q ope c -> Quant (Left q) (ope2Role ope) $ ce2Concept c
+    AS.ObjectHasValue ope i -> Quant (Left AS.SomeValuesFrom) (ope2Role ope) $ i2c i
     -- the following translations are partly workarounds
-    ObjectHasSelf ope -> Quant (Left SomeValuesFrom) (ope2Role ope)
+    AS.ObjectHasSelf ope -> Quant (Left AS.SomeValuesFrom) (ope2Role ope)
       $ CName selfS
-    ObjectCardinality (Cardinality t i ope mc) -> Quant (Right (t, i))
+    AS.ObjectCardinality (AS.Cardinality t i ope mc) -> Quant (Right (t, i))
       (ope2Role ope) $ maybe topC ce2Concept mc
     _ -> CName dATAS
 
-ope2Role :: ObjectPropertyExpression -> Role
+ope2Role :: AS.ObjectPropertyExpression -> Role
 ope2Role ope = case ope of
-    ObjectProp o -> let r = show $ iriPath o in
-      if isPredefObjProp o then if r == topObjProp then topR else botR
+    AS.ObjectProp o -> let r = show $ iriPath o in
+      if AS.isPredefObjProp o then if r == topObjProp then topR else botR
       else RName r
-    ObjectInverseOf e -> UnOp InvR $ ope2Role e
+    AS.ObjectInverseOf e -> UnOp InvR $ ope2Role e

--- a/OWL2/ManchesterPrint.hs
+++ b/OWL2/ManchesterPrint.hs
@@ -18,7 +18,7 @@ import Common.AS_Annotation as Anno
 import Common.Lib.State
 import Common.IRI
 
-import OWL2.AS
+import qualified OWL2.AS as AS
 import OWL2.Extract
 import OWL2.MS
 import OWL2.Sign
@@ -40,8 +40,8 @@ printOneNamed ns = pretty
 
 delTopic :: Extended -> Sign -> Sign
 delTopic e s = case e of
-  ClassEntity (Expression c) -> s { concepts = Set.delete c $ concepts s }
-  ObjectEntity (ObjectProp o) -> s
+  ClassEntity (AS.Expression c) -> s { concepts = Set.delete c $ concepts s }
+  ObjectEntity (AS.ObjectProp o) -> s
     { objectProperties = Set.delete o $ objectProperties s }
   SimpleEntity et -> execState (modEntity Set.delete et) s
   _ -> s
@@ -58,7 +58,7 @@ printOWLBasicTheory = printBasicTheory . prepareBasicTheory
 
 prepareBasicTheory :: (Sign, [Named Axiom]) -> (Sign, [Named Axiom])
 prepareBasicTheory (s, l) =
-  (s { prefixMap = Map.union (prefixMap s) predefPrefixes }, l)
+  (s { prefixMap = Map.union (prefixMap s) AS.predefPrefixes }, l)
 
 printBasicTheory :: (Sign, [Named Axiom]) -> Doc
 printBasicTheory = pretty . convertBasicTheory
@@ -118,13 +118,13 @@ printMisc :: Pretty a => Annotations -> (b -> Doc) -> b -> AnnotatedList a
 printMisc a f r anl = f r <+> (printAnnotations a $+$ printAnnotatedList anl)
 
 -- | Misc ListFrameBits
-printMiscBit :: Relation -> Annotations -> ListFrameBit -> Doc
+printMiscBit :: AS.Relation -> Annotations -> ListFrameBit -> Doc
 printMiscBit r a lfb = case lfb of
-    ExpressionBit anl -> printMisc a printEquivOrDisjointClasses (getED r) anl
-    ObjectBit anl -> printMisc a printEquivOrDisjointProp (getED r) anl
-    DataBit anl -> printMisc a printEquivOrDisjointProp (getED r) anl
+    ExpressionBit anl -> printMisc a printEquivOrDisjointClasses (AS.getED r) anl
+    ObjectBit anl -> printMisc a printEquivOrDisjointProp (AS.getED r) anl
+    DataBit anl -> printMisc a printEquivOrDisjointProp (AS.getED r) anl
     IndividualSameOrDifferent anl ->
-        printMisc a printSameOrDifferentInd (getSD r) anl
+        printMisc a printSameOrDifferentInd (AS.getSD r) anl
     _ -> empty
 
 printAnnFrameBit :: Annotations -> AnnFrameBit -> Doc
@@ -163,7 +163,7 @@ instance Pretty Frame where
 
 printFrame :: Frame -> Doc
 printFrame (Frame eith bl) = case eith of
-    SimpleEntity (Entity _ e uri) -> keyword (showEntityType e) <+>
+    SimpleEntity (AS.Entity _ e uri) -> keyword (AS.showEntityType e) <+>
             fsep [pretty uri $+$ vcat (map pretty bl)]
     ObjectEntity ope -> keyword objectPropertyC <+>
             (pretty ope $+$ fsep [vcat (map pretty bl)])
@@ -172,7 +172,7 @@ printFrame (Frame eith bl) = case eith of
     Misc a -> case bl of
         [ListFrameBit (Just r) lfb] -> printMiscBit r a lfb
         [AnnFrameBit ans (AnnotationFrameBit Assertion)] ->
-            let [Annotation _ iri _] = a
+            let [AS.Annotation _ iri _] = a
             in keyword individualC <+> (pretty iri $+$ printAnnotations ans)
         h : r -> printFrame (Frame eith [h])
           $+$ printFrame (Frame eith r)
@@ -184,10 +184,10 @@ instance Pretty Axiom where
 printAxiom :: Axiom -> Doc
 printAxiom (PlainAxiom e fb) = printFrame (Frame e [fb])
 
-printImport :: ImportIRI -> Doc
+printImport :: AS.ImportIRI -> Doc
 printImport x = keyword importC <+> pretty x
 
-printPrefixes :: PrefixMap -> Doc
+printPrefixes :: AS.PrefixMap -> Doc
 printPrefixes x = vcat (map (\ (a, b) ->
        (text "Prefix:" <+> text a <> colon <+> text ('<' : b ++ ">")))
           (Map.toList x))

--- a/OWL2/Medusa.hs
+++ b/OWL2/Medusa.hs
@@ -62,9 +62,9 @@ getClass axs n = case checkMapMaybe (getClassAux n) axs of
 getClassAux :: IRI -> Axiom -> Maybe IRI
 getClassAux ind ax =
   case axiomTopic ax of
-    SimpleEntity e | cutIRI e == ind ->
+    SimpleEntity e | AS.cutIRI e == ind ->
       case axiomBit ax of
-         ListFrameBit (Just Types) (ExpressionBit classes) -> firstClass classes
+         ListFrameBit (Just AS.Types) (ExpressionBit classes) -> firstClass classes
          _ -> Nothing
     _ -> Nothing
 
@@ -81,11 +81,11 @@ getMeetsFactsAux :: [Axiom] -> Set.Set (IRI, IRI) -> IRI -> Axiom ->
                  Maybe (IRI, IRI, IRI, IRI)
 getMeetsFactsAux axs tInds point1 ax =
   case axiomTopic ax of
-    SimpleEntity e | cutIRI e == point1 ->
+    SimpleEntity e | AS.cutIRI e == point1 ->
       case axiomBit ax of
          ListFrameBit Nothing (IndividualFacts [([],
-                               (ObjectPropertyFact Positive
-                                                   (ObjectProp ope) point2))
+                               (ObjectPropertyFact AS.Positive
+                                                   (AS.ObjectProp ope) point2))
                                                ]) ->
             if show (iriPath ope) == "meets" then
                 getFiatBoundaryFacts axs tInds point1 point2
@@ -107,7 +107,7 @@ getFiatBoundaryFacts axs tInds point1 point2 =
            Just (ind1, typeOf point1, ind2, typeOf point2)
         _ -> Nothing
 
-getFiatBoundaryFactsAux :: IRI -> AS.Axiom -> Maybe IRI
+getFiatBoundaryFactsAux :: IRI -> Axiom -> Maybe IRI
 getFiatBoundaryFactsAux point ax =
   case axiomTopic ax of
     SimpleEntity e ->
@@ -118,18 +118,18 @@ getFiatBoundaryFactsAux point ax =
     _ -> Nothing
 
 
-loopFacts :: AnnotatedList Fact -> Entity -> IRI -> Maybe IRI
+loopFacts :: AnnotatedList Fact -> AS.Entity -> IRI -> Maybe IRI
 loopFacts [] _ _ = Nothing
 loopFacts (afact:facts') e point =
   case afact of
-    ([], (ObjectPropertyFact Positive (ObjectProp ope) point')) ->
+    ([], (ObjectPropertyFact AS.Positive (AS.ObjectProp ope) point')) ->
       if (show (iriPath ope) == "has_fiat_boundary") &&
-         (iriPath point == iriPath point') then Just $ cutIRI e
+         (iriPath point == iriPath point') then Just $ AS.cutIRI e
        else loopFacts facts' e point
     _ -> loopFacts facts' e point
 
 
 -- | retrieve the first class of list, somewhat arbitrary
-firstClass :: AnnotatedList ClassExpression -> Maybe IRI
-firstClass ((_,Expression c):_) = Just c
+firstClass :: AnnotatedList AS.ClassExpression -> Maybe IRI
+firstClass ((_,AS.Expression c):_) = Just c
 firstClass _ = Nothing

--- a/OWL2/Medusa.hs
+++ b/OWL2/Medusa.hs
@@ -14,7 +14,7 @@ see https://github.com/ConceptualBlending/monster_render_system
 
 module OWL2.Medusa where
 
-import OWL2.AS
+import qualified OWL2.AS as AS
 import OWL2.Sign
 import OWL2.MS
 
@@ -107,7 +107,7 @@ getFiatBoundaryFacts axs tInds point1 point2 =
            Just (ind1, typeOf point1, ind2, typeOf point2)
         _ -> Nothing
 
-getFiatBoundaryFactsAux :: IRI -> Axiom -> Maybe IRI
+getFiatBoundaryFactsAux :: IRI -> AS.Axiom -> Maybe IRI
 getFiatBoundaryFactsAux point ax =
   case axiomTopic ax of
     SimpleEntity e ->

--- a/OWL2/Morphism.hs
+++ b/OWL2/Morphism.hs
@@ -15,7 +15,7 @@ Morphisms for OWL
 module OWL2.Morphism where
 
 import Common.IRI
-import OWL2.AS
+import qualified OWL2.AS as AS
 import OWL2.MS
 import OWL2.Sign
 import OWL2.ManchesterPrint ()
@@ -56,10 +56,10 @@ isOWLInclusion :: OWLMorphism -> Bool
 isOWLInclusion m = Map.null (pmap m)
   && Map.null (mmaps m) && isSubSign (osource m) (otarget m)
 
-symMap :: MorphMap -> Map.Map Entity Entity
-symMap = Map.mapWithKey (\ (Entity lb ty _) -> Entity lb ty)
+symMap :: MorphMap -> Map.Map AS.Entity AS.Entity
+symMap = Map.mapWithKey (\ (AS.Entity lb ty _) -> AS.Entity lb ty)
 
-inducedElems :: MorphMap -> [Entity]
+inducedElems :: MorphMap -> [AS.Entity]
 inducedElems = Map.elems . symMap
 
 inducedSign :: MorphMap -> StringMap -> Sign -> Sign
@@ -83,12 +83,12 @@ inducedFromMor :: Map.Map RawSymb RawSymb -> Sign -> Result OWLMorphism
 inducedFromMor rm sig = do
   let syms = symOf sig
   (mm, tm) <- foldM (\ (m, t) p -> case p of
-        (ASymbol s@(Entity _ _ v), ASymbol (Entity _ _ u)) ->
+        (ASymbol s@(AS.Entity _ _ v), ASymbol (AS.Entity _ _ u)) ->
             if Set.member s syms
             then return $ if u == v then (m, t) else (Map.insert s u m, t)
             else fail $ "unknown symbol: " ++ showDoc s "\n" ++ shows sig ""
         (AnUri v, AnUri u) -> case filter (`Set.member` syms)
-          $ map (`mkEntity` v) entityTypes of
+          $ map (`AS.mkEntity` v) AS.entityTypes of
           [] -> let v2 = showIRICompact v
                     u2 = showIRICompact u
                 in inducedPref v2 u2 sig (m, t)
@@ -103,7 +103,7 @@ inducedFromMor rm sig = do
     , pmap = tm
     , mmaps = mm }
 
-symMapOf :: OWLMorphism -> Map.Map Entity Entity
+symMapOf :: OWLMorphism -> Map.Map AS.Entity AS.Entity
 symMapOf mor = Map.union (symMap $ mmaps mor) $ setToMap $ symOf $ osource mor
 
 instance Pretty OWLMorphism where
@@ -132,7 +132,7 @@ legalMor m = let mm = mmaps m in unless
 
 composeMor :: OWLMorphism -> OWLMorphism -> Result OWLMorphism
 composeMor m1 m2 =
-  let nm = Set.fold (\ s@(Entity _ ty u) -> let
+  let nm = Set.fold (\ s@(AS.Entity _ ty u) -> let
             t = getIri ty u $ mmaps m1
             r = getIri ty t $ mmaps m2
             in if r == u then id else Map.insert s r) Map.empty
@@ -142,17 +142,17 @@ composeMor m1 m2 =
      , pmap = composeMap (prefixMap $ osource m1) (pmap m1) $ pmap m2
      , mmaps = nm }
 
-cogeneratedSign :: Set.Set Entity -> Sign -> Result OWLMorphism
+cogeneratedSign :: Set.Set AS.Entity -> Sign -> Result OWLMorphism
 cogeneratedSign s sign =
   let sig2 = execState (mapM_ (modEntity Set.delete) $ Set.toList s) sign
   in if isSubSign sig2 sign then return $ inclOWLMorphism sig2 sign else
          fail "non OWL2 subsignatures for (co)generatedSign"
 
-generatedSign :: Set.Set Entity -> Sign -> Result OWLMorphism
+generatedSign :: Set.Set AS.Entity -> Sign -> Result OWLMorphism
 generatedSign s sign = cogeneratedSign (Set.difference (symOf sign) s) sign
 
-matchesSym :: Entity -> RawSymb -> Bool
-matchesSym e@(Entity _ _ u) r = case r of
+matchesSym :: AS.Entity -> RawSymb -> Bool
+matchesSym e@(AS.Entity _ _ u) r = case r of
        ASymbol s -> s == e
        AnUri s -> s == u  -- expandedIRI s == expandedIRI u 
                 || case
@@ -166,7 +166,7 @@ statSymbItems sig = map (function Expand . StringMap $ prefixMap sig)
   . concatMap
   (\ (SymbItems m us) -> case m of
                AnyEntity -> map AnUri us
-               EntityType ty -> map (ASymbol . mkEntity ty) us
+               EntityType ty -> map (ASymbol . AS.mkEntity ty) us
                PrefixO -> map (APrefix . showIRI) us)
 
 statSymbMapItems :: Sign -> Maybe Sign -> [SymbMapItems]
@@ -180,9 +180,9 @@ statSymbMapItems sig mtsig =
   . foldM (\ m (s, t) -> case Map.lookup s m of
     Nothing -> return $ Map.insert s t m
     Just u -> case (u, t) of
-      (AnUri su, ASymbol (Entity _ _ tu)) | su == tu ->
+      (AnUri su, ASymbol (AS.Entity _ _ tu)) | su == tu ->
         return $ Map.insert s t m
-      (ASymbol (Entity _ _ su), AnUri tu) | su == tu -> return m
+      (ASymbol (AS.Entity _ _ su), AnUri tu) | su == tu -> return m
       (AnUri su, APrefix tu) | showIRICompact su == tu ->
         return $ Map.insert s t m
       (APrefix su, AnUri tu) | su == showIRICompact tu -> return m
@@ -195,7 +195,7 @@ statSymbMapItems sig mtsig =
       case m of
         AnyEntity -> map (\ (s, t) -> (AnUri s, AnUri t)) ps
         EntityType ty ->
-            let mS = ASymbol . mkEntity ty
+            let mS = ASymbol . AS.mkEntity ty
             in map (\ (s, t) -> (mS s, mS t)) ps
         PrefixO ->
             map (\ (s, t) -> (APrefix (showIRICompact s), APrefix $ showIRICompact t)) ps)

--- a/OWL2/OWL22CASL.hs
+++ b/OWL2/OWL22CASL.hs
@@ -32,7 +32,7 @@ import CASL_DL.PredefinedCASLAxioms
 import OWL2.Logic_OWL2
 import OWL2.Keywords
 import OWL2.MS
-import OWL2.AS as O
+import qualified OWL2.AS as AS as O
 import OWL2.Parse
 import OWL2.Print
 import OWL2.ProfilesAndSublogics

--- a/OWL2/OWL22CASL.hs
+++ b/OWL2/OWL22CASL.hs
@@ -32,7 +32,7 @@ import CASL_DL.PredefinedCASLAxioms
 import OWL2.Logic_OWL2
 import OWL2.Keywords
 import OWL2.MS
-import qualified OWL2.AS as AS as O
+import qualified OWL2.AS as AS
 import OWL2.Parse
 import OWL2.Print
 import OWL2.ProfilesAndSublogics
@@ -70,7 +70,7 @@ instance Comorphism
     SymbMapItems    -- symbol map items domain
     OS.Sign         -- signature domain
     OWLMorphism     -- morphism domain
-    Entity          -- symbol domain
+    AS.Entity          -- symbol domain
     RawSymb         -- rawsymbol domain
     ProofTree       -- proof tree codomain
     CASL            -- lid codomain
@@ -218,32 +218,32 @@ mapMorphism oMor = do
       cdm <- mapSign $ osource oMor
       ccd <- mapSign $ otarget oMor
       let emap = mmaps oMor
-          preds = Map.foldWithKey (\ (Entity _ ty u1) u2 -> let
+          preds = Map.foldWithKey (\ (AS.Entity _ ty u1) u2 -> let
               i1 = uriToCaslId u1
               i2 = uriToCaslId u2
               in case ty of
-                Class -> Map.insert (i1, conceptPred) i2
-                ObjectProperty -> Map.insert (i1, objectPropPred) i2
-                DataProperty -> Map.insert (i1, dataPropPred) i2
+                AS.Class -> Map.insert (i1, conceptPred) i2
+                AS.ObjectProperty -> Map.insert (i1, objectPropPred) i2
+                AS.DataProperty -> Map.insert (i1, dataPropPred) i2
                 _ -> id) Map.empty emap
-          ops = Map.foldWithKey (\ (Entity _ ty u1) u2 -> case ty of
-                NamedIndividual -> Map.insert (uriToCaslId u1, indiConst)
+          ops = Map.foldWithKey (\ (AS.Entity _ ty u1) u2 -> case ty of
+                AS.NamedIndividual -> Map.insert (uriToCaslId u1, indiConst)
                   (uriToCaslId u2, Total)
                 _ -> id) Map.empty emap
       return (embedMorphism () cdm ccd)
                  { op_map = ops
                  , pred_map = preds }
 
-mapSymbol :: Entity -> Set.Set Symbol
-mapSymbol (Entity _ ty iRi) = let
+mapSymbol :: AS.Entity -> Set.Set Symbol
+mapSymbol (AS.Entity _ ty iRi) = let
   syN = Set.singleton . Symbol (uriToCaslId iRi)
   in case ty of
-    Class -> syN $ PredAsItemType conceptPred
-    ObjectProperty -> syN $ PredAsItemType objectPropPred
-    DataProperty -> syN $ PredAsItemType dataPropPred
-    NamedIndividual -> syN $ OpAsItemType indiConst
-    AnnotationProperty -> Set.empty
-    Datatype -> Set.empty
+    AS.Class -> syN $ PredAsItemType conceptPred
+    AS.ObjectProperty -> syN $ PredAsItemType objectPropPred
+    AS.DataProperty -> syN $ PredAsItemType dataPropPred
+    AS.NamedIndividual -> syN $ OpAsItemType indiConst
+    AS.AnnotationProperty -> Set.empty
+    AS.Datatype -> Set.empty
 
 mapSign :: OS.Sign -> Result CASLSign
 mapSign sig =
@@ -300,87 +300,87 @@ mapVar v = case v of
     OIndi i -> mapIndivURI i
 
 -- | Mapping of Class URIs
-mapClassURI :: Class -> Token -> Result CASLFORMULA
+mapClassURI :: AS.Class -> Token -> Result CASLFORMULA
 mapClassURI c t = fmap (mkPred conceptPred [mkThingVar t]) $ uriToIdM c
 
 -- | Mapping of Individual URIs
-mapIndivURI :: Individual -> Result (TERM ())
+mapIndivURI :: AS.Individual -> Result (TERM ())
 mapIndivURI uriI = do
     ur <- uriToIdM uriI
     return $ mkAppl (mkQualOp ur (Op_type Total [] thing nullRange)) []
 
-mapNNInt :: NNInt -> TERM ()
-mapNNInt int = let NNInt uInt = int in foldr1 joinDigits $ map mkDigit uInt
+mapNNInt :: AS.NNInt -> TERM ()
+mapNNInt int = let AS.NNInt uInt = int in foldr1 joinDigits $ map mkDigit uInt
 
-mapIntLit :: IntLit -> TERM ()
+mapIntLit :: AS.IntLit -> TERM ()
 mapIntLit int =
-    let cInt = mapNNInt $ absInt int
-    in if isNegInt int then negateInt $ upcast cInt integer
+    let cInt = mapNNInt $ AS.absInt int
+    in if AS.isNegInt int then negateInt $ upcast cInt integer
         else upcast cInt integer
 
-mapDecLit :: DecLit -> TERM ()
+mapDecLit :: AS.DecLit -> TERM ()
 mapDecLit dec =
-    let ip = truncDec dec
-        np = absInt ip
-        fp = fracDec dec
+    let ip = AS.truncDec dec
+        np = AS.absInt ip
+        fp = AS.fracDec dec
         n = mkDecimal (mapNNInt np) (mapNNInt fp)
-    in if isNegInt ip then negateFloat n else n
+    in if AS.isNegInt ip then negateFloat n else n
 
-mapFloatLit :: FloatLit -> TERM ()
+mapFloatLit :: AS.FloatLit -> TERM ()
 mapFloatLit f =
-    let fb = floatBase f
-        ex = floatExp f
+    let fb = AS.floatBase f
+        ex = AS.floatExp f
      in mkFloat (mapDecLit fb) (mapIntLit ex)
 
-mapNrLit :: Literal -> TERM ()
+mapNrLit :: AS.Literal -> TERM ()
 mapNrLit l = case l of
-    NumberLit f
-        | isFloatInt f -> mapIntLit $ truncDec $ floatBase f
-        | isFloatDec f -> mapDecLit $ floatBase f
+    AS.NumberLit f
+        | AS.isFloatInt f -> mapIntLit $ AS.truncDec $ AS.floatBase f
+        | AS.isFloatDec f -> mapDecLit $ AS.floatBase f
         | otherwise -> mapFloatLit f
     _ -> error "not number literal"
 
-mapLiteral :: Literal -> Result (TERM ())
+mapLiteral :: AS.Literal -> Result (TERM ())
 mapLiteral lit = return $ case lit of
-    Literal l ty -> Sorted_term (case ty of
-        Untyped _ -> foldr consChar emptyStringTerm l
-        Typed dt -> case getDatatypeCat dt of
-            OWL2Number -> let p = parse literal "" l in case p of
+    AS.Literal l ty -> Sorted_term (case ty of
+        AS.Untyped _ -> foldr consChar emptyStringTerm l
+        AS.Typed dt -> case AS.getDatatypeCat dt of
+            AS.OWL2Number -> let p = parse literal "" l in case p of
                 Right nr -> mapNrLit nr
                 _ -> error "cannot parse number literal"
-            OWL2Bool -> case l of
+            AS.OWL2Bool -> case l of
                 "true" -> trueT
                 _ -> falseT
             _ -> foldr consChar emptyStringTerm l) dataS nullRange
     _ -> mapNrLit lit
 
 -- | Mapping of data properties
-mapDataProp :: DataPropertyExpression -> Int -> Int
+mapDataProp :: AS.DataPropertyExpression -> Int -> Int
             -> Result CASLFORMULA
 mapDataProp dp a b = fmap (mkPred dataPropPred [qualThing a, qualData b])
     $ uriToIdM dp
 
 -- | Mapping of obj props
-mapObjProp :: ObjectPropertyExpression -> Int -> Int
+mapObjProp :: AS.ObjectPropertyExpression -> Int -> Int
         -> Result CASLFORMULA
 mapObjProp ob a b = case ob of
-      ObjectProp u -> fmap (mkPred objectPropPred $ map qualThing [a, b])
+      AS.ObjectProp u -> fmap (mkPred objectPropPred $ map qualThing [a, b])
             $ uriToIdM u
-      ObjectInverseOf u -> mapObjProp u b a
+      AS.ObjectInverseOf u -> mapObjProp u b a
 
 -- | Mapping of obj props with Individuals
-mapObjPropI :: ObjectPropertyExpression -> VarOrIndi -> VarOrIndi
+mapObjPropI :: AS.ObjectPropertyExpression -> VarOrIndi -> VarOrIndi
               -> Result CASLFORMULA
 mapObjPropI ob lP rP = case ob of
-    ObjectProp u -> do
+    AS.ObjectProp u -> do
         l <- mapVar lP
         r <- mapVar rP
         fmap (mkPred objectPropPred [l, r]) $ uriToIdM u
-    ObjectInverseOf u -> mapObjPropI u rP lP
+    AS.ObjectInverseOf u -> mapObjPropI u rP lP
 
 -- | mapping of individual list
-mapComIndivList :: SameOrDifferent -> Maybe Individual
-    -> [Individual] -> Result [CASLFORMULA]
+mapComIndivList :: AS.SameOrDifferent -> Maybe AS.Individual
+    -> [AS.Individual] -> Result [CASLFORMULA]
 mapComIndivList sod mol inds = do
     fs <- mapM mapIndivURI inds
     tps <- case mol of
@@ -389,13 +389,13 @@ mapComIndivList sod mol inds = do
             f <- mapIndivURI ol
             return $ mkPairs f fs
     return $ map (\ (x, y) -> case sod of
-        Same -> mkStEq x y
-        Different -> mkNeg $ mkStEq x y) tps
+        AS.Same -> mkStEq x y
+        AS.Different -> mkNeg $ mkStEq x y) tps
 
 {- | Mapping along DataPropsList for creation of pairs for commutative
 operations. -}
-mapComDataPropsList :: Maybe DataPropertyExpression
-    -> [DataPropertyExpression] -> Int -> Int
+mapComDataPropsList :: Maybe AS.DataPropertyExpression
+    -> [AS.DataPropertyExpression] -> Int -> Int
     -> Result [(CASLFORMULA, CASLFORMULA)]
 mapComDataPropsList md props a b = do
     fs <- mapM (\ x -> mapDataProp x a b) props
@@ -405,8 +405,8 @@ mapComDataPropsList md props a b = do
 
 {- | Mapping along ObjectPropsList for creation of pairs for commutative
 operations. -}
-mapComObjectPropsList :: Maybe ObjectPropertyExpression
-    -> [ObjectPropertyExpression] -> Int -> Int
+mapComObjectPropsList :: Maybe AS.ObjectPropertyExpression
+    -> [AS.ObjectPropertyExpression] -> Int -> Int
     -> Result [(CASLFORMULA, CASLFORMULA)]
 mapComObjectPropsList mol props a b = do
     fs <- mapM (\ x -> mapObjProp x a b) props
@@ -415,31 +415,31 @@ mapComObjectPropsList mol props a b = do
         Just ol -> fmap (`mkPairs` fs) $ mapObjProp ol a b
 
 -- | mapping of Data Range
-mapDataRange :: DataRange -> Int -> Result (CASLFORMULA, [CASLSign])
+mapDataRange :: AS.DataRange -> Int -> Result (CASLFORMULA, [CASLSign])
 mapDataRange dr i = case dr of
-    DataType d fl -> do
+    AS.DataType d fl -> do
         let dt = mkMember (qualData i) $ uriToCaslId d
         (sens, s) <- mapAndUnzipM (mapFacet i) fl
         return (conjunct $ dt : sens, concat s)
-    DataComplementOf drc -> do
+    AS.DataComplementOf drc -> do
         (sens, s) <- mapDataRange drc i
         return (mkNeg sens, s)
-    DataJunction jt drl -> do
+    AS.DataJunction jt drl -> do
         (jl, sl) <- mapAndUnzipM ((\ v r -> mapDataRange r v) i) drl
         --let usig = uniteL sl
         return $ case jt of
-                IntersectionOf -> (conjunct jl, concat sl)
-                UnionOf -> (disjunct jl, concat sl)
-    DataOneOf cs -> do
+                AS.IntersectionOf -> (conjunct jl, concat sl)
+                AS.UnionOf -> (disjunct jl, concat sl)
+    AS.DataOneOf cs -> do
         ls <- mapM mapLiteral cs
         return (disjunct $ map (mkStEq $ qualData i) ls, [])
 
-mkFacetPred :: TERM f -> ConstrainingFacet -> Int -> (FORMULA f, Id)
+mkFacetPred :: TERM f -> AS.ConstrainingFacet -> Int -> (FORMULA f, Id)
 mkFacetPred lit f var =
     let cf = mkInfix $ fromCF f
     in (mkPred dataPred [qualData var, lit] cf, cf)
 
-mapFacet :: Int -> (ConstrainingFacet, RestrictionValue)
+mapFacet :: Int -> (AS.ConstrainingFacet, AS.RestrictionValue)
     -> Result (CASLFORMULA, [CASLSign])
 mapFacet var (f, r) = do
     con <- mapLiteral r
@@ -448,15 +448,15 @@ mapFacet var (f, r) = do
             [(emptySign ()) {predMap = MapSet.fromList [(cf, [dataPred])]}])
 
 cardProps :: Bool
-    -> Either ObjectPropertyExpression DataPropertyExpression -> Int
+    -> Either AS.ObjectPropertyExpression AS.DataPropertyExpression -> Int
     -> [Int] -> Result [CASLFORMULA]
 cardProps b prop var vLst =
     if b then let Left ope = prop in mapM (mapObjProp ope var) vLst
      else let Right dpe = prop in mapM (mapDataProp dpe var) vLst
 
-mapCard :: Bool -> CardinalityType -> Int
-    -> Either ObjectPropertyExpression DataPropertyExpression
-    -> Maybe (Either ClassExpression DataRange) -> Int
+mapCard :: Bool -> AS.CardinalityType -> Int
+    -> Either AS.ObjectPropertyExpression AS.DataPropertyExpression
+    -> Maybe (Either AS.ClassExpression AS.DataRange) -> Int
     -> Result (FORMULA (), [CASLSign])
 mapCard b ct n prop d var = do
     let vlst = map (var +) [1 .. n]
@@ -498,62 +498,62 @@ mapCard b ct n prop d var = do
         exactLst =  if null qVars then senAux else mkExist qVars senAux
         ts = concat $ s ++ s' ++ s''
     return $ case ct of
-            MinCardinality -> (mkExist qVars minLst, ts)
-            MaxCardinality -> (mkForall qVarsM maxLst, ts)
-            ExactCardinality -> (exactLst, ts)
+            AS.MinCardinality -> (mkExist qVars minLst, ts)
+            AS.MaxCardinality -> (mkForall qVarsM maxLst, ts)
+            AS.ExactCardinality -> (exactLst, ts)
 
 -- | mapping of OWL2 Descriptions
-mapDescription :: ClassExpression -> Int ->
+mapDescription :: AS.ClassExpression -> Int ->
     Result (CASLFORMULA, [CASLSign])
 mapDescription desc var = case desc of
-    Expression u -> do
+    AS.Expression u -> do
         c <- mapClassURI u $ mkNName var
         return (c, [])
-    ObjectJunction ty ds -> do
+    AS.ObjectJunction ty ds -> do
         (els, s) <- mapAndUnzipM (flip mapDescription var) ds
         return ((case ty of
-                UnionOf -> disjunct
-                IntersectionOf -> conjunct)
+                AS.UnionOf -> disjunct
+                AS.IntersectionOf -> conjunct)
             els, concat s)
-    ObjectComplementOf d -> do
+    AS.ObjectComplementOf d -> do
         (els, s) <- mapDescription d var
         return (mkNeg els, s)
-    ObjectOneOf is -> do
+    AS.ObjectOneOf is -> do
         il <- mapM mapIndivURI is
         return (disjunct $ map (mkStEq $ qualThing var) il, [])
-    ObjectValuesFrom ty o d -> let n = var + 1 in do
+    AS.ObjectValuesFrom ty o d -> let n = var + 1 in do
         oprop0 <- mapObjProp o var n
         (desc0, s) <- mapDescription d n
         return $ case ty of
-            SomeValuesFrom -> (mkExist [thingDecl n] $ conjunct [oprop0, desc0],
+            AS.SomeValuesFrom -> (mkExist [thingDecl n] $ conjunct [oprop0, desc0],
                                s)
-            AllValuesFrom -> (mkVDecl [n] $ mkImpl oprop0 desc0,
+            AS.AllValuesFrom -> (mkVDecl [n] $ mkImpl oprop0 desc0,
                                s)
-    ObjectHasSelf o -> do
+    AS.ObjectHasSelf o -> do
         op <- mapObjProp o var var
         return (op, [])
-    ObjectHasValue o i -> do
+    AS.ObjectHasValue o i -> do
         op <- mapObjPropI o (OVar var) (OIndi i)
         return (op, [])
-    ObjectCardinality (Cardinality ct n oprop d) -> mapCard True ct n
+    AS.ObjectCardinality (AS.Cardinality ct n oprop d) -> mapCard True ct n
         (Left oprop) (fmap Left d) var
-    DataValuesFrom ty dpe dr -> let n = var + 1 in do
-        oprop0 <- mapDataProp dpe var n
+    AS.DataValuesFrom ty dpe dr -> let n = var + 1 in do
+        oprop0 <- mapDataProp (head dpe) var n
         (desc0, s) <- mapDataRange dr n
         --let ts = niteCASLSign cSig s
         return $ case ty of
-            SomeValuesFrom -> (mkExist [dataDecl n] $ conjunct [oprop0, desc0],
+            AS.SomeValuesFrom -> (mkExist [dataDecl n] $ conjunct [oprop0, desc0],
                 s)
-            AllValuesFrom -> (mkVDataDecl [n] $ mkImpl oprop0 desc0, s)
-    DataHasValue dpe c -> do
+            AS.AllValuesFrom -> (mkVDataDecl [n] $ mkImpl oprop0 desc0, s)
+    AS.DataHasValue dpe c -> do
         con <- mapLiteral c
         return (mkPred dataPropPred [qualThing var, con]
                            $ uriToCaslId dpe, [])
-    DataCardinality (Cardinality ct n dpe dr) -> mapCard False ct n
+    AS.DataCardinality (AS.Cardinality ct n dpe dr) -> mapCard False ct n
         (Right dpe) (fmap Right dr) var
 
 -- | Mapping of a list of descriptions
-mapDescriptionList :: Int -> [ClassExpression]
+mapDescriptionList :: Int -> [AS.ClassExpression]
         -> Result ([CASLFORMULA], [CASLSign])
 mapDescriptionList n lst = do
     (els, s) <- mapAndUnzipM (uncurry $ mapDescription)
@@ -561,7 +561,7 @@ mapDescriptionList n lst = do
     return (els, concat s)
 
 -- | Mapping of a list of pairs of descriptions
-mapDescriptionListP :: Int -> [(ClassExpression, ClassExpression)]
+mapDescriptionListP :: Int -> [(AS.ClassExpression, AS.ClassExpression)]
                     -> Result ([(CASLFORMULA, CASLFORMULA)], [CASLSign])
 mapDescriptionListP  n lst = do
     let (l, r) = unzip lst
@@ -571,63 +571,63 @@ mapDescriptionListP  n lst = do
 mapFact :: Extended -> Fact -> Result CASLFORMULA
 mapFact ex f = case f of
     ObjectPropertyFact posneg obe ind -> case ex of
-        SimpleEntity (Entity _ NamedIndividual siri) -> do
+        SimpleEntity (AS.Entity _ AS.NamedIndividual siri) -> do
             oPropH <- mapObjPropI obe (OIndi siri) (OIndi ind)
             let oProp = case posneg of
-                    Positive -> oPropH
-                    Negative -> Negation oPropH nullRange
+                    AS.Positive -> oPropH
+                    AS.Negative -> Negation oPropH nullRange
             return oProp
         _ -> fail $ "ObjectPropertyFactsFacts Entity fail: " ++ show f
     DataPropertyFact posneg dpe lit -> case ex of
-        SimpleEntity (Entity _ NamedIndividual iRi) -> do
+        SimpleEntity (AS.Entity _ AS.NamedIndividual iRi) -> do
             inS <- mapIndivURI iRi
             inT <- mapLiteral lit
             oPropH <- mapDataProp dpe 1 2
             let oProp = case posneg of
-                    Positive -> oPropH
-                    Negative -> Negation oPropH nullRange
+                    AS.Positive -> oPropH
+                    AS.Negative -> Negation oPropH nullRange
             return $ mkForall [thingDecl 1, dataDecl 2] $ implConj
                 [mkEqDecl 1 inS, mkEqVar (dataDecl 2) $ upcast inT dataS] oProp
         _ -> fail $ "DataPropertyFact Entity fail " ++ show f
 
-mapCharact :: ObjectPropertyExpression -> Character
+mapCharact :: AS.ObjectPropertyExpression -> AS.Character
             -> Result CASLFORMULA
 mapCharact ope c = case c of
-    Functional -> do
+    AS.Functional -> do
         so1 <- mapObjProp ope 1 2
         so2 <- mapObjProp ope 1 3
         return $ mkFIE [1, 2, 3] [so1, so2] 2 3
-    InverseFunctional -> do
+    AS.InverseFunctional -> do
         so1 <- mapObjProp ope 1 3
         so2 <- mapObjProp ope 2 3
         return $ mkFIE [1, 2, 3] [so1, so2] 1 2
-    Reflexive -> do
+    AS.Reflexive -> do
         so <- mapObjProp ope 1 1
         return $ mkRI [1] 1 so
-    Irreflexive -> do
+    AS.Irreflexive -> do
         so <- mapObjProp ope 1 1
         return $ mkRI [1] 1 $ mkNeg so
-    Symmetric -> do
+    AS.Symmetric -> do
         so1 <- mapObjProp ope 1 2
         so2 <- mapObjProp ope 2 1
         return $ mkVDecl [1, 2] $ mkImpl so1 so2
-    Asymmetric -> do
+    AS.Asymmetric -> do
         so1 <- mapObjProp ope 1 2
         so2 <- mapObjProp ope 2 1
         return $ mkVDecl [1, 2] $ mkImpl so1 $ mkNeg so2
-    Antisymmetric -> do
+    AS.Antisymmetric -> do
         so1 <- mapObjProp ope 1 2
         so2 <- mapObjProp ope 2 1
         return $ mkFIE [1, 2] [so1, so2] 1 2
-    Transitive -> do
+    AS.Transitive -> do
         so1 <- mapObjProp ope 1 2
         so2 <- mapObjProp ope 2 3
         so3 <- mapObjProp ope 1 3
         return $ mkVDecl [1, 2, 3] $ implConj [so1, so2] so3
 
 -- | Mapping of ObjectSubPropertyChain
-mapSubObjPropChain :: [ObjectPropertyExpression]
-    -> ObjectPropertyExpression -> Result CASLFORMULA
+mapSubObjPropChain :: [AS.ObjectPropertyExpression]
+    -> AS.ObjectPropertyExpression -> Result CASLFORMULA
 mapSubObjPropChain props oP = do
      let (_, vars) = unzip $ zip (oP:props) [1 ..]
      -- because we need n+1 vars for a chain of n roles
@@ -637,37 +637,37 @@ mapSubObjPropChain props oP = do
      return $ mkVDecl vars $ implConj oProps ooP
 
 -- | Mapping of subobj properties
-mapSubObjProp :: ObjectPropertyExpression
-    -> ObjectPropertyExpression -> Int -> Result CASLFORMULA
+mapSubObjProp :: AS.ObjectPropertyExpression
+    -> AS.ObjectPropertyExpression -> Int -> Result CASLFORMULA
 mapSubObjProp e1 e2 a = do
     let b = a + 1
     l <- mapObjProp e1 a b
     r <- mapObjProp e2 a b
     return $ mkForallRange (map thingDecl [a, b]) (mkImpl l r) nullRange
 
-mkEDPairs :: [Int] -> Maybe O.Relation -> [(FORMULA f, FORMULA f)]
+mkEDPairs :: [Int] -> Maybe AS.Relation -> [(FORMULA f, FORMULA f)]
     -> Result ([FORMULA f], [CASLSign])
 mkEDPairs il mr pairs = do
     let ls = map (\ (x, y) -> mkVDecl il
             $ case fromMaybe (error "expected EDRelation") mr of
-                EDRelation Equivalent -> mkEqv x y
-                EDRelation Disjoint -> mkNC [x, y]
+                AS.EDRelation AS.Equivalent -> mkEqv x y
+                AS.EDRelation AS.Disjoint -> mkNC [x, y]
                 _ -> error "expected EDRelation") pairs
     return (ls, [])
 
-mkEDPairs' :: [Int] -> Maybe O.Relation -> [(FORMULA f, FORMULA f)]
+mkEDPairs' :: [Int] -> Maybe AS.Relation -> [(FORMULA f, FORMULA f)]
     -> Result ([FORMULA f], [CASLSign])
 mkEDPairs' [i1, i2] mr pairs = do
     let ls = map (\ (x, y) -> mkVDecl [i1] $ mkVDataDecl [i2]
             $ case fromMaybe (error "expected EDRelation") mr of
-                EDRelation Equivalent -> mkEqv x y
-                EDRelation Disjoint -> mkNC [x, y]
+                AS.EDRelation AS.Equivalent -> mkEqv x y
+                AS.EDRelation AS.Disjoint -> mkNC [x, y]
                 _ -> error "expected EDRelation") pairs
     return (ls, [])
 mkEDPairs' _ _ _ = error "wrong call of mkEDPairs'"
 
 -- | Mapping of ListFrameBit
-mapListFrameBit :: Extended -> Maybe O.Relation -> ListFrameBit
+mapListFrameBit :: Extended -> Maybe AS.Relation -> ListFrameBit
        -> Result ([CASLFORMULA], [CASLSign])
 mapListFrameBit ex rel lfb =
     let err = failMsg $ PlainAxiom ex $ ListFrameBit rel lfb
@@ -677,14 +677,14 @@ mapListFrameBit ex rel lfb =
           Misc _ -> let cel = map snd cls in do
             (els, s) <- mapDescriptionListP 1 $ comPairs cel cel
             mkEDPairs [1] rel els
-          SimpleEntity (Entity _ ty iRi) -> do
+          SimpleEntity (AS.Entity _ ty iRi) -> do
               (els, s) <- mapAndUnzipM (\ (_, c) -> mapDescription c 1) cls
               case ty of
-                NamedIndividual | rel == Just Types -> do
+                AS.NamedIndividual | rel == Just AS.Types -> do
                   inD <- mapIndivURI iRi
                   let els' = map (substitute (mkNName 1) thing inD) els
                   return ( els', concat s)
-                DataProperty | rel == (Just $ DRRelation ADomain) -> do
+                AS.DataProperty | rel == (Just $ AS.DRRelation AS.ADomain) -> do
                   oEx <- mapDataProp iRi 1 2
                   let vars = (mkNName 1, mkNName 2)
                   return (map (mkFI [tokDecl $ fst vars]
@@ -693,25 +693,25 @@ mapListFrameBit ex rel lfb =
           ObjectEntity oe -> case rel of
               Nothing -> err
               Just re -> case re of
-                  DRRelation r -> do
+                  AS.DRRelation r -> do
                     tobjP <- mapObjProp oe 1 2
                     (tdsc, s) <- mapAndUnzipM (\ (_, c) -> mapDescription c
                         $ case r of
-                                ADomain -> 1
-                                ARange -> 2) cls
+                                AS.ADomain -> 1
+                                AS.ARange -> 2) cls
                     let vars = case r of
-                                ADomain -> (mkNName 1, mkNName 2)
-                                ARange -> (mkNName 2, mkNName 1)
+                                AS.ADomain -> (mkNName 1, mkNName 2)
+                                AS.ARange -> (mkNName 2, mkNName 1)
                     return (map (mkFI [tokDecl $ fst vars] [tokDecl $ snd vars] tobjP) tdsc,
                             concat s)
                   _ -> err
           ClassEntity ce -> let cel = map snd cls in case rel of
               Nothing -> return ([], [])
               Just r -> case r of
-                EDRelation _ -> do
+                AS.EDRelation _ -> do
                     (decrsS, s) <- mapDescriptionListP 1 $ mkPairs ce cel
                     mkEDPairs [1] rel decrsS
-                SubClass -> do
+                AS.SubClass -> do
                   (domT, s1) <- mapDescription ce 1
                   (codT, s2) <- mapDescriptionList 1 cel
                   return (map (mk1VDecl . mkImpl domT) codT,
@@ -724,14 +724,14 @@ mapListFrameBit ex rel lfb =
             pairs <- mapComObjectPropsList Nothing opl 1 2
             mkEDPairs [1, 2] rel pairs
         ObjectEntity op -> case r of
-            EDRelation _ -> do
+            AS.EDRelation _ -> do
                 pairs <- mapComObjectPropsList (Just op) opl 1 2
                 mkEDPairs [1, 2] rel pairs
-            SubPropertyOf -> do
+            AS.SubPropertyOf -> do
                 os <- mapM (\ (o1, o2) -> mapSubObjProp o1 o2 3)
                     $ mkPairs op opl
                 return (os, [])
-            InverseOf -> do
+            AS.InverseOf -> do
                 os1 <- mapM (\ o1 -> mapObjProp o1 1 2) opl
                 o2 <- mapObjProp op 2 1
                 return (map (mkVDecl [1, 2] . mkEqv o2) os1, [])
@@ -743,28 +743,28 @@ mapListFrameBit ex rel lfb =
         Misc _ -> do
             pairs <- mapComDataPropsList Nothing dl 1 2
             mkEDPairs' [1, 2] rel pairs
-        SimpleEntity (Entity _ DataProperty iRi) -> case r of
-            SubPropertyOf -> do
+        SimpleEntity (AS.Entity _ AS.DataProperty iRi) -> case r of
+            AS.SubPropertyOf -> do
                 os1 <- mapM (\ o1 -> mapDataProp o1 1 2) dl
                 o2 <- mapDataProp iRi 1 2 -- was 2 1
                 return (map (mkForall [thingDecl 1, dataDecl 2]
                     . mkImpl o2) os1, [])
-            EDRelation _ -> do
+            AS.EDRelation _ -> do
                 pairs <- mapComDataPropsList (Just iRi) dl 1 2
                 mkEDPairs' [1, 2] rel pairs
             _ -> return ([], [])
         _ -> err
     IndividualSameOrDifferent al -> case rel of
         Nothing -> err
-        Just (SDRelation re) -> do
+        Just (AS.SDRelation re) -> do
             let mi = case ex of
-                    SimpleEntity (Entity _ NamedIndividual iRi) -> Just iRi
+                    SimpleEntity (AS.Entity _ AS.NamedIndividual iRi) -> Just iRi
                     _ -> Nothing
             fs <- mapComIndivList re mi $ map snd al
             return (fs, [])
         _ -> err
     DataPropRange dpr -> case ex of
-        SimpleEntity (Entity _ DataProperty iRi) -> do
+        SimpleEntity (AS.Entity _ AS.DataProperty iRi) -> do
             oEx <- mapDataProp iRi 1 2
             (odes, s) <- mapAndUnzipM (\ (_, c) -> mapDataRange c 2) dpr
             let vars = (mkNName 1, mkNName 2)
@@ -788,20 +788,20 @@ mapAnnFrameBit ex ans afb =
     in case afb of
     AnnotationFrameBit _ -> return ([], [])
     DataFunctional -> case ex of
-        SimpleEntity (Entity _ _ iRi) -> do
+        SimpleEntity (AS.Entity _ _ iRi) -> do
             so1 <- mapDataProp iRi 1 2
             so2 <- mapDataProp iRi 1 3
             return ([mkForall (thingDecl 1 : map dataDecl [2, 3]) $ implConj
                         [so1, so2] $ mkEqVar (dataDecl 2) $ qualData 3], [])
         _ -> err
     DatatypeBit dr -> case ex of
-        SimpleEntity (Entity _ Datatype iRi) -> do
+        SimpleEntity (AS.Entity _ AS.Datatype iRi) -> do
             (odes, s) <- mapDataRange dr 2
             return ([mkVDataDecl [2] $ mkEqv odes $ mkMember
                     (qualData 2) $ uriToCaslId iRi], s)
         _ -> err
     ClassDisjointUnion clsl -> case ex of
-        ClassEntity (Expression iRi) -> do
+        ClassEntity (AS.Expression iRi) -> do
             (decrs, s1) <- mapDescriptionList 1 clsl
             (decrsS, s2) <- mapDescriptionListP 1 $ comPairs clsl clsl
             let decrsP = map (\ (x, y) -> conjunct [x, y]) decrsS
@@ -833,7 +833,7 @@ mapAnnFrameBit ex ans afb =
 keyDecl :: Int -> [Int] -> [VAR_DECL]
 keyDecl h il = map thingDecl (take h il) ++ map dataDecl (drop h il)
 
-mapKey :: ClassExpression -> [FORMULA ()] -> [FORMULA ()]
+mapKey :: AS.ClassExpression -> [FORMULA ()] -> [FORMULA ()]
     -> Int -> [Int] -> Int -> Result (FORMULA (), [CASLSign])
 mapKey ce pl npl p i h = do
     (nce, s) <- mapDescription ce 1

--- a/OWL2/OWL22CommonLogic.hs
+++ b/OWL2/OWL22CommonLogic.hs
@@ -27,7 +27,7 @@ import qualified Data.Map as Map
 
 -- OWL2 = domain
 import OWL2.Logic_OWL2
-import OWL2.AS
+import qualified OWL2.AS as AS
 import Common.IRI
 import OWL2.Keywords
 import OWL2.MS

--- a/OWL2/OWL22CommonLogic.hs
+++ b/OWL2/OWL22CommonLogic.hs
@@ -61,7 +61,7 @@ instance Comorphism
     SymbMapItems            -- symbol map items domain
     OS.Sign                 -- signature domain
     OWLMorphism             -- morphism domain
-    Entity                  -- symbol domain
+    AS.Entity                  -- symbol domain
     RawSymb                 -- rawsymbol domain
     ProofTree               -- proof tree codomain
     CommonLogic             -- lid codomain
@@ -105,7 +105,7 @@ hetsPrefix = ""
 voiToTok :: VarOrIndi -> Token
 voiToTok v = case v of
     OVar o -> mkNName o
-    OIndi o -> uriToTok o
+    OIndi o -> AS.uriToTok o
 
 varToInt :: VarOrIndi -> Int
 varToInt v = case v of
@@ -113,7 +113,7 @@ varToInt v = case v of
     _ -> error $ "could not translate " ++ show v
 
 uriToTokM :: IRI -> Result Token
-uriToTokM = return . uriToTok
+uriToTokM = return . AS.uriToTok
 
 mkBools :: BOOL_SENT -> SENTENCE
 mkBools bs = Bool_sent bs nullRange
@@ -254,11 +254,11 @@ mapMorphism oMor = do
     mapp <- mapMap $ mmaps oMor
     return (CLM.mkMorphism dm cd mapp)
 
-mapMap :: Map.Map Entity IRI -> Result (Map.Map Id Id)
-mapMap m = return $ Map.map uriToId $ Map.mapKeys entityToId m
+mapMap :: Map.Map AS.Entity IRI -> Result (Map.Map Id Id)
+mapMap m = return $ Map.map AS.uriToId $ Map.mapKeys AS.entityToId m
 
-mapSymbol :: Entity -> Set.Set Symbol
-mapSymbol (Entity _ _ iri) = Set.singleton $ idToRaw $ uriToId iri
+mapSymbol :: AS.Entity -> Set.Set Symbol
+mapSymbol (AS.Entity _ _ iri) = Set.singleton $ idToRaw $ AS.uriToId iri
 
 mapSign :: OS.Sign -> Result Sign
 mapSign sig =
@@ -268,7 +268,7 @@ mapSign sig =
                         , OS.dataProperties sig
                         , OS.annotationRoles sig
                         , OS.individuals sig ]
-      itms = Set.map uriToId conc
+      itms = Set.map AS.uriToId conc
   in return emptySig { discourseNames = itms }
 
 nothingSent :: CommonAnno.Named TEXT
@@ -277,16 +277,16 @@ nothingSent = CommonAnno.makeNamed "" $ senToText $ mk1QU $ mkBN $ mkSAtom
 
 thingIncl :: IRI -> CommonAnno.Named TEXT
 thingIncl iri = CommonAnno.makeNamed "" $ senToText
-    $ mk1QU $ mkBI (mk1TermAtom $ uriToTok iri) $ mkSAtom "Thing"
+    $ mk1QU $ mkBI (mk1TermAtom $ AS.uriToTok iri) $ mkSAtom "Thing"
 
 dataIncl :: IRI -> CommonAnno.Named TEXT
 dataIncl iri = CommonAnno.makeNamed "" $ senToText
-    $ mk1QU $ mkBI (mk1TermAtom $ uriToTok iri) $ mkSAtom "Datatype"
+    $ mk1QU $ mkBI (mk1TermAtom $ AS.uriToTok iri) $ mkSAtom "Datatype"
 
 propertyIncl :: String -> IRI -> CommonAnno.Named TEXT
 propertyIncl s prop = CommonAnno.makeNamed "" $ senToText $
     let [d, pr] = map (`mkTermAtoms` map mkNTERM [1, 2])
-            [uriToTok prop, mkSimpleId s]
+            [AS.uriToTok prop, mkSimpleId s]
     in mkBI d $ if s `elem` [topDataProp, topObjProp] then pr else mkBN pr
 
 declarations :: OS.Sign -> [CommonAnno.Named TEXT]
@@ -315,8 +315,8 @@ mapTheory (owlSig, owlSens) = do
                 (sen, sig) <- mapSentence y z
                 return (x ++ sen, unite sig y)
                 ) ([], cSig) owlSens
-    let sig = unite (emptySig {discourseNames = Set.fromList $ map (uriToId .
-            setReservedPrefix . mkIRI) $ "Datatype" : predefClass
+    let sig = unite (emptySig {discourseNames = Set.fromList $ map (AS.uriToId .
+            AS.setReservedPrefix . mkIRI) $ "Datatype" : predefClass
             ++ [topDataProp, bottomDataProp, topObjProp, bottomObjProp]
             ++ datatypeKeys}) nSig
         cSens = map (CommonAnno.markSen "OWLbuiltin")
@@ -334,15 +334,15 @@ mapSentence cSig inSen = do
     return (map (flip CommonAnno.mapNamed inSen . const) outAx, outSig)
 
 -- | Mapping of Class IRIs
-mapClassIRI :: Sign -> Class -> Token -> Result SENTENCE
+mapClassIRI :: Sign -> AS.Class -> Token -> Result SENTENCE
 mapClassIRI _ c tok = fmap (`mkTermAtoms` [Name_term tok]) $ uriToTokM c
 
 -- | Mapping of Individual IRIs
-mapIndivIRI :: Sign -> Individual -> Result TERM
+mapIndivIRI :: Sign -> AS.Individual -> Result TERM
 mapIndivIRI _ i = fmap Name_term $ uriToTokM i
 
 -- | mapping of individual list
-mapComIndivList :: Sign -> SameOrDifferent -> Maybe Individual -> [Individual]
+mapComIndivList :: Sign -> AS.SameOrDifferent -> Maybe AS.Individual -> [AS.Individual]
                 -> Result [SENTENCE]
 mapComIndivList cSig sod mi inds = do
     fs <- mapM (mapIndivIRI cSig) inds
@@ -350,57 +350,57 @@ mapComIndivList cSig sod mi inds = do
         Nothing -> return $ comPairs fs fs
         Just i -> fmap (`mkPairs` fs) $ mapIndivIRI cSig i
     let sntLst = map (\ (x, y) -> case sod of
-                    Same -> mkAE x y
-                    Different -> mkBN $ mkAE x y) il
+                    AS.Same -> mkAE x y
+                    AS.Different -> mkBN $ mkAE x y) il
     return [mkBC sntLst]
 
-mapLit :: Int -> Literal -> Result (Either (SENTENCE, SENTENCE) TERM)
+mapLit :: Int -> AS.Literal -> Result (Either (SENTENCE, SENTENCE) TERM)
 mapLit i c = return $ case c of
-    Literal l ty -> case ty of
-        Typed dt -> Left (mkEqual (mkSimpleId l) $ mkNName i,
-                    mkTermAtoms (uriToTok dt) [mkNTERM i])
-        Untyped _ -> Right $ Name_term $ mkSimpleId l
-    NumberLit l -> Left (mkEqual (mkSimpleId $ show l) $ mkNName i,
-                    mkTermAtoms (mkSimpleId $ numberName l) [mkNTERM i])
+    AS.Literal l ty -> case ty of
+        AS.Typed dt -> Left (mkEqual (mkSimpleId l) $ mkNName i,
+                    mkTermAtoms (AS.uriToTok dt) [mkNTERM i])
+        AS.Untyped _ -> Right $ Name_term $ mkSimpleId l
+    AS.NumberLit l -> Left (mkEqual (mkSimpleId $ show l) $ mkNName i,
+                    mkTermAtoms (mkSimpleId $ AS.numberName l) [mkNTERM i])
 
 -- | Mapping of data properties
-mapDataProp :: Sign -> DataPropertyExpression -> VarOrIndi -> VarOrIndi
+mapDataProp :: Sign -> AS.DataPropertyExpression -> VarOrIndi -> VarOrIndi
             -> Result SENTENCE
 mapDataProp _ dp a b = fmap (`mkTermAtoms` map mkVTerm [a, b])
     $ uriToTokM dp
 
-mapDataPropI :: Sign -> VarOrIndi -> VarOrIndi -> DataPropertyExpression
+mapDataPropI :: Sign -> VarOrIndi -> VarOrIndi -> AS.DataPropertyExpression
              -> Result SENTENCE
 mapDataPropI cSig a b dp = mapDataProp cSig dp a b
 
 -- | Mapping of obj props
-mapObjProp :: Sign -> ObjectPropertyExpression -> VarOrIndi -> VarOrIndi
+mapObjProp :: Sign -> AS.ObjectPropertyExpression -> VarOrIndi -> VarOrIndi
             -> Result SENTENCE
 mapObjProp cSig ob v1 v2 = case ob of
-    ObjectProp u -> fmap (`mkTermAtoms` map mkVTerm [v1, v2]) $ uriToTokM u
-    ObjectInverseOf u -> mapObjProp cSig u v2 v1
+    AS.ObjectProp u -> fmap (`mkTermAtoms` map mkVTerm [v1, v2]) $ uriToTokM u
+    AS.ObjectInverseOf u -> mapObjProp cSig u v2 v1
 
-mapDPE :: Sign -> DataPropertyExpression -> Int -> Int -> Result SENTENCE
+mapDPE :: Sign -> AS.DataPropertyExpression -> Int -> Int -> Result SENTENCE
 mapDPE cSig dpe x y = mapDataProp cSig dpe (OVar x) $ OVar y
 
-mapOPE :: Sign -> ObjectPropertyExpression -> Int -> Int -> Result SENTENCE
+mapOPE :: Sign -> AS.ObjectPropertyExpression -> Int -> Int -> Result SENTENCE
 mapOPE cSig ope x y = mapObjProp cSig ope (OVar x) $ OVar y
 
-mapOPEList :: Sign -> Int -> Int -> [ObjectPropertyExpression]
+mapOPEList :: Sign -> Int -> Int -> [AS.ObjectPropertyExpression]
     -> Result [SENTENCE]
 mapOPEList s a b = mapM ((\ sig x1 x2 op -> mapOPE sig op x1 x2 ) s a b)
 
-mapDPEList :: Sign -> Int -> Int -> [DataPropertyExpression]
+mapDPEList :: Sign -> Int -> Int -> [AS.DataPropertyExpression]
     -> Result [SENTENCE]
 mapDPEList s a b = mapM ((\ sig x1 x2 dp -> mapDPE sig dp x1 x2 ) s a b)
 
 mapObjPropListP :: Sign -> Int -> Int
-    -> [(ObjectPropertyExpression, ObjectPropertyExpression)]
+    -> [(AS.ObjectPropertyExpression, AS.ObjectPropertyExpression)]
     -> Result [(SENTENCE, SENTENCE)]
 mapObjPropListP = mapObjOrDataListP mapOPEList
 
 mapDataPropListP :: Sign -> Int -> Int
-    -> [(DataPropertyExpression, DataPropertyExpression)]
+    -> [(AS.DataPropertyExpression, AS.DataPropertyExpression)]
     -> Result [(SENTENCE, SENTENCE)]
 mapDataPropListP = mapObjOrDataListP mapDPEList
 
@@ -413,52 +413,52 @@ mapObjOrDataListP f cSig a b ls = do
     return $ zip l1 l2
 
 -- | mapping of Data Range
-mapDataRange :: Sign -> DataRange -> VarOrIndi -> Result (SENTENCE, Sign)
+mapDataRange :: Sign -> AS.DataRange -> VarOrIndi -> Result (SENTENCE, Sign)
 mapDataRange cSig dr var = let uid = mkVTerm var in case dr of
-    DataJunction jt drl -> do
+    AS.DataJunction jt drl -> do
         (jl, sig) <- mapAndUnzipM ((\ s v r -> mapDataRange s r v) cSig var) drl
         let un = uniteL sig
         return $ case jt of
-                IntersectionOf -> (mkBC jl, un)
-                UnionOf -> (mkBD jl, un)
-    DataComplementOf cdr -> do
+                AS.IntersectionOf -> (mkBC jl, un)
+                AS.UnionOf -> (mkBD jl, un)
+    AS.DataComplementOf cdr -> do
         (dc, sig) <- mapDataRange cSig cdr var
         return (mkBN dc, sig)
-    DataOneOf cs -> do
+    AS.DataOneOf cs -> do
         let i = varToInt var
         cl <- mapM (mapLit i) cs
         let (sens, ts) = (lefts cl, rights cl)
             sl = map (\ (s1, s2) -> mkBC [s1, s2]) sens
         tl <- mapM (\ x -> return $ mkAtoms $ Atom x [Term_seq uid]) ts
         return (mkBD $ tl ++ sl, cSig)
-    DataType dt rlst -> do
-        let sent = mkTermAtoms (uriToTok dt) [uid]
+    AS.DataType dt rlst -> do
+        let sent = mkTermAtoms (AS.uriToTok dt) [uid]
         (sens, sigL) <- mapAndUnzipM (mapFacet cSig var uid) rlst
         return (mkBC $ sent : sens, uniteL $ cSig : sigL)
 
 -- | mapping of a tuple of ConstrainingFacet and RestictionValue
-mapFacet :: Sign -> VarOrIndi -> TERM -> (ConstrainingFacet, RestrictionValue)
+mapFacet :: Sign -> VarOrIndi -> TERM -> (AS.ConstrainingFacet, AS.RestrictionValue)
     -> Result (SENTENCE, Sign)
 mapFacet sig i var (f, r) = let v = varToInt i + 1 in do
     l <- mapLit v r
     let sign = unite sig $ emptySig {
                   discourseNames = Set.fromList [stringToId $ showIRI
-                                                  $ stripReservedPrefix f]}
+                                                  $ AS.stripReservedPrefix f]}
     case l of
-        Right lit -> return (mkTermAtoms (uriToTok f) [lit, var], sign)
-        Left (s1, s2) -> return (mkBC [mkTermAtoms (uriToTok f)
+        Right lit -> return (mkTermAtoms (AS.uriToTok f) [lit, var], sign)
+        Left (s1, s2) -> return (mkBC [mkTermAtoms (AS.uriToTok f)
                     [mkVTerm $ OVar v, var], s1, s2], sign)
 
 cardProps :: Bool -> Sign
-    -> Either ObjectPropertyExpression DataPropertyExpression -> Int
+    -> Either AS.ObjectPropertyExpression AS.DataPropertyExpression -> Int
     -> [VarOrIndi] -> Result [SENTENCE]
 cardProps b cSig prop var vLst =
     if b then let Left ope = prop in mapM (mapObjProp cSig ope $ OVar var) vLst
      else let Right dpe = prop in mapM (mapDataProp cSig dpe $ OVar var) vLst
 
-mapCard :: Bool -> Sign -> CardinalityType -> Int
-    -> Either ObjectPropertyExpression DataPropertyExpression
-    -> Maybe (Either ClassExpression DataRange) -> Int
+mapCard :: Bool -> Sign -> AS.CardinalityType -> Int
+    -> Either AS.ObjectPropertyExpression AS.DataPropertyExpression
+    -> Maybe (Either AS.ClassExpression AS.DataRange) -> Int
     -> Result (SENTENCE, Sign)
 mapCard b cSig ct n prop d var = do
     let vlst = map (var +) [1 .. n]
@@ -482,68 +482,68 @@ mapCard b cSig ct n prop d var = do
     let minLst = mkQE qVars $ mkBC $ dlst ++ dOut ++ oProps
         maxLst = mkQE qVarsM $ mkBI (mkBC $ oPropsM ++ dOut) $ mkBD dlstM
     return $ case ct of
-                MinCardinality -> (minLst, cSig)
-                MaxCardinality -> (maxLst, cSig)
-                ExactCardinality -> (mkBC [minLst, maxLst], uniteL sigL)
+                AS.MinCardinality -> (minLst, cSig)
+                AS.MaxCardinality -> (maxLst, cSig)
+                AS.ExactCardinality -> (mkBC [minLst, maxLst], uniteL sigL)
 
 -- | mapping of OWL Descriptions
-mapDescription :: Sign -> ClassExpression -> VarOrIndi -> Int
+mapDescription :: Sign -> AS.ClassExpression -> VarOrIndi -> Int
                -> Result (SENTENCE, Sign)
 mapDescription cSig des oVar aVar =
   let varN = case oVar of
         OVar v -> mkNName v
-        OIndi i -> uriToTok i
+        OIndi i -> AS.uriToTok i
       var = case oVar of
         OVar v -> v
         OIndi _ -> aVar
   in case des of
-    Expression cl -> do
+    AS.Expression cl -> do
         ne <- mapClassIRI cSig cl varN
         return (ne, cSig)
-    ObjectJunction jt desL -> do
+    AS.ObjectJunction jt desL -> do
         (cel, dSig) <- mapAndUnzipM ((\ w x y z -> mapDescription w z x y)
                             cSig oVar aVar) desL
         let un = uniteL dSig
         return $ case jt of
-                UnionOf -> (mkBD cel, un)
-                IntersectionOf -> (mkBC cel, un)
-    ObjectComplementOf descr -> do
+                AS.UnionOf -> (mkBD cel, un)
+                AS.IntersectionOf -> (mkBC cel, un)
+    AS.ObjectComplementOf descr -> do
         (ce, dSig) <- mapDescription cSig descr oVar aVar
         return (mkBN ce, dSig)
-    ObjectOneOf il -> do
+    AS.ObjectOneOf il -> do
         nil <- mapM (mapIndivIRI cSig) il
         return (mkBD $ map (mkAE $ Name_term varN) nil, cSig)
-    ObjectValuesFrom qt oprop descr -> let v = var + 1 in do
+    AS.ObjectValuesFrom qt oprop descr -> let v = var + 1 in do
         ope <- mapOPE cSig oprop var v
         (ce, dSig) <- mapDescription cSig descr (OVar v) $ aVar + 1
         return $ case qt of
-            SomeValuesFrom -> (mkQE [mkNAME v] $ mkBC [ope, ce], dSig)
-            AllValuesFrom -> (mkQU [mkNAME v] $ mkBI ope ce, dSig)
-    ObjectHasSelf oprop -> smap mapObjProp cSig oprop oVar oVar
-    ObjectHasValue oprop indiv -> smap mapObjProp cSig oprop oVar (OIndi indiv)
-    ObjectCardinality (Cardinality ct n oprop d) -> mapCard True cSig ct n
+            AS.SomeValuesFrom -> (mkQE [mkNAME v] $ mkBC [ope, ce], dSig)
+            AS.AllValuesFrom -> (mkQU [mkNAME v] $ mkBI ope ce, dSig)
+    AS.ObjectHasSelf oprop -> smap mapObjProp cSig oprop oVar oVar
+    AS.ObjectHasValue oprop indiv -> smap mapObjProp cSig oprop oVar (OIndi indiv)
+    AS.ObjectCardinality (AS.Cardinality ct n oprop d) -> mapCard True cSig ct n
         (Left oprop) (fmap Left d) var
-    DataValuesFrom qt dpe dr -> let varNN = mkNName $ var + 1 in do
+    AS.DataValuesFrom qt dpe dr -> let varNN = mkNName $ var + 1 in do
         (drSent, drSig) <- mapDataRange cSig dr $ OVar $ var + 1
-        senl <- mapM (mapDataPropI cSig (OVar var) $ OVar $ var + 1) [dpe]
+        senl <- mapM (mapDataPropI cSig (OVar var) $ OVar $ var + 1) dpe
         let sent = mkBC $ drSent : senl
         return $ case qt of
-            AllValuesFrom -> (mkQU [Name varNN] sent, drSig)
-            SomeValuesFrom -> (mkQE [Name varNN] sent, drSig)
-    DataHasValue dpe c -> do
+            AS.AllValuesFrom -> (mkQU [Name varNN] sent, drSig)
+            AS.SomeValuesFrom -> (mkQE [Name varNN] sent, drSig)
+    AS.DataHasValue dpe c -> do
         let nvar = var + 1
         con <- mapLit nvar c
         case con of
-            Right lit -> return (mkAtoms $ Atom (Name_term $ uriToTok dpe)
+            Right lit -> return (mkAtoms $ Atom (Name_term $ AS.uriToTok dpe)
                     [mkTermSeq varN, Term_seq lit], cSig)
             Left (s1, s2) -> do
                 sens <- mapDataProp cSig dpe oVar $ OVar nvar
                 return (mkBC [sens, s1, s2], cSig)
-    DataCardinality (Cardinality ct n dpe dr) -> mapCard False cSig ct n
+    AS.DataCardinality (AS.Cardinality ct n dpe dr) -> mapCard False cSig ct n
         (Right dpe) (fmap Right dr) var
 
 -- | Mapping of a list of descriptions
-mapDescriptionList :: Sign -> Int -> [ClassExpression]
+mapDescriptionList :: Sign -> Int -> [AS.ClassExpression]
     -> Result ([SENTENCE], Sign)
 mapDescriptionList cSig n lst = do
     (sens, lSig) <- mapAndUnzipM ((\ w x y z ->
@@ -552,7 +552,7 @@ mapDescriptionList cSig n lst = do
     return (sens, sig)
 
 -- | Mapping of a list of pairs of descriptions
-mapDescriptionListP :: Sign -> Int -> [(ClassExpression, ClassExpression)]
+mapDescriptionListP :: Sign -> Int -> [(AS.ClassExpression, AS.ClassExpression)]
     -> Result ([(SENTENCE, SENTENCE)], Sign)
 mapDescriptionListP cSig n lst = do
     let (l, r) = unzip lst
@@ -560,22 +560,22 @@ mapDescriptionListP cSig n lst = do
     (rlst, tSig) <- mapDescriptionList cSig n r
     return (zip llst rlst, unite ssSig tSig)
 
-mapClassAssertion :: TERM -> (ClassExpression, SENTENCE) -> TEXT
+mapClassAssertion :: TERM -> (AS.ClassExpression, SENTENCE) -> TEXT
 mapClassAssertion ind (ce, sent) = case ce of
-    Expression _ -> senToText sent
+    AS.Expression _ -> senToText sent
     _ -> senToText $ (mk1QU . mkBI (mkAE mk1NTERM ind)) sent
 
 mapFact :: Sign -> Extended -> Fact -> Result TEXT
 mapFact cSig ex f = case f of
     ObjectPropertyFact posneg obe ind -> case ex of
-        SimpleEntity (Entity _ NamedIndividual siri) -> do
+        SimpleEntity (AS.Entity _ AS.NamedIndividual siri) -> do
             oPropH <- mapObjProp cSig obe (OIndi siri) (OIndi ind)
             return $ senToText $ case posneg of
-                            Positive -> oPropH
-                            Negative -> mkBN oPropH
+                            AS.Positive -> oPropH
+                            AS.Negative -> mkBN oPropH
         _ -> failMsg f
     DataPropertyFact posneg dpe lit -> case ex of
-        SimpleEntity (Entity _ NamedIndividual iri) -> do
+        SimpleEntity (AS.Entity _ AS.NamedIndividual iri) -> do
              inS <- mapIndivIRI cSig iri
              inT <- mapLit 1 lit
              nm <- uriToTokM dpe
@@ -585,48 +585,48 @@ mapFact cSig ex f = case f of
                         sens <- mapDataProp cSig dpe (OIndi iri) $ OVar 1
                         return $ mkBC [sens, s1, s2]
              return $ senToText $ case posneg of
-                             Positive -> dPropH
-                             Negative -> mkBN dPropH
+                             AS.Positive -> dPropH
+                             AS.Negative -> mkBN dPropH
         _ -> failMsg f
 
-mapCharact :: Sign -> ObjectPropertyExpression -> Character -> Result TEXT
+mapCharact :: Sign -> AS.ObjectPropertyExpression -> AS.Character -> Result TEXT
 mapCharact cSig ope c = case c of
-    Functional -> do
+    AS.Functional -> do
         so1 <- mapOPE cSig ope 1 2
         so2 <- mapOPE cSig ope 1 3
         return $ mkQUBI (map mkNAME [1, 2, 3]) [so1, so2]
                 (mkNTERM 2) (mkNTERM 3)
-    InverseFunctional -> do
+    AS.InverseFunctional -> do
         so1 <- mapOPE cSig ope 1 3
         so2 <- mapOPE cSig ope 2 3
         return $ mkQUBI (map mkNAME [1, 2, 3]) [so1, so2]
                 (mkNTERM 1) (mkNTERM 2)
-    Reflexive -> do
+    AS.Reflexive -> do
         so <- mapOPE cSig ope 1 1
         return $ senToText $ mk1QU so
-    Irreflexive -> do
+    AS.Irreflexive -> do
         so <- mapOPE cSig ope 1 1
         return $ senToText $ mk1QU $ mkBN so
-    Symmetric -> do
+    AS.Symmetric -> do
         so1 <- mapOPE cSig ope 1 2
         so2 <- mapOPE cSig ope 2 1
         return $ senToText $ mkQU [mkNAME 1, mkNAME 2] $ mkBI so1 so2
-    Asymmetric -> do
+    AS.Asymmetric -> do
         so1 <- mapOPE cSig ope 1 2
         so2 <- mapOPE cSig ope 2 1
         return $ senToText $ mkQU [mkNAME 1, mkNAME 2] $ mkBI so1 $ mkBN so2
-    Antisymmetric -> do
+    AS.Antisymmetric -> do
         so1 <- mapOPE cSig ope 1 2
         so2 <- mapOPE cSig ope 2 1
         return $ mkQUBI [mkNAME 1, mkNAME 2] [so1, so2] (mkNTERM 1) (mkNTERM 2)
-    Transitive -> do
+    AS.Transitive -> do
         so1 <- mapOPE cSig ope 1 2
         so2 <- mapOPE cSig ope 2 3
         so3 <- mapOPE cSig ope 1 3
         return $ senToText $ mkQU [mkNAME 1, mkNAME 2, mkNAME 3] $ mkBI
                 (mkBC [so1, so2]) so3
 
-mapKey :: Sign -> ClassExpression -> ([SENTENCE], [SENTENCE]) -> Int -> [Int]
+mapKey :: Sign -> AS.ClassExpression -> ([SENTENCE], [SENTENCE]) -> Int -> [Int]
     -> Result SENTENCE
 mapKey cSig ce (pl, npl) p i = do
     (nce, _) <- mapDescription cSig ce (OVar 1) 1
@@ -635,15 +635,15 @@ mapKey cSig ce (pl, npl) p i = do
                 $ mkAE (mkNTERM p) $ mkNTERM 1
     return $ mk1QU $ mkBI nce $ mkQE (map mkNAME i) $ mkBC $ pl ++ [un]
 
-mapSubObjProp :: Sign -> ObjectPropertyExpression -> ObjectPropertyExpression
+mapSubObjProp :: Sign -> AS.ObjectPropertyExpression -> AS.ObjectPropertyExpression
     -> Int -> Result SENTENCE
 mapSubObjProp cSig sp p a = let b = a + 1 in do
     l <- mapOPE cSig sp a b
     r <- mapOPE cSig p a b
     return $ mkQU (map mkNAME [a, b]) $ mkBI l r
 
-mapSubObjPropChain :: Sign -> [ObjectPropertyExpression]
-    -> ObjectPropertyExpression -> Int -> Result SENTENCE
+mapSubObjPropChain :: Sign -> [AS.ObjectPropertyExpression]
+    -> AS.ObjectPropertyExpression -> Int -> Result SENTENCE
 mapSubObjPropChain cSig opl op a = let b = a + 1 in do
     let vars = [a + 2 .. a + length opl]
         vl = a : vars ++ [a + 1]
@@ -652,17 +652,17 @@ mapSubObjPropChain cSig opl op a = let b = a + 1 in do
     let lst = map mkNAME $ a : b : vars
     return $ mkQU lst $ mkBI (mkBC npl) np
 
-mkEDPairs :: Sign -> [Int] -> Maybe Relation -> [(SENTENCE, SENTENCE)]
+mkEDPairs :: Sign -> [Int] -> Maybe AS.Relation -> [(SENTENCE, SENTENCE)]
     -> Result ([TEXT], Sign)
 mkEDPairs s il med pairs = do
     let ls = case fromMaybe (error "expected EDRelation") med of
-         EDRelation Equivalent -> map (uncurry mkBB) pairs
-         EDRelation Disjoint -> map (\ (x, y) -> mkBN $ mkBC [x, y]) pairs
+         AS.EDRelation AS.Equivalent -> map (uncurry mkBB) pairs
+         AS.EDRelation AS.Disjoint -> map (\ (x, y) -> mkBN $ mkBC [x, y]) pairs
          _ -> error "expected EDRelation"
     return ([eqFB il ls], s)
 
 -- | Mapping of ListFrameBit
-mapListFrameBit :: Sign -> Extended -> Maybe Relation -> ListFrameBit
+mapListFrameBit :: Sign -> Extended -> Maybe AS.Relation -> ListFrameBit
                 -> Result ([TEXT], Sign)
 mapListFrameBit cSig ex rel lfb = case lfb of
     AnnotationBit _ -> return ([], cSig)
@@ -670,15 +670,15 @@ mapListFrameBit cSig ex rel lfb = case lfb of
           Misc _ -> let cel = map snd cls in do
             (els, sig) <- mapDescriptionListP cSig 1 $ comPairs cel cel
             mkEDPairs sig [1] rel els
-          SimpleEntity (Entity _ ty iri) -> do
+          SimpleEntity (AS.Entity _ ty iri) -> do
              ls <- mapM (\ (_, c) -> mapDescription cSig c (OIndi iri) 1) cls
              case ty of
-              NamedIndividual | rel == Just Types -> do
+              AS.NamedIndividual | rel == Just AS.Types -> do
                   inD <- mapIndivIRI cSig iri
                   let ocls = map (mapClassAssertion inD)
                             $ zip (map snd cls) $ map fst ls
                   return (ocls, uniteL $ map snd ls)
-              DataProperty | rel == (Just $ DRRelation ADomain) -> do
+              AS.DataProperty | rel == (Just $ AS.DRRelation AS.ADomain) -> do
                   oEx <- mapDPE cSig iri 1 2
                   return (msen2Txt $ map (mkSent [mk1NAME] [mkNAME 2] oEx
                             . fst) ls, uniteL $ map snd ls)
@@ -686,16 +686,16 @@ mapListFrameBit cSig ex rel lfb = case lfb of
           ObjectEntity oe -> case rel of
               Nothing -> failMsg cls
               Just re -> case re of
-                  DRRelation r -> do
+                  AS.DRRelation r -> do
                     tobjP <- mapOPE cSig oe 1 2
                     tdsc <- mapM (\ (_, c) -> mapDescription cSig c (case r of
-                                ADomain -> OVar 1
-                                ARange -> OVar 2) $ case r of
-                                ADomain -> 1
-                                ARange -> 2) cls
+                                AS.ADomain -> OVar 1
+                                AS.ARange -> OVar 2) $ case r of
+                                AS.ADomain -> 1
+                                AS.ARange -> 2) cls
                     let vars = case r of
-                                ADomain -> (1, 2)
-                                ARange -> (2, 1)
+                                AS.ADomain -> (1, 2)
+                                AS.ARange -> (2, 1)
                     return (msen2Txt $ map (mkSent [mkNAME $ fst vars]
                                 [mkNAME $ snd vars] tobjP . fst) tdsc,
                             uniteL $ map snd tdsc)
@@ -703,10 +703,10 @@ mapListFrameBit cSig ex rel lfb = case lfb of
           ClassEntity ce -> let cel = map snd cls in case rel of
               Nothing -> failMsg lfb
               Just r -> case r of
-                EDRelation _ -> do
+                AS.EDRelation _ -> do
                    (decrsS, dSig) <- mapDescriptionListP cSig 1 $ mkPairs ce cel
                    mkEDPairs dSig [1] rel decrsS
-                SubClass -> do
+                AS.SubClass -> do
                     (domT, dSig) <- mapDescription cSig ce (OVar 1) 1
                     ls <- mapM (\ cd -> mapDescription cSig cd (OVar 1) 1) cel
                     rSig <- sigUnion cSig (unite dSig $ uniteL $ map snd ls)
@@ -719,14 +719,14 @@ mapListFrameBit cSig ex rel lfb = case lfb of
                     pairs <- mapObjPropListP cSig 1 2 $ comPairs opl opl
                     mkEDPairs cSig [1, 2] rel pairs
             ObjectEntity op -> case r of
-                EDRelation _ -> do
+                AS.EDRelation _ -> do
                     pairs <- mapObjPropListP cSig 1 2 $ mkPairs op opl
                     mkEDPairs cSig [1, 2] rel pairs
-                SubPropertyOf -> do
+                AS.SubPropertyOf -> do
                     os <- mapM (\ (o1, o2) -> mapSubObjProp cSig o1 o2 3)
                             $ mkPairs op opl
                     return (msen2Txt os, cSig)
-                InverseOf -> do
+                AS.InverseOf -> do
                     os1 <- mapM (\ o1 -> mapOPE cSig o1 1 2) opl
                     o2 <- mapOPE cSig op 2 1
                     return (msen2Txt $ map (\ cd -> mkQU (map mkNAME [1, 2])
@@ -739,11 +739,11 @@ mapListFrameBit cSig ex rel lfb = case lfb of
             Misc _ -> do
                     pairs <- mapDataPropListP cSig 1 2 $ comPairs dl dl
                     mkEDPairs cSig [1, 2] rel pairs
-            SimpleEntity (Entity _ DataProperty iri) -> case r of
-                EDRelation _ -> do
+            SimpleEntity (AS.Entity _ AS.DataProperty iri) -> case r of
+                AS.EDRelation _ -> do
                     pairs <- mapDataPropListP cSig 1 2 $ mkPairs iri dl
                     mkEDPairs cSig [1, 2] rel pairs
-                SubPropertyOf -> do
+                AS.SubPropertyOf -> do
                     os1 <- mapM (\ o1 -> mapDPE cSig o1 1 2) dl
                     o2 <- mapDPE cSig iri 1 2
                     return (msen2Txt $ map (mkQU (map mkNAME [1, 2])
@@ -752,13 +752,13 @@ mapListFrameBit cSig ex rel lfb = case lfb of
             _ -> failMsg lfb
     IndividualSameOrDifferent anl -> case rel of
         Nothing -> failMsg lfb
-        Just (SDRelation re) -> do
-            let SimpleEntity (Entity _ NamedIndividual iri) = ex
+        Just (AS.SDRelation re) -> do
+            let SimpleEntity (AS.Entity _ AS.NamedIndividual iri) = ex
             fs <- mapComIndivList cSig re (Just iri) $ map snd anl
             return (msen2Txt fs, cSig)
         _ -> failMsg lfb
     DataPropRange dpr -> case ex of
-        SimpleEntity (Entity _ DataProperty iri) -> do
+        SimpleEntity (AS.Entity _ AS.DataProperty iri) -> do
             oEx <- mapDPE cSig iri 1 2
             ls <- mapM (\ (_, r) -> mapDataRange cSig r $ OVar 2) dpr
             return (msen2Txt $ map (mkSent [mkNAME 1] [mkNAME 2] oEx
@@ -779,20 +779,20 @@ mapAnnFrameBit cSig ex afb =
     let err = fail $ "could not translate " ++ show afb in case afb of
     AnnotationFrameBit _ -> return ([], cSig)
     DataFunctional -> case ex of
-        SimpleEntity (Entity _ DataProperty iri) -> do
+        SimpleEntity (AS.Entity _ AS.DataProperty iri) -> do
             so1 <- mapDPE cSig iri 1 2
             so2 <- mapDPE cSig iri 1 3
             return ([mkQUBI (map mkNAME [1, 2, 3]) [so1, so2]
                         (mkNTERM 2) $ mkNTERM 3], cSig)
         _ -> err
     DatatypeBit dr -> case ex of
-        SimpleEntity (Entity _ Datatype iri) -> do
+        SimpleEntity (AS.Entity _ AS.Datatype iri) -> do
            (odes, dSig) <- mapDataRange cSig dr $ OVar 1
-           let dtp = mkTermAtoms (uriToTok iri) [mkVTerm $ OVar 1]
+           let dtp = mkTermAtoms (AS.uriToTok iri) [mkVTerm $ OVar 1]
            return ([senToText $ mk1QU $ mkBB dtp odes], dSig)
         _ -> err
     ClassDisjointUnion clsl -> case ex of
-        ClassEntity (Expression iri) -> do
+        ClassEntity (AS.Expression iri) -> do
             (decrs, dSig) <- mapDescriptionList cSig 1 clsl
             (decrsS, pSig) <- mapDescriptionListP cSig 1 $ comPairs clsl clsl
             let decrsP = unzip decrsS

--- a/OWL2/Parse.hs
+++ b/OWL2/Parse.hs
@@ -15,7 +15,7 @@ References  :  <http://www.w3.org/TR/2009/NOTE-owl2-manchester-syntax-20091027/>
 
 module OWL2.Parse where
 
-import OWL2.AS
+import qualified OWL2.AS as AS
 import OWL2.Symbols
 import OWL2.Keywords
 import OWL2.ColonKeywords
@@ -36,12 +36,12 @@ import Control.Monad (liftM2)
 import Data.Char
 import qualified Data.Map as Map
 
-characters :: [Character]
+characters :: [AS.Character]
 characters = [minBound .. maxBound]
 
 -- | OWL and CASL structured keywords including 'andS' and 'notS'
 owlKeywords :: [String]
-owlKeywords = notS : stringS : map show entityTypes
+owlKeywords = notS : stringS : map show AS.entityTypes
   ++ map show characters ++ keywords ++ criticalKeywords
 
 ncNameStart :: Char -> Bool
@@ -224,37 +224,37 @@ datatypeUri = fmap mkIRI (choice $ map keyword datatypeKeys) <|> uriP
 optSign :: CharParser st Bool
 optSign = option False $ fmap (== '-') (oneOf "+-")
 
-postDecimal :: CharParser st NNInt
-postDecimal = char '.' >> option zeroNNInt getNNInt
+postDecimal :: CharParser st AS.NNInt
+postDecimal = char '.' >> option AS.zeroNNInt getNNInt
 
-getNNInt :: CharParser st NNInt
-getNNInt = fmap (NNInt . map digitToInt) getNumber
+getNNInt :: CharParser st AS.NNInt
+getNNInt = fmap (AS.NNInt . map digitToInt) getNumber
 
-intLit :: CharParser st IntLit
+intLit :: CharParser st AS.IntLit
 intLit = do
   b <- optSign
   n <- getNNInt
-  return $ negNNInt b n
+  return $ AS.negNNInt b n
 
-decimalLit :: CharParser st DecLit
-decimalLit = liftM2 DecLit intLit $ option zeroNNInt postDecimal
+decimalLit :: CharParser st AS.DecLit
+decimalLit = liftM2 AS.DecLit intLit $ option AS.zeroNNInt postDecimal
 
-floatDecimal :: CharParser st DecLit
+floatDecimal :: CharParser st AS.DecLit
 floatDecimal = do
     n <- getNNInt
-    f <- option zeroNNInt postDecimal
-    return $ DecLit (negNNInt False n) f
+    f <- option AS.zeroNNInt postDecimal
+    return $ AS.DecLit (AS.negNNInt False n) f
    <|> do
     n <- postDecimal
-    return $ DecLit zeroInt n
+    return $ AS.DecLit AS.zeroInt n
 
-floatingPointLit :: CharParser st FloatLit
+floatingPointLit :: CharParser st AS.FloatLit
 floatingPointLit = do
    b <- optSign
    d <- floatDecimal
-   i <- option zeroInt (oneOf "eE" >> intLit)
+   i <- option AS.zeroInt (oneOf "eE" >> intLit)
    optionMaybe $ oneOf "fF"
-   return $ FloatLit (negDec b d) i
+   return $ AS.FloatLit (AS.negDec b d) i
 
 languageTag :: CharParser st String
 languageTag = atMost1 4 letter
@@ -265,24 +265,24 @@ rmQuotes s = case s of
   _ : tl@(_ : _) -> init tl
   _ -> error "rmQuotes"
 
-stringLiteral :: CharParser st Literal
+stringLiteral :: CharParser st AS.Literal
 stringLiteral = do
   s <- fmap rmQuotes stringLit
   do
-      string cTypeS
+      string AS.cTypeS
       d <- datatypeUri
-      return $ Literal s $ Typed d
+      return $ AS.Literal s $ AS.Typed d
     <|> do
         string asP
         t <- skips $ optionMaybe languageTag
-        return $ Literal s $ Untyped t
-    <|> skips (return $ Literal s $ Typed $ mkIRI stringS)
+        return $ AS.Literal s $ AS.Untyped t
+    <|> skips (return $ AS.Literal s $ AS.Typed $ mkIRI stringS)
 
-literal :: CharParser st Literal
+literal :: CharParser st AS.Literal
 literal = do
     f <- skips $ try floatingPointLit
-         <|> fmap decToFloat decimalLit
-    return $ NumberLit f
+         <|> fmap AS.decToFloat decimalLit
+    return $ AS.NumberLit f
   <|> stringLiteral
 
 -- * description
@@ -293,7 +293,7 @@ owlClassUri = uriP
 individualUri :: CharParser st IRI
 individualUri = uriP
 
-individual :: CharParser st Individual
+individual :: CharParser st AS.Individual
 individual = do
     i <- individualUri
     return $ if prefixName i == "_" then i {isBlankNode = True}
@@ -329,18 +329,18 @@ keyword :: String -> CharParser st String
 keyword s = keywordNotFollowedBy s (alphaNum <|> char '_')
 
 -- base OWLClass excluded
-atomic :: CharParser st ClassExpression
+atomic :: CharParser st AS.ClassExpression
 atomic = parensP description
-  <|> fmap ObjectOneOf (bracesP $ sepByComma individual)
+  <|> fmap AS.ObjectOneOf (bracesP $ sepByComma individual)
 
-objectPropertyExpr :: CharParser st ObjectPropertyExpression
+objectPropertyExpr :: CharParser st AS.ObjectPropertyExpression
 objectPropertyExpr = do
     keyword inverseS
-    fmap ObjectInverseOf objectPropertyExpr
-  <|> fmap ObjectProp uriP
+    fmap AS.ObjectInverseOf objectPropertyExpr
+  <|> fmap AS.ObjectProp uriP
 
 -- creating the facet-value pairs
-facetValuePair :: CharParser st (ConstrainingFacet, RestrictionValue)
+facetValuePair :: CharParser st (AS.ConstrainingFacet, AS.RestrictionValue)
 facetValuePair = do
   df <- choice $ map (\ f -> keyword (showFacet f) >> return f)
       [ LENGTH
@@ -356,58 +356,58 @@ facetValuePair = do
       , MAXINCLUSIVE
       , MAXEXCLUSIVE ]
   rv <- literal
-  return (facetToIRI df, rv)
+  return (AS.facetToIRI df, rv)
 
 -- it returns DataType Datatype or DatatypeRestriction Datatype [facetValuePair]
-dataRangeRestriction :: CharParser st DataRange
+dataRangeRestriction :: CharParser st AS.DataRange
 dataRangeRestriction = do
   e <- datatypeUri
-  option (DataType e []) $ fmap (DataType e) $ bracketsP
+  option (AS.DataType e []) $ fmap (AS.DataType e) $ bracketsP
     $ sepByComma facetValuePair
 
-dataConjunct :: CharParser st DataRange
-dataConjunct = fmap (mkDataJunction IntersectionOf)
+dataConjunct :: CharParser st AS.DataRange
+dataConjunct = fmap (mkDataJunction AS.IntersectionOf)
       $ sepBy1 dataPrimary $ keyword andS
 
-dataRange :: CharParser st DataRange
-dataRange = fmap (mkDataJunction UnionOf)
+dataRange :: CharParser st AS.DataRange
+dataRange = fmap (mkDataJunction AS.UnionOf)
       $ sepBy1 dataConjunct $ keyword orS
 
-dataPrimary :: CharParser st DataRange
+dataPrimary :: CharParser st AS.DataRange
 dataPrimary = do
     keyword notS
-    fmap DataComplementOf dataPrimary
-   <|> fmap DataOneOf (bracesP $ sepByComma literal)
+    fmap AS.DataComplementOf dataPrimary
+   <|> fmap AS.DataOneOf (bracesP $ sepByComma literal)
    <|> dataRangeRestriction
 
-mkDataJunction :: JunctionType -> [DataRange] -> DataRange
+mkDataJunction :: AS.JunctionType -> [AS.DataRange] -> AS.DataRange
 mkDataJunction ty ds = case nubOrd ds of
   [] -> error "mkDataJunction"
   [x] -> x
-  ns -> DataJunction ty ns
+  ns -> AS.DataJunction ty ns
 
 -- parses "some" or "only"
-someOrOnly :: CharParser st QuantifierType
+someOrOnly :: CharParser st AS.QuantifierType
 someOrOnly = choice
-  $ map (\ f -> keyword (showQuantifierType f) >> return f)
-    [AllValuesFrom, SomeValuesFrom]
+  $ map (\ f -> keyword (AS.showQuantifierType f) >> return f)
+    [AS.AllValuesFrom, AS.SomeValuesFrom]
 
 -- locates the keywords "min" "max" "exact" and their argument
-card :: CharParser st (CardinalityType, Int)
+card :: CharParser st (AS.CardinalityType, Int)
 card = do
-  c <- choice $ map (\ f -> keywordNotFollowedBy (showCardinalityType f) letter
+  c <- choice $ map (\ f -> keywordNotFollowedBy (AS.showCardinalityType f) letter
                             >> return f)
-             [MinCardinality, MaxCardinality, ExactCardinality]
+             [AS.MinCardinality, AS.MaxCardinality, AS.ExactCardinality]
   n <- skips getNumber
   return (c, value 10 n)
 
 -- tries to parse either a IRI or a literal
-individualOrConstant :: CharParser st (Either Individual Literal)
+individualOrConstant :: CharParser st (Either AS.Individual AS.Literal)
 individualOrConstant = fmap Right literal <|> fmap Left individual
 
 {- | applies the previous one to a list separated by commas
     (the list needs to be all of the same type, of course) -}
-individualOrConstantList :: CharParser st (Either [Individual] [Literal])
+individualOrConstantList :: CharParser st (Either [AS.Individual] [AS.Literal])
 individualOrConstantList = do
     ioc <- individualOrConstant
     case ioc of
@@ -416,127 +416,127 @@ individualOrConstantList = do
       Right c -> fmap (Right . (c :)) $ optionL
         $ commaP >> sepByComma literal
 
-primaryOrDataRange :: CharParser st (Either ClassExpression DataRange)
+primaryOrDataRange :: CharParser st (Either AS.ClassExpression AS.DataRange)
 primaryOrDataRange = do
   ns <- many $ keyword notS  -- allows multiple not before primary
   ed <- do
       u <- datatypeUri
-      fmap Left (restrictionAny $ ObjectProp u)
-        <|> fmap (Right . DataType u)
+      fmap Left (restrictionAny $ AS.ObjectProp u)
+        <|> fmap (Right . AS.DataType u)
             (bracketsP $ sepByComma facetValuePair)
-        <|> return (if isDatatypeKey u
-              then Right $ DataType u []
-              else Left $ Expression u) -- could still be a datatypeUri
+        <|> return (if AS.isDatatypeKey u
+              then Right $ AS.DataType u []
+              else Left $ AS.Expression u) -- could still be a datatypeUri
     <|> do
       e <- bracesP individualOrConstantList
       return $ case e of
-        Left us -> Left $ ObjectOneOf us
-        Right cs -> Right $ DataOneOf cs
+        Left us -> Left $ AS.ObjectOneOf us
+        Right cs -> Right $ AS.DataOneOf cs
     <|> fmap Left restrictionOrAtomic
   return $ if even (length ns) then ed else
     case ed of
-      Left d -> Left $ ObjectComplementOf d
-      Right d -> Right $ DataComplementOf d
+      Left d -> Left $ AS.ObjectComplementOf d
+      Right d -> Right $ AS.DataComplementOf d
 
-mkObjectJunction :: JunctionType -> [ClassExpression] -> ClassExpression
+mkObjectJunction :: AS.JunctionType -> [AS.ClassExpression] -> AS.ClassExpression
 mkObjectJunction ty ds = case nubOrd ds of
   [] -> error "mkObjectJunction"
   [x] -> x
-  ns -> ObjectJunction ty ns
+  ns -> AS.ObjectJunction ty ns
 
-restrictionAny :: ObjectPropertyExpression -> CharParser st ClassExpression
+restrictionAny :: AS.ObjectPropertyExpression -> CharParser st AS.ClassExpression
 restrictionAny opExpr = do
       keyword valueS
       e <- individualOrConstant
       case e of
-        Left u -> return $ ObjectHasValue opExpr u
+        Left u -> return $ AS.ObjectHasValue opExpr u
         Right c -> case opExpr of
-          ObjectProp dpExpr -> return $ DataHasValue dpExpr c
+          AS.ObjectProp dpExpr -> return $ AS.DataHasValue dpExpr c
           _ -> unexpected "literal"
     <|> do
       keyword selfS
-      return $ ObjectHasSelf opExpr
+      return $ AS.ObjectHasSelf opExpr
     <|> do -- sugar
       keyword onlysomeS
       ds <- bracketsP $ sepByComma description
-      let as = map (ObjectValuesFrom SomeValuesFrom opExpr) ds
-          o = ObjectValuesFrom AllValuesFrom opExpr
-              $ mkObjectJunction UnionOf ds
-      return $ mkObjectJunction IntersectionOf $ o : as
+      let as = map (AS.ObjectValuesFrom AS.SomeValuesFrom opExpr) ds
+          o = AS.ObjectValuesFrom AS.AllValuesFrom opExpr
+              $ mkObjectJunction AS.UnionOf ds
+      return $ mkObjectJunction AS.IntersectionOf $ o : as
     <|> do -- sugar
       keyword hasS
       iu <- individual
-      return $ ObjectValuesFrom SomeValuesFrom opExpr $ ObjectOneOf [iu]
+      return $ AS.ObjectValuesFrom AS.SomeValuesFrom opExpr $ AS.ObjectOneOf [iu]
     <|> do
       v <- someOrOnly
       pr <- primaryOrDataRange
       case pr of
-        Left p -> return $ ObjectValuesFrom v opExpr p
+        Left p -> return $ AS.ObjectValuesFrom v opExpr p
         Right r -> case opExpr of
-          ObjectProp dpExpr -> return $ DataValuesFrom v dpExpr r
-          _ -> unexpected $ "dataRange after " ++ showQuantifierType v
+          AS.ObjectProp dpExpr -> return $ AS.DataValuesFrom v [dpExpr] r
+          _ -> unexpected $ "dataRange after " ++ AS.showQuantifierType v
     <|> do
       (c, n) <- card
       mp <- optionMaybe primaryOrDataRange
       case mp of
-         Nothing -> return $ ObjectCardinality $ Cardinality c n opExpr Nothing
+         Nothing -> return $ AS.ObjectCardinality $ AS.Cardinality c n opExpr Nothing
          Just pr -> case pr of
            Left p ->
-             return $ ObjectCardinality $ Cardinality c n opExpr $ Just p
+             return $ AS.ObjectCardinality $ AS.Cardinality c n opExpr $ Just p
            Right r -> case opExpr of
-             ObjectProp dpExpr ->
-               return $ DataCardinality $ Cardinality c n dpExpr $ Just r
-             _ -> unexpected $ "dataRange after " ++ showCardinalityType c
+             AS.ObjectProp dpExpr ->
+               return $ AS.DataCardinality $ AS.Cardinality c n dpExpr $ Just r
+             _ -> unexpected $ "dataRange after " ++ AS.showCardinalityType c
 
-restriction :: CharParser st ClassExpression
+restriction :: CharParser st AS.ClassExpression
 restriction = objectPropertyExpr >>= restrictionAny
 
-restrictionOrAtomic :: CharParser st ClassExpression
+restrictionOrAtomic :: CharParser st AS.ClassExpression
 restrictionOrAtomic = do
     opExpr <- objectPropertyExpr
     restrictionAny opExpr <|> case opExpr of
-       ObjectProp euri -> return $ Expression euri
+       AS.ObjectProp euri -> return $ AS.Expression euri
        _ -> unexpected "inverse object property"
   <|> atomic
 
 optNot :: (a -> a) -> CharParser st a -> CharParser st a
 optNot f p = (keyword notS >> fmap f p) <|> p
 
-primary :: CharParser st ClassExpression
-primary = optNot ObjectComplementOf restrictionOrAtomic
+primary :: CharParser st AS.ClassExpression
+primary = optNot AS.ObjectComplementOf restrictionOrAtomic
 
-conjunction :: CharParser st ClassExpression
+conjunction :: CharParser st AS.ClassExpression
 conjunction = do
-    curi <- fmap Expression $ try (owlClassUri << keyword thatS)
-    rs <- sepBy1 (optNot ObjectComplementOf restriction) $ keyword andS
-    return $ mkObjectJunction IntersectionOf $ curi : rs
-  <|> fmap (mkObjectJunction IntersectionOf)
+    curi <- fmap AS.Expression $ try (owlClassUri << keyword thatS)
+    rs <- sepBy1 (optNot AS.ObjectComplementOf restriction) $ keyword andS
+    return $ mkObjectJunction AS.IntersectionOf $ curi : rs
+  <|> fmap (mkObjectJunction AS.IntersectionOf)
       (sepBy1 primary $ keyword andS)
 
-description :: CharParser st ClassExpression
+description :: CharParser st AS.ClassExpression
 description =
-  fmap (mkObjectJunction UnionOf) $ sepBy1 conjunction $ keyword orS
+  fmap (mkObjectJunction AS.UnionOf) $ sepBy1 conjunction $ keyword orS
 
-entityType :: CharParser st EntityType
+entityType :: CharParser st AS.EntityType
 entityType = choice $ map (\ f -> keyword (show f) >> return f)
-  entityTypes
+  AS.entityTypes
 
 {- | same as annotation Target in Manchester Syntax,
       named annotation Value in Abstract Syntax -}
-annotationValue :: CharParser st AnnotationValue
+annotationValue :: CharParser st AS.AnnotationValue
 annotationValue = do
     l <- literal
-    return $ AnnValLit l
+    return $ AS.AnnValLit l
   <|> do
     i <- individual
-    return $ AnnValue i
+    return $ AS.AnnValue i
 
-equivOrDisjointL :: [EquivOrDisjoint]
-equivOrDisjointL = [Equivalent, Disjoint]
+equivOrDisjointL :: [AS.EquivOrDisjoint]
+equivOrDisjointL = [AS.Equivalent, AS.Disjoint]
 
-equivOrDisjoint :: CharParser st EquivOrDisjoint
+equivOrDisjoint :: CharParser st AS.EquivOrDisjoint
 equivOrDisjoint = choice
-  $ map (\ f -> pkeyword (showEquivOrDisjoint f) >> return f)
+  $ map (\ f -> pkeyword (AS.showEquivOrDisjoint f) >> return f)
   equivOrDisjointL
 
 subPropertyKey :: CharParser st ()
@@ -545,28 +545,28 @@ subPropertyKey = pkeyword subPropertyOfC
 characterKey :: CharParser st ()
 characterKey = pkeyword characteristicsC
 
-sameOrDifferent :: CharParser st SameOrDifferent
+sameOrDifferent :: CharParser st AS.SameOrDifferent
 sameOrDifferent = choice
-  $ map (\ f -> pkeyword (showSameOrDifferent f) >> return f)
-  [Same, Different]
+  $ map (\ f -> pkeyword (AS.showSameOrDifferent f) >> return f)
+  [AS.Same, AS.Different]
 
-sameOrDifferentIndu :: CharParser st SameOrDifferent
-sameOrDifferentIndu = (pkeyword sameIndividualC >> return Same)
-    <|> (pkeyword differentIndividualsC >> return Different)
+sameOrDifferentIndu :: CharParser st AS.SameOrDifferent
+sameOrDifferentIndu = (pkeyword sameIndividualC >> return AS.Same)
+    <|> (pkeyword differentIndividualsC >> return AS.Different)
 
-equivOrDisjointKeyword :: String -> CharParser st EquivOrDisjoint
+equivOrDisjointKeyword :: String -> CharParser st AS.EquivOrDisjoint
 equivOrDisjointKeyword ext = choice
   $ map (\ f -> pkeyword (show f ++ ext) >> return f)
   equivOrDisjointL
 
-objectPropertyCharacter :: CharParser st Character
+objectPropertyCharacter :: CharParser st AS.Character
 objectPropertyCharacter =
   choice $ map (\ f -> keyword (show f) >> return f) characters
 
-domainOrRange :: CharParser st DomainOrRange
+domainOrRange :: CharParser st AS.DomainOrRange
 domainOrRange = choice
-  $ map (\ f -> pkeyword (showDomainOrRange f) >> return f)
-  [ADomain, ARange]
+  $ map (\ f -> pkeyword (AS.showDomainOrRange f) >> return f)
+  [AS.ADomain, AS.ARange]
 
 nsEntry :: CharParser st (String, IRI)
 nsEntry = do

--- a/OWL2/ParseOWLAsLibDefn.hs
+++ b/OWL2/ParseOWLAsLibDefn.hs
@@ -12,7 +12,7 @@ analyse OWL files by calling the external Java parser.
 
 module OWL2.ParseOWLAsLibDefn (parseOWLAsLibDefn) where
 
-import OWL2.AS
+import qualified OWL2.AS as AS
 import OWL2.MS
 
 import Data.List

--- a/OWL2/Print.hs
+++ b/OWL2/Print.hs
@@ -18,7 +18,7 @@ import Common.Id
 import Common.Keywords
 import Common.IRI
 
-import OWL2.AS
+import qualified OWL2.AS as AS
 import OWL2.MS
 import OWL2.Symbols
 import OWL2.Keywords
@@ -26,7 +26,7 @@ import OWL2.ColonKeywords
 
 import Data.List
 
-instance Pretty Character where
+instance Pretty AS.Character where
     pretty = printCharact . show
 
 printCharact :: String -> Doc
@@ -35,12 +35,12 @@ printCharact = text
 printIRI :: IRI -> Doc
 printIRI q
     | ((hasFullIRI q || prefixName q `elem` ["", "owl", "rdfs"])
-       && isPredefPropOrClass q)
-       || isDatatypeKey q = keyword $ getPredefName q
+       && AS.isPredefPropOrClass q)
+       || AS.isDatatypeKey q = keyword $ AS.getPredefName q
     | otherwise = text $ showIRI q
 
 printDataIRI :: IRI -> Doc
-printDataIRI q = if isDatatypeKey q then text $ showIRI $ setDatatypePrefix q
+printDataIRI q = if AS.isDatatypeKey q then text $ showIRI $ AS.setDatatypePrefix q
  else printIRI q
 
 -- | Symbols printing
@@ -72,41 +72,41 @@ instance Pretty RawSymb where
         AnUri u -> pretty u
         APrefix p -> pretty p
 
-cardinalityType :: CardinalityType -> Doc
-cardinalityType = keyword . showCardinalityType
+cardinalityType :: AS.CardinalityType -> Doc
+cardinalityType = keyword . AS.showCardinalityType
 
-quantifierType :: QuantifierType -> Doc
-quantifierType = keyword . showQuantifierType
+quantifierType :: AS.QuantifierType -> Doc
+quantifierType = keyword . AS.showQuantifierType
 
-printRelation :: Relation -> Doc
-printRelation = keyword . showRelation
+printRelation :: AS.Relation -> Doc
+printRelation = keyword . AS.showRelation
 
-printEquivOrDisjointClasses :: EquivOrDisjoint -> Doc
+printEquivOrDisjointClasses :: AS.EquivOrDisjoint -> Doc
 printEquivOrDisjointClasses x = case x of
-    Equivalent -> text "EquivalentClasses:"
-    Disjoint -> text "DisjointClasses:"
+    AS.Equivalent -> text "EquivalentClasses:"
+    AS.Disjoint -> text "DisjointClasses:"
 
-printEquivOrDisjointProp :: EquivOrDisjoint -> Doc
+printEquivOrDisjointProp :: AS.EquivOrDisjoint -> Doc
 printEquivOrDisjointProp e = case e of
-    Disjoint -> text "DisjointProperties:"
-    Equivalent -> text "EquivalentProperties:"
+    AS.Disjoint -> text "DisjointProperties:"
+    AS.Equivalent -> text "EquivalentProperties:"
 
-printPositiveOrNegative :: PositiveOrNegative -> Doc
+printPositiveOrNegative :: AS.PositiveOrNegative -> Doc
 printPositiveOrNegative x = case x of
-    Positive -> empty
-    Negative -> keyword notS
+    AS.Positive -> empty
+    AS.Negative -> keyword notS
 
-printSameOrDifferentInd :: SameOrDifferent -> Doc
+printSameOrDifferentInd :: AS.SameOrDifferent -> Doc
 printSameOrDifferentInd x = case x of
-    Same -> keyword sameIndividualC
-    Different -> keyword differentIndividualsC
+    AS.Same -> keyword sameIndividualC
+    AS.Different -> keyword differentIndividualsC
 
-instance Pretty Entity where
-    pretty (Entity _ ty e) = keyword (show ty) <+> pretty e
+instance Pretty AS.Entity where
+    pretty (AS.Entity _ ty e) = keyword (show ty) <+> pretty e
 
-instance Pretty Literal where
+instance Pretty AS.Literal where
     pretty lit = case lit of
-        Literal lexi ty -> let
+        AS.Literal lexi ty -> let
           escapeDQ c s = case s of
             "" -> ""
             h : t -> case h of
@@ -114,24 +114,24 @@ instance Pretty Literal where
               _ | odd c || h /= '"' -> h : escapeDQ 0 t
               _ -> '\\' : h : escapeDQ 0 t
           in plainText ('"' : escapeDQ 0 lexi ++ "\"") <> case ty of
-            Typed u -> keyword cTypeS <> printDataIRI u
-            Untyped tag -> case tag of
+            AS.Typed u -> keyword AS.cTypeS <> printDataIRI u
+            AS.Untyped tag -> case tag of
               Nothing -> empty
               Just tag2 -> text asP <> text tag2
-        NumberLit f -> text (show f)
+        AS.NumberLit f -> text (show f)
 
-instance Pretty ObjectPropertyExpression where
+instance Pretty AS.ObjectPropertyExpression where
     pretty = printObjPropExp
 
-printObjPropExp :: ObjectPropertyExpression -> Doc
+printObjPropExp :: AS.ObjectPropertyExpression -> Doc
 printObjPropExp obExp = case obExp of
-    ObjectProp ou -> pretty ou
-    ObjectInverseOf iopExp -> keyword inverseS <+> printObjPropExp iopExp
+    AS.ObjectProp ou -> pretty ou
+    AS.ObjectInverseOf iopExp -> keyword inverseS <+> printObjPropExp iopExp
 
-printFV :: (ConstrainingFacet, RestrictionValue) -> Doc
+printFV :: (AS.ConstrainingFacet, AS.RestrictionValue) -> Doc
 printFV (facet, restValue) = pretty (fromCF facet) <+> pretty restValue
 
-fromCF :: ConstrainingFacet -> String
+fromCF :: AS.ConstrainingFacet -> String
 fromCF f
     | hasFullIRI f = showIRICompact f \\ "http://www.w3.org/2001/XMLSchema#"
     | otherwise = show $ iriPath f
@@ -140,83 +140,83 @@ instance Pretty DatatypeFacet where
     pretty = keyword . showFacet
 
 -- | Printing the DataRange
-instance Pretty DataRange where
+instance Pretty AS.DataRange where
     pretty = printDataRange
 
-printDataRange :: DataRange -> Doc
+printDataRange :: AS.DataRange -> Doc
 printDataRange dr = case dr of
-    DataType dtype l -> pretty dtype <+>
+    AS.DataType dtype l -> pretty dtype <+>
       if null l then empty else brackets $ sepByCommas $ map printFV l
-    DataComplementOf drange -> keyword notS <+> pretty drange
-    DataOneOf constList -> specBraces $ ppWithCommas constList
-    DataJunction ty drlist -> let
+    AS.DataComplementOf drange -> keyword notS <+> pretty drange
+    AS.DataOneOf constList -> specBraces $ ppWithCommas constList
+    AS.DataJunction ty drlist -> let
       k = case ty of
-          UnionOf -> orS
-          IntersectionOf -> andS
+          AS.UnionOf -> orS
+          AS.IntersectionOf -> andS
       in fsep $ prepPunctuate (keyword k <> space) $ map pretty drlist
 
 -- | Printing the ClassExpression
-instance Pretty ClassExpression where
+instance Pretty AS.ClassExpression where
   pretty desc = case desc of
-   Expression ocUri -> printIRI ocUri
-   ObjectJunction ty ds -> let
+   AS.Expression ocUri -> printIRI ocUri
+   AS.ObjectJunction ty ds -> let
       (k, p) = case ty of
-          UnionOf -> (orS, pretty)
-          IntersectionOf -> (andS, printPrimary)
+          AS.UnionOf -> (orS, pretty)
+          AS.IntersectionOf -> (andS, printPrimary)
       in fsep $ prepPunctuate (keyword k <> space) $ map p ds
-   ObjectComplementOf d -> keyword notS <+> printNegatedPrimary d
-   ObjectOneOf indUriList -> specBraces $ ppWithCommas indUriList
-   ObjectValuesFrom ty opExp d ->
+   AS.ObjectComplementOf d -> keyword notS <+> printNegatedPrimary d
+   AS.ObjectOneOf indUriList -> specBraces $ ppWithCommas indUriList
+   AS.ObjectValuesFrom ty opExp d ->
       printObjPropExp opExp <+> quantifierType ty <+> printNegatedPrimary d
-   ObjectHasSelf opExp ->
+   AS.ObjectHasSelf opExp ->
       printObjPropExp opExp <+> keyword selfS
-   ObjectHasValue opExp indUri ->
+   AS.ObjectHasValue opExp indUri ->
       pretty opExp <+> keyword valueS <+> pretty indUri
-   ObjectCardinality (Cardinality ty card opExp maybeDesc) ->
+   AS.ObjectCardinality (AS.Cardinality ty card opExp maybeDesc) ->
       printObjPropExp opExp <+> cardinalityType ty
         <+> text (show card)
         <+> maybe (keyword "Thing") printPrimary maybeDesc
-   DataValuesFrom ty dpExp dRange ->
-       printIRI dpExp <+> quantifierType ty
+   AS.DataValuesFrom ty dpExp dRange ->
+       printIRI (head dpExp) <+> quantifierType ty
         <+> pretty dRange
-   DataHasValue dpExp cons -> pretty dpExp <+> keyword valueS <+> pretty cons
-   DataCardinality (Cardinality ty card dpExp maybeRange) ->
+   AS.DataHasValue dpExp cons -> pretty dpExp <+> keyword valueS <+> pretty cons
+   AS.DataCardinality (AS.Cardinality ty card dpExp maybeRange) ->
        pretty dpExp <+> cardinalityType ty <+> text (show card)
          <+> maybe empty pretty maybeRange
 
-printPrimary :: ClassExpression -> Doc
+printPrimary :: AS.ClassExpression -> Doc
 printPrimary d = let dd = pretty d in case d of
-  ObjectJunction {} -> parens dd
+  AS.ObjectJunction {} -> parens dd
   _ -> dd
 
-printNegatedPrimary :: ClassExpression -> Doc
+printNegatedPrimary :: AS.ClassExpression -> Doc
 printNegatedPrimary d = let r = parens $ pretty d in case d of
-  ObjectComplementOf _ -> r
-  ObjectValuesFrom {} -> r
-  DataValuesFrom {} -> r
-  ObjectHasValue {} -> r
-  DataHasValue {} -> r
+  AS.ObjectComplementOf _ -> r
+  AS.ObjectValuesFrom {} -> r
+  AS.DataValuesFrom {} -> r
+  AS.ObjectHasValue {} -> r
+  AS.DataHasValue {} -> r
   _ -> printPrimary d
 
 -- | annotations printing
-instance Pretty AnnotationValue where
+instance Pretty AS.AnnotationValue where
     pretty x = case x of
-        AnnValue iri -> pretty iri
-        AnnValLit lit -> pretty lit
+        AS.AnnValue iri -> pretty iri
+        AS.AnnValLit lit -> pretty lit
 
-instance Pretty OWL2.AS.Annotation where
+instance Pretty AS.Annotation where
     pretty = printAnnotation
 
-printAnnotation :: OWL2.AS.Annotation -> Doc
-printAnnotation (Annotation ans ap av) =
+printAnnotation :: AS.Annotation -> Doc
+printAnnotation (AS.Annotation ans ap av) =
     sep [printAnnotations ans, sep [pretty ap, pretty av]]
 
 printAnnotations :: Annotations -> Doc
 printAnnotations l = case l of
     [] -> empty
     _ -> keyword annotationsC <+>
-          vcat (punctuate comma (map (\ (Annotation ans ap av) ->
-            printAnnotations ans $+$ pretty (Annotation [] ap av)) l) )
+          vcat (punctuate comma (map (\ (AS.Annotation ans ap av) ->
+            printAnnotations ans $+$ pretty (AS.Annotation [] ap av)) l) )
 
 printAnnotatedList :: Pretty a => AnnotatedList a -> Doc
 printAnnotatedList l =

--- a/OWL2/Profiles.hs
+++ b/OWL2/Profiles.hs
@@ -15,7 +15,7 @@ References  :  <http://www.w3.org/TR/owl2-profiles/>
 
 module OWL2.Profiles where
 
-import OWL2.AS
+import qualified OWL2.AS as AS
 import OWL2.MS
 
 import Data.Data
@@ -74,124 +74,124 @@ andList f cel = andProfileList (map f cel)
 minimalCovering :: Profiles -> [Profiles] -> Profiles
 minimalCovering c pl = andProfileList [c, andProfileList pl]
 
-dataType :: Datatype -> Profiles
+dataType :: AS.Datatype -> Profiles
 dataType _ = topProfile -- needs to be implemented, of course
 
-literal :: Literal -> Profiles
+literal :: AS.Literal -> Profiles
 literal _ = topProfile -- needs to be implemented
 
-individual :: Individual -> Profiles
-individual i = if isAnonymous i then rlProfile else topProfile
+individual :: AS.Individual -> Profiles
+individual i = if AS.isAnonymous i then rlProfile else topProfile
 
-objProp :: ObjectPropertyExpression -> Profiles
+objProp :: AS.ObjectPropertyExpression -> Profiles
 objProp ope = case ope of
-    ObjectInverseOf _ -> qlrlProfile
+    AS.ObjectInverseOf _ -> qlrlProfile
     _ -> topProfile
 
-dataRange :: DataRange -> Profiles
+dataRange :: AS.DataRange -> Profiles
 dataRange dr = case dr of
-    DataType dt cfl ->
+    AS.DataType dt cfl ->
         if null cfl then dataType dt
          else bottomProfile
-    DataJunction IntersectionOf drl -> andProfileList $ map dataRange drl
-    DataOneOf ll -> bottomProfile {
+    AS.DataJunction AS.IntersectionOf drl -> andProfileList $ map dataRange drl
+    AS.DataOneOf ll -> bottomProfile {
                         el = el (andList literal ll) && length ll == 1
                     }
     _ -> bottomProfile
 
-subClass :: ClassExpression -> Profiles
+subClass :: AS.ClassExpression -> Profiles
 subClass cex = case cex of
-    Expression c -> if isThing c then elqlProfile else topProfile
-    ObjectJunction jt cel -> minimalCovering (case jt of
-        IntersectionOf -> elrlProfile
-        UnionOf -> rlProfile) $ map subClass cel
-    ObjectOneOf il -> bottomProfile {
+    AS.Expression c -> if AS.isThing c then elqlProfile else topProfile
+    AS.ObjectJunction jt cel -> minimalCovering (case jt of
+        AS.IntersectionOf -> elrlProfile
+        AS.UnionOf -> rlProfile) $ map subClass cel
+    AS.ObjectOneOf il -> bottomProfile {
                     el = el (andList individual il) && length il == 1,
                     rl = ql $ andList individual il
                 }
-    ObjectValuesFrom SomeValuesFrom ope ce -> andProfileList [objProp ope,
+    AS.ObjectValuesFrom AS.SomeValuesFrom ope ce -> andProfileList [objProp ope,
         case ce of
-            Expression c -> if isThing c then topProfile
+            AS.Expression c -> if AS.isThing c then topProfile
                              else elrlProfile
             _ -> minimalCovering elrlProfile [subClass ce]]
-    ObjectHasValue ope i -> minimalCovering elrlProfile
+    AS.ObjectHasValue ope i -> minimalCovering elrlProfile
        [objProp ope, individual i]
-    ObjectHasSelf ope -> minimalCovering elProfile [objProp ope]
-    DataValuesFrom SomeValuesFrom _ dr -> dataRange dr
-    DataHasValue _ l -> literal l
+    AS.ObjectHasSelf ope -> minimalCovering elProfile [objProp ope]
+    AS.DataValuesFrom AS.SomeValuesFrom _ dr -> dataRange dr
+    AS.DataHasValue _ l -> literal l
     _ -> bottomProfile
 
-superClass :: ClassExpression -> Profiles
+superClass :: AS.ClassExpression -> Profiles
 superClass cex = case cex of
-    Expression c -> if isThing c then elqlProfile else topProfile
-    ObjectJunction IntersectionOf cel -> andList superClass cel
-    ObjectComplementOf ce -> minimalCovering qlrlProfile [subClass ce]
-    ObjectOneOf il -> bottomProfile {
+    AS.Expression c -> if AS.isThing c then elqlProfile else topProfile
+    AS.ObjectJunction AS.IntersectionOf cel -> andList superClass cel
+    AS.ObjectComplementOf ce -> minimalCovering qlrlProfile [subClass ce]
+    AS.ObjectOneOf il -> bottomProfile {
                     el = el (andList individual il) && length il == 1,
                     rl = ql $ andList individual il
                 }
-    ObjectValuesFrom qt ope ce -> case qt of
-        SomeValuesFrom -> andProfileList [objProp ope, case ce of
-            Expression _ -> elqlProfile
+    AS.ObjectValuesFrom qt ope ce -> case qt of
+        AS.SomeValuesFrom -> andProfileList [objProp ope, case ce of
+            AS.Expression _ -> elqlProfile
             _ -> elProfile]
-        AllValuesFrom -> andProfileList [superClass ce, rlProfile]
-    ObjectHasValue ope i -> andProfileList [elrlProfile, objProp ope,
+        AS.AllValuesFrom -> andProfileList [superClass ce, rlProfile]
+    AS.ObjectHasValue ope i -> andProfileList [elrlProfile, objProp ope,
         individual i]
-    ObjectHasSelf ope -> andProfileList [elProfile, objProp ope]
-    ObjectCardinality (Cardinality MaxCardinality i _ mce) ->
+    AS.ObjectHasSelf ope -> andProfileList [elProfile, objProp ope]
+    AS.ObjectCardinality (AS.Cardinality AS.MaxCardinality i _ mce) ->
         if elem i [0, 1] then andProfileList [rlProfile, case mce of
             Nothing -> topProfile
             Just ce -> case ce of
-                Expression _ -> topProfile
+                AS.Expression _ -> topProfile
                 _ -> subClass ce]
          else bottomProfile
-    DataValuesFrom qt _ dr -> andProfileList [dataRange dr, case qt of
-        SomeValuesFrom -> elqlProfile
-        AllValuesFrom -> rlProfile]
-    DataHasValue _ l -> andProfileList [elrlProfile, literal l]
-    DataCardinality (Cardinality MaxCardinality i _ mdr) ->
+    AS.DataValuesFrom qt _ dr -> andProfileList [dataRange dr, case qt of
+        AS.SomeValuesFrom -> elqlProfile
+        AS.AllValuesFrom -> rlProfile]
+    AS.DataHasValue _ l -> andProfileList [elrlProfile, literal l]
+    AS.DataCardinality (AS.Cardinality AS.MaxCardinality i _ mdr) ->
         if elem i [0, 1] then andProfileList [rlProfile, case mdr of
             Nothing -> topProfile
             Just dr -> dataRange dr]
          else bottomProfile
     _ -> bottomProfile
 
-equivClassRL :: ClassExpression -> Bool
+equivClassRL :: AS.ClassExpression -> Bool
 equivClassRL cex = case cex of
-    Expression c -> (not . isThing) c
-    ObjectJunction IntersectionOf cel -> all equivClassRL cel
-    ObjectHasValue _ i -> rl $ individual i
-    DataHasValue _ l -> rl $ literal l
+    AS.Expression c -> (not . AS.isThing) c
+    AS.ObjectJunction AS.IntersectionOf cel -> all equivClassRL cel
+    AS.ObjectHasValue _ i -> rl $ individual i
+    AS.DataHasValue _ l -> rl $ literal l
     _ -> False
 
-annotation :: Annotation -> Profiles
-annotation (Annotation as _ av) = andProfileList [annotations as, case av of
-    AnnValLit l -> literal l
+annotation :: AS.Annotation -> Profiles
+annotation (AS.Annotation as _ av) = andProfileList [annotations as, case av of
+    AS.AnnValLit l -> literal l
     _ -> topProfile]
 
 annotations :: Annotations -> Profiles
 annotations ans = andProfileList $ map annotation ans
 
-assertionQL :: ClassExpression -> Bool
+assertionQL :: AS.ClassExpression -> Bool
 assertionQL ce = case ce of
-    Expression _ -> True
+    AS.Expression _ -> True
     _ -> False
 
-char :: [Character] -> [Character] -> Bool
+char :: [AS.Character] -> [AS.Character] -> Bool
 char charList ls = all (`elem` ls) charList
 
 fact :: Fact -> Profiles
 fact f = case f of
     ObjectPropertyFact pn ope i -> andProfileList [objProp ope, individual i,
         case pn of
-            Positive -> topProfile
-            Negative -> elrlProfile]
+            AS.Positive -> topProfile
+            AS.Negative -> elrlProfile]
     DataPropertyFact pn _ l -> andProfileList [literal l,
         case pn of
-            Positive -> topProfile
-            Negative -> elrlProfile]
+            AS.Positive -> topProfile
+            AS.Negative -> elrlProfile]
 
-lFB :: Extended -> Maybe Relation -> ListFrameBit -> Profiles
+lFB :: Extended -> Maybe AS.Relation -> ListFrameBit -> Profiles
 lFB ext mr lfb = case lfb of
     AnnotationBit anl -> annotations $ concatMap fst anl
     ExpressionBit anl ->
@@ -206,7 +206,7 @@ lFB ext mr lfb = case lfb of
                     rl = all equivClassRL cel
                 }]
             ClassEntity c -> case r of
-                SubClass -> andProfileList [ans, subClass c,
+                AS.SubClass -> andProfileList [ans, subClass c,
                     andList superClass cel]
                 _ -> andProfileList [ans, bottomProfile {
                     el = el $ andList subClass $ c : cel,
@@ -215,9 +215,9 @@ lFB ext mr lfb = case lfb of
                 }]
             ObjectEntity op -> andProfileList [ans, objProp op,
                 andList superClass cel]
-            SimpleEntity (Entity _ ty ent) -> case ty of
-                DataProperty -> andProfileList [ans, andList superClass cel]
-                NamedIndividual -> andProfileList [ans, individual ent,
+            SimpleEntity (AS.Entity _ ty ent) -> case ty of
+                AS.DataProperty -> andProfileList [ans, andList superClass cel]
+                AS.NamedIndividual -> andProfileList [ans, individual ent,
                     bottomProfile {
                         el = el $ andList superClass cel,
                         ql = all assertionQL cel,
@@ -230,11 +230,11 @@ lFB ext mr lfb = case lfb of
             r = fromMaybe (error "relation needed") mr
         in case ext of
             Misc anno -> andProfileList [ans, annotations anno, opl, case r of
-                EDRelation Equivalent -> topProfile
+                AS.EDRelation AS.Equivalent -> topProfile
                 _ -> qlrlProfile]
             ObjectEntity op -> andProfileList [ans, opl, objProp op, case r of
-                SubPropertyOf -> topProfile
-                EDRelation Equivalent -> topProfile
+                AS.SubPropertyOf -> topProfile
+                AS.EDRelation AS.Equivalent -> topProfile
                 _ -> qlrlProfile]
             _ -> error "invalit object bit"
     DataBit anl ->
@@ -242,11 +242,11 @@ lFB ext mr lfb = case lfb of
             r = fromMaybe (error "relation needed") mr
         in case ext of
             Misc anno -> andProfileList [ans, annotations anno, case r of
-                EDRelation Equivalent -> topProfile
+                AS.EDRelation AS.Equivalent -> topProfile
                 _ -> qlrlProfile]
             _ -> andProfileList [ans, case r of
-                    SubPropertyOf -> topProfile
-                    EDRelation Equivalent -> topProfile
+                    AS.SubPropertyOf -> topProfile
+                    AS.EDRelation AS.Equivalent -> topProfile
                     _ -> qlrlProfile]
     IndividualSameOrDifferent anl ->
         let ans = annotations $ concatMap fst anl
@@ -254,11 +254,11 @@ lFB ext mr lfb = case lfb of
             i = andList individual $ map snd anl
         in case ext of
             Misc anno -> andProfileList [ans, annotations anno, i, case r of
-                SDRelation Different -> topProfile
+                AS.SDRelation AS.Different -> topProfile
                 _ -> elrlProfile]
-            SimpleEntity (Entity _ _ ind) -> andProfileList [ans, individual ind,
+            SimpleEntity (AS.Entity _ _ ind) -> andProfileList [ans, individual ind,
                 i, case r of
-                    SDRelation Different -> topProfile
+                    AS.SDRelation AS.Different -> topProfile
                     _ -> elrlProfile]
             _ -> error "bad individual bit"
     ObjectCharacteristics anl ->
@@ -267,10 +267,10 @@ lFB ext mr lfb = case lfb of
         in case ext of
             ObjectEntity op -> andProfileList [ans, objProp op,
                     bottomProfile {
-                        el = char cl [Reflexive, Transitive],
-                        ql = char cl [Reflexive, Symmetric, Asymmetric],
-                        rl = char cl [Functional, InverseFunctional,
-                                Irreflexive, Symmetric, Asymmetric, Transitive]
+                        el = char cl [AS.Reflexive, AS.Transitive],
+                        ql = char cl [AS.Reflexive, AS.Symmetric, AS.Asymmetric],
+                        rl = char cl [AS.Functional, AS.InverseFunctional,
+                                AS.Irreflexive, AS.Symmetric, AS.Asymmetric, AS.Transitive]
                     }]
             _ -> error "object entity needed"
     DataPropRange anl ->
@@ -281,7 +281,7 @@ lFB ext mr lfb = case lfb of
         let ans = annotations $ concatMap fst anl
             facts = andList fact $ map snd anl
         in case ext of
-            SimpleEntity (Entity _ _ i) ->
+            SimpleEntity (AS.Entity _ _ i) ->
                 andProfileList [ans, facts, individual i]
             _ -> error "bad fact bit"
 
@@ -292,7 +292,7 @@ aFB ext anno afb =
         AnnotationFrameBit _ -> ans
         DataFunctional -> andProfileList [ans, elrlProfile]
         DatatypeBit dr -> case ext of
-            SimpleEntity (Entity _ _ dt) -> andProfileList
+            SimpleEntity (AS.Entity _ _ dt) -> andProfileList
                 [ans, dataType dt, dataRange dr]
             _ -> error "bad datatype bit"
         ClassDisjointUnion _ -> bottomProfile

--- a/OWL2/Propositional2OWL2.hs
+++ b/OWL2/Propositional2OWL2.hs
@@ -20,7 +20,7 @@ import Common.AS_Annotation
 import Common.Id
 import Common.Result
 
-import OWL2.AS
+import qualified OWL2.AS as AS
 import Common.IRI
 import OWL2.Keywords
 import OWL2.MS

--- a/OWL2/Propositional2OWL2.hs
+++ b/OWL2/Propositional2OWL2.hs
@@ -64,7 +64,7 @@ instance Comorphism Propositional2OWL2
     OWLSym.SymbMapItems
     OWLSign.Sign
     OWLMor.OWLMorphism
-    Entity
+    AS.Entity
     OWLSym.RawSymb
     ProofTree
     where
@@ -76,28 +76,28 @@ instance Comorphism Propositional2OWL2
         isInclusionComorphism Propositional2OWL2 = True
         has_model_expansion Propositional2OWL2 = True
 
-mkOWLDeclaration :: ClassExpression -> Axiom
-mkOWLDeclaration ex = PlainAxiom (ClassEntity $ Expression $ setPrefix "owl"
-    $ mkIRI thingS) $ ListFrameBit (Just SubClass) $ ExpressionBit [([], ex)]
+mkOWLDeclaration :: AS.ClassExpression -> Axiom
+mkOWLDeclaration ex = PlainAxiom (ClassEntity $ AS.Expression $ setPrefix "owl"
+    $ mkIRI thingS) $ ListFrameBit (Just AS.SubClass) $ ExpressionBit [([], ex)]
 
 tokToIRI :: Token -> IRI
 tokToIRI = idToIRI . simpleIdToId
 
-mapFormula :: FORMULA -> ClassExpression
+mapFormula :: FORMULA -> AS.ClassExpression
 mapFormula f = case f of
-    False_atom _ -> Expression $ mkIRI nothingS
-    True_atom _ -> Expression $ mkIRI thingS
-    Predication p -> Expression $ tokToIRI p
-    Negation nf _ -> ObjectComplementOf $ mapFormula nf
-    Conjunction fl _ -> ObjectJunction IntersectionOf $ map mapFormula fl
-    Disjunction fl _ -> ObjectJunction UnionOf $ map mapFormula fl
-    Implication a b _ -> ObjectJunction UnionOf [ObjectComplementOf
+    False_atom _ -> AS.Expression $ mkIRI nothingS
+    True_atom _ -> AS.Expression $ mkIRI thingS
+    Predication p -> AS.Expression $ tokToIRI p
+    Negation nf _ -> AS.ObjectComplementOf $ mapFormula nf
+    Conjunction fl _ -> AS.ObjectJunction AS.IntersectionOf $ map mapFormula fl
+    Disjunction fl _ -> AS.ObjectJunction AS.UnionOf $ map mapFormula fl
+    Implication a b _ -> AS.ObjectJunction AS.UnionOf [AS.ObjectComplementOf
                 $ mapFormula a, mapFormula b]
-    Equivalence a b _ -> ObjectJunction IntersectionOf $ map mapFormula
+    Equivalence a b _ -> AS.ObjectJunction AS.IntersectionOf $ map mapFormula
                 [Implication a b nullRange, Implication b a nullRange]
 
 mapPredDecl :: PRED_ITEM -> [Axiom]
-mapPredDecl (Pred_item il _) = map (mkOWLDeclaration . Expression
+mapPredDecl (Pred_item il _) = map (mkOWLDeclaration . AS.Expression
     . tokToIRI) il
 
 mapAxiomItems :: Annoted FORMULA -> Axiom

--- a/OWL2/Rename.hs
+++ b/OWL2/Rename.hs
@@ -15,7 +15,7 @@ no prefix clashes
 
 module OWL2.Rename where
 
-import OWL2.AS
+import qualified OWL2.AS as AS
 import Common.IRI
 import Common.Id (stringToId)
 import OWL2.MS
@@ -30,7 +30,7 @@ import qualified Data.Set as Set
 import Common.Result
 
 testAndInteg :: (String, String)
-     -> (PrefixMap, StringMap) -> (PrefixMap, StringMap)
+     -> (AS.PrefixMap, StringMap) -> (AS.PrefixMap, StringMap)
 testAndInteg (pre, oiri) (old, tm) = case Map.lookup pre old of
   Just anIri ->
    if oiri == anIri then (old, tm)
@@ -38,7 +38,7 @@ testAndInteg (pre, oiri) (old, tm) = case Map.lookup pre old of
          in (Map.insert pre' oiri old, Map.insert pre pre' tm)
   Nothing -> (Map.insert pre oiri old, tm)
 
-disambiguateName :: String -> PrefixMap -> String
+disambiguateName :: String -> AS.PrefixMap -> String
 disambiguateName n nameMap =
   let nm = if null n then "n" else n  -- change other empty prefixes to "n..."
       newname = reverse . dropWhile isDigit $ reverse nm
@@ -71,12 +71,12 @@ intersectSign s1 s2 = do
             }
     else fail "Static analysis could not intersect signatures"
 
-integPref :: PrefixMap -> PrefixMap
-                    -> (PrefixMap, StringMap)
+integPref :: AS.PrefixMap -> AS.PrefixMap
+                    -> (AS.PrefixMap, StringMap)
 integPref oldMap testMap =
    foldr testAndInteg (oldMap, Map.empty) (Map.toList testMap)
 
-newOid :: OntologyIRI -> OntologyIRI -> OntologyIRI
+newOid :: AS.OntologyIRI -> AS.OntologyIRI -> AS.OntologyIRI
 newOid id1 id2 =
   let lid1 = iriPath id1
       lid2 = iriPath id2

--- a/OWL2/Sign.hs
+++ b/OWL2/Sign.hs
@@ -37,7 +37,7 @@ data Sign = Sign
               -- data properties
             , annotationRoles :: Set.Set AnnotationProperty
               -- annotation properties
-            , individuals :: Set.Set Individual  -- named individuals
+            , individuals :: Set.Set NamedIndividual  -- named individuals
             , labelMap :: Map.Map IRI String -- labels (for better readability)
             , prefixMap :: PrefixMap
             } deriving (Show, Typeable, Data)

--- a/OWL2/Sign.hs
+++ b/OWL2/Sign.hs
@@ -15,7 +15,7 @@ module OWL2.Sign where
 
 
 import Common.IRI
-import OWL2.AS
+import qualified OWL2.AS as AS
 
 import qualified Data.Set as Set
 import qualified Data.Map as Map
@@ -28,18 +28,18 @@ import Control.Monad
 import Data.Data
 
 data Sign = Sign
-            { concepts :: Set.Set Class
+            { concepts :: Set.Set AS.Class
               -- classes
-            , datatypes :: Set.Set Datatype -- datatypes
-            , objectProperties :: Set.Set ObjectProperty
+            , datatypes :: Set.Set AS.Datatype -- datatypes
+            , objectProperties :: Set.Set AS.ObjectProperty
               -- object properties
-            , dataProperties :: Set.Set DataProperty
+            , dataProperties :: Set.Set AS.DataProperty
               -- data properties
-            , annotationRoles :: Set.Set AnnotationProperty
+            , annotationRoles :: Set.Set AS.AnnotationProperty
               -- annotation properties
-            , individuals :: Set.Set NamedIndividual  -- named individuals
+            , individuals :: Set.Set AS.NamedIndividual  -- named individuals
             , labelMap :: Map.Map IRI String -- labels (for better readability)
-            , prefixMap :: PrefixMap
+            , prefixMap :: AS.PrefixMap
             } deriving (Show, Typeable, Data)
 
 instance Ord Sign where
@@ -50,10 +50,10 @@ instance Eq Sign where
   s1 == s2 = compare s1 s2 == EQ
 
 data SignAxiom =
-    Subconcept ClassExpression ClassExpression   -- subclass, superclass
-  | Role (DomainOrRangeOrFunc (RoleKind, RoleType)) ObjectPropertyExpression
-  | Data (DomainOrRangeOrFunc ()) DataPropertyExpression
-  | Conceptmembership Individual ClassExpression
+    Subconcept AS.ClassExpression AS.ClassExpression   -- subclass, superclass
+  | Role (DomainOrRangeOrFunc (RoleKind, RoleType)) AS.ObjectPropertyExpression
+  | Data (DomainOrRangeOrFunc ()) AS.DataPropertyExpression
+  | Conceptmembership AS.Individual AS.ClassExpression
     deriving (Show, Eq, Ord, Typeable, Data)
 
 data RoleKind = FuncRole | RefRole deriving (Show, Eq, Ord, Typeable, Data)
@@ -64,8 +64,8 @@ data DesKind = RDomain | DDomain | RIRange
   deriving (Show, Eq, Ord, Typeable, Data)
 
 data DomainOrRangeOrFunc a =
-    DomainOrRange DesKind ClassExpression
-  | RDRange DataRange
+    DomainOrRange DesKind AS.ClassExpression
+  | RDRange AS.DataRange
   | FuncProp a
     deriving (Show, Eq, Ord, Typeable, Data)
 
@@ -92,14 +92,14 @@ diffSig a b =
       , individuals = individuals a `Set.difference` individuals b
       }
 
-addSymbToSign :: Sign -> Entity -> Result Sign
+addSymbToSign :: Sign -> AS.Entity -> Result Sign
 addSymbToSign sig ent =
  case ent of
-   Entity _ Class eIri ->
+   AS.Entity _ AS.Class eIri ->
     return sig {concepts = Set.insert eIri $ concepts sig}
-   Entity _ ObjectProperty eIri ->
+   AS.Entity _ AS.ObjectProperty eIri ->
     return sig {objectProperties = Set.insert eIri $ objectProperties sig}
-   Entity _ NamedIndividual eIri ->
+   AS.Entity _ AS.NamedIndividual eIri ->
     return sig {individuals = Set.insert eIri $ individuals sig}
    _ -> return sig
 
@@ -129,29 +129,29 @@ isSubSign a b =
        && Set.isSubsetOf (annotationRoles a) (annotationRoles b)
        && Set.isSubsetOf (individuals a) (individuals b)
 
-symOf :: Sign -> Set.Set Entity
+symOf :: Sign -> Set.Set AS.Entity
 symOf s = Set.unions
-  [ Set.map (\ ir -> Entity (Map.lookup ir $ labelMap s) Class ir) $ concepts s
-  , Set.map (mkEntity Datatype) $ datatypes s
-  , Set.map (mkEntity ObjectProperty) $ objectProperties s
-  , Set.map (mkEntity DataProperty) $ dataProperties s
-  , Set.map (mkEntity NamedIndividual) $ individuals s
-  , Set.map (mkEntity AnnotationProperty) $ annotationRoles s ]
+  [ Set.map (\ ir -> AS.Entity (Map.lookup ir $ labelMap s) AS.Class ir) $ concepts s
+  , Set.map (AS.mkEntity AS.Datatype) $ datatypes s
+  , Set.map (AS.mkEntity AS.ObjectProperty) $ objectProperties s
+  , Set.map (AS.mkEntity AS.DataProperty) $ dataProperties s
+  , Set.map (AS.mkEntity AS.NamedIndividual) $ individuals s
+  , Set.map (AS.mkEntity AS.AnnotationProperty) $ annotationRoles s ]
 
 -- | takes an entity and modifies the sign according to the given function
-modEntity :: (IRI -> Set.Set IRI -> Set.Set IRI) -> Entity -> State Sign ()
-modEntity f (Entity _ ty u) = do
+modEntity :: (IRI -> Set.Set IRI -> Set.Set IRI) -> AS.Entity -> State Sign ()
+modEntity f (AS.Entity _ ty u) = do
   s <- get
   let chg = f u
-  unless (isDatatypeKey u || isThing u) $ put $ case ty of
-    Datatype -> s { datatypes = chg $ datatypes s }
-    Class -> s { concepts = chg $ concepts s }
-    ObjectProperty -> s { objectProperties = chg $ objectProperties s }
-    DataProperty -> s { dataProperties = chg $ dataProperties s }
-    NamedIndividual -> if isAnonymous u then s
+  unless (AS.isDatatypeKey u || AS.isThing u) $ put $ case ty of
+    AS.Datatype -> s { datatypes = chg $ datatypes s }
+    AS.Class -> s { concepts = chg $ concepts s }
+    AS.ObjectProperty -> s { objectProperties = chg $ objectProperties s }
+    AS.DataProperty -> s { dataProperties = chg $ dataProperties s }
+    AS.NamedIndividual -> if AS.isAnonymous u then s
          else s { individuals = chg $ individuals s }
-    AnnotationProperty -> s {annotationRoles = chg $ annotationRoles s}
+    AS.AnnotationProperty -> s {annotationRoles = chg $ annotationRoles s}
 
 -- | adding entities to the signature
-addEntity :: Entity -> State Sign ()
+addEntity :: AS.Entity -> State Sign ()
 addEntity = modEntity Set.insert

--- a/OWL2/StaticAnalysis.hs
+++ b/OWL2/StaticAnalysis.hs
@@ -14,7 +14,7 @@ module OWL2.StaticAnalysis where
 
 import OWL2.Sign
 import OWL2.Morphism
-import OWL2.AS
+import qualified OWL2.AS as AS
 import OWL2.MS
 import OWL2.Print ()
 import OWL2.Theorem

--- a/OWL2/StaticAnalysis.hs
+++ b/OWL2/StaticAnalysis.hs
@@ -39,144 +39,144 @@ import Control.Monad
 import Logic.Logic
 
 -- | Error messages for static analysis
-failMsg :: Entity -> ClassExpression -> Result a
-failMsg (Entity _ ty e) desc =
+failMsg :: AS.Entity -> AS.ClassExpression -> Result a
+failMsg (AS.Entity _ ty e) desc =
   fatal_error
-    ("undeclared `" ++ showEntityType ty
+    ("undeclared `" ++ AS.showEntityType ty
           ++ " " ++ showIRI e ++ "` in the following ClassExpression:\n"
           ++ showDoc desc "") $ iriPos e
 
 -- | checks if an entity is in the signature
-checkEntity :: Sign -> Entity -> Result ()
-checkEntity s t@(Entity _ ty e) =
-  let errMsg = mkError ("unknown " ++ showEntityType ty) e
+checkEntity :: Sign -> AS.Entity -> Result ()
+checkEntity s t@(AS.Entity _ ty e) =
+  let errMsg = mkError ("unknown " ++ AS.showEntityType ty) e
   in case ty of
-   Datatype -> unless (Set.member e (datatypes s) || isDatatypeKey e) errMsg
-   Class -> unless (Set.member e (concepts s) || isThing e) errMsg
-   ObjectProperty -> unless (isDeclObjProp s $ ObjectProp e) errMsg
-   DataProperty -> unless (isDeclDataProp s e) errMsg
-   AnnotationProperty -> unless (Set.member e (annotationRoles s)
-        || isPredefAnnoProp e) $ justWarn () $ showDoc t " unknown"
+   AS.Datatype -> unless (Set.member e (datatypes s) || AS.isDatatypeKey e) errMsg
+   AS.Class -> unless (Set.member e (concepts s) || AS.isThing e) errMsg
+   AS.ObjectProperty -> unless (isDeclObjProp s $ AS.ObjectProp e) errMsg
+   AS.DataProperty -> unless (isDeclDataProp s e) errMsg
+   AS.AnnotationProperty -> unless (Set.member e (annotationRoles s)
+        || AS.isPredefAnnoProp e) $ justWarn () $ showDoc t " unknown"
    _ -> return ()
 
 -- | takes an iri and finds out what entities it belongs to
-correctEntity :: Sign -> IRI -> [Entity]
+correctEntity :: Sign -> IRI -> [AS.Entity]
 correctEntity s iri =
-    [mkEntity AnnotationProperty iri | Set.member iri (annotationRoles s)] ++
-    [mkEntity Class iri | Set.member iri (concepts s)] ++
-    [mkEntity ObjectProperty iri | Set.member iri (objectProperties s)] ++
-    [mkEntity DataProperty iri | Set.member iri (dataProperties s)] ++
-    [mkEntity Datatype iri | Set.member iri (datatypes s)] ++
-    [mkEntity NamedIndividual iri | Set.member iri (individuals s)]
+    [AS.mkEntity AS.AnnotationProperty iri | Set.member iri (annotationRoles s)] ++
+    [AS.mkEntity AS.Class iri | Set.member iri (concepts s)] ++
+    [AS.mkEntity AS.ObjectProperty iri | Set.member iri (objectProperties s)] ++
+    [AS.mkEntity AS.DataProperty iri | Set.member iri (dataProperties s)] ++
+    [AS.mkEntity AS.Datatype iri | Set.member iri (datatypes s)] ++
+    [AS.mkEntity AS.NamedIndividual iri | Set.member iri (individuals s)]
 
-checkLiteral :: Sign -> Literal -> Result ()
+checkLiteral :: Sign -> AS.Literal -> Result ()
 checkLiteral s l = case l of
-    Literal _ (Typed dt) -> checkEntity s $ mkEntity Datatype dt
+    AS.Literal _ (AS.Typed dt) -> checkEntity s $ AS.mkEntity AS.Datatype dt
     _ -> return ()
 
-isDeclInd :: Sign -> Individual -> Bool
+isDeclInd :: Sign -> AS.Individual -> Bool
 isDeclInd s ind = Set.member ind $ individuals s
 
-isDeclObjProp :: Sign -> ObjectPropertyExpression -> Bool
-isDeclObjProp s ope = let op = objPropToIRI ope in
-    Set.member op (objectProperties s) || isPredefObjProp op
+isDeclObjProp :: Sign -> AS.ObjectPropertyExpression -> Bool
+isDeclObjProp s ope = let op = AS.objPropToIRI ope in
+    Set.member op (objectProperties s) || AS.isPredefObjProp op
 
-isDeclDataProp :: Sign -> DataPropertyExpression -> Bool
-isDeclDataProp s dp = Set.member dp (dataProperties s) || isPredefDataProp dp
+isDeclDataProp :: Sign -> AS.DataPropertyExpression -> Bool
+isDeclDataProp s dp = Set.member dp (dataProperties s) || AS.isPredefDataProp dp
 
 {- | takes a list of object properties and discards the ones
     which are not in the signature -}
-filterObjProp :: Sign -> [ObjectPropertyExpression]
-    -> [ObjectPropertyExpression]
+filterObjProp :: Sign -> [AS.ObjectPropertyExpression]
+    -> [AS.ObjectPropertyExpression]
 filterObjProp = filter . isDeclObjProp
 
-checkObjPropList :: Sign -> [ObjectPropertyExpression] -> Result ()
+checkObjPropList :: Sign -> [AS.ObjectPropertyExpression] -> Result ()
 checkObjPropList s ol = do
     let ls = map (isDeclObjProp s) ol
     unless (and ls) $ fail $ "undeclared object properties:\n" ++
                       showDoc (map (\o -> case o of
-                                     ObjectProp _ -> o
-                                     ObjectInverseOf x -> x) ol) ""
+                                     AS.ObjectProp _ -> o
+                                     AS.ObjectInverseOf x -> x) ol) ""
 
-checkDataPropList :: Sign -> [DataPropertyExpression] -> Result ()
+checkDataPropList :: Sign -> [AS.DataPropertyExpression] -> Result ()
 checkDataPropList s dl = do
     let ls = map (isDeclDataProp s) dl
     unless (and ls) $ fail $ "undeclared data properties:\n" ++ showDoc dl ""
 
 -- | checks if a DataRange is valid
-checkDataRange :: Sign -> DataRange -> Result ()
+checkDataRange :: Sign -> AS.DataRange -> Result ()
 checkDataRange s dr = case dr of
-    DataType dt rl -> do
-        checkEntity s $ mkEntity Datatype dt
+    AS.DataType dt rl -> do
+        checkEntity s $ AS.mkEntity AS.Datatype dt
         mapM_ (checkLiteral s . snd) rl
-    DataJunction _ drl -> mapM_ (checkDataRange s) drl
-    DataComplementOf r -> checkDataRange s r
-    DataOneOf ll -> mapM_ (checkLiteral s) ll
+    AS.DataJunction _ drl -> mapM_ (checkDataRange s) drl
+    AS.DataComplementOf r -> checkDataRange s r
+    AS.DataOneOf ll -> mapM_ (checkLiteral s) ll
 
 {- | converts ClassExpression to DataRanges because some
      DataProperties may be parsed as ObjectProperties -}
-classExpressionToDataRange :: Sign -> ClassExpression -> Result DataRange
+classExpressionToDataRange :: Sign -> AS.ClassExpression -> Result AS.DataRange
 classExpressionToDataRange s ce = case ce of
-    Expression u -> checkEntity s (mkEntity Datatype u)
-        >> return (DataType u [])
-    ObjectJunction jt cel -> fmap (DataJunction jt)
+    AS.Expression u -> checkEntity s (AS.mkEntity AS.Datatype u)
+        >> return (AS.DataType u [])
+    AS.ObjectJunction jt cel -> fmap (AS.DataJunction jt)
         $ mapM (classExpressionToDataRange s) cel
-    ObjectComplementOf c -> fmap DataComplementOf
+    AS.ObjectComplementOf c -> fmap AS.DataComplementOf
         $ classExpressionToDataRange s c
     _ -> fail $ "cannot convert ClassExpression to DataRange\n"
             ++ showDoc ce ""
 
 {- | checks a ClassExpression and recursively converts the
      (maybe inappropriately) parsed syntax to a one satisfying the signature -}
-checkClassExpression :: Sign -> ClassExpression -> Result ClassExpression
+checkClassExpression :: Sign -> AS.ClassExpression -> Result AS.ClassExpression
 checkClassExpression s desc =
     let errMsg i = failMsg i desc
-        objErr i = errMsg $ mkEntity ObjectProperty i
-        datErr i = errMsg $ mkEntity DataProperty i
+        objErr i = errMsg $ AS.mkEntity AS.ObjectProperty i
+        datErr i = errMsg $ AS.mkEntity AS.DataProperty i
     in case desc of
-    Expression u -> if isThing u
-        then return $ Expression $ setReservedPrefix u
-        else checkEntity s (mkEntity Class u) >> return desc
-    ObjectJunction ty ds -> fmap (ObjectJunction ty)
+    AS.Expression u -> if AS.isThing u
+        then return $ AS.Expression $ AS.setReservedPrefix u
+        else checkEntity s (AS.mkEntity AS.Class u) >> return desc
+    AS.ObjectJunction ty ds -> fmap (AS.ObjectJunction ty)
         $ mapM (checkClassExpression s) ds
-    ObjectComplementOf d -> fmap ObjectComplementOf $ checkClassExpression s d
-    ObjectOneOf _ -> return desc
-    ObjectValuesFrom q opExpr d -> if isDeclObjProp s opExpr
-        then fmap (ObjectValuesFrom q opExpr) $ checkClassExpression s d
-        else let iri = objPropToIRI opExpr
+    AS.ObjectComplementOf d -> fmap AS.ObjectComplementOf $ checkClassExpression s d
+    AS.ObjectOneOf _ -> return desc
+    AS.ObjectValuesFrom q opExpr d -> if isDeclObjProp s opExpr
+        then fmap (AS.ObjectValuesFrom q opExpr) $ checkClassExpression s d
+        else let iri = AS.objPropToIRI opExpr
              in if isDeclDataProp s iri then
-                    fmap (DataValuesFrom q iri)
+                    fmap (AS.DataValuesFrom q [iri])
                       $ classExpressionToDataRange s d
                 else objErr iri
-    ObjectHasSelf opExpr -> if isDeclObjProp s opExpr then return desc
-        else objErr $ objPropToIRI opExpr
-    ObjectHasValue opExpr _ -> if isDeclObjProp s opExpr then return desc
-        else objErr $ objPropToIRI opExpr
-    ObjectCardinality (Cardinality a b opExpr md) -> do
-        let iri = objPropToIRI opExpr
+    AS.ObjectHasSelf opExpr -> if isDeclObjProp s opExpr then return desc
+        else objErr $ AS.objPropToIRI opExpr
+    AS.ObjectHasValue opExpr _ -> if isDeclObjProp s opExpr then return desc
+        else objErr $ AS.objPropToIRI opExpr
+    AS.ObjectCardinality (AS.Cardinality a b opExpr md) -> do
+        let iri = AS.objPropToIRI opExpr
             mbrOP = Set.member iri $ objectProperties s
         case md of
             Nothing
                 | mbrOP -> return desc
                 | isDeclDataProp s iri ->
-                        return $ DataCardinality $ Cardinality a b iri Nothing
+                        return $ AS.DataCardinality $ AS.Cardinality a b iri Nothing
                 | otherwise -> objErr iri
             Just d ->
-                if mbrOP then fmap (ObjectCardinality . Cardinality a b opExpr
+                if mbrOP then fmap (AS.ObjectCardinality . AS.Cardinality a b opExpr
                             . Just) $ checkClassExpression s d
                 else do
                     dr <- classExpressionToDataRange s d
                     if isDeclDataProp s iri then
-                        return $ DataCardinality
-                          $ Cardinality a b iri $ Just dr
+                        return $ AS.DataCardinality
+                          $ AS.Cardinality a b iri $ Just dr
                         else datErr iri
-    DataValuesFrom _ dExp r -> checkDataRange s r
-        >> if isDeclDataProp s dExp then return desc else datErr dExp
-    DataHasValue dExp l -> do
+    AS.DataValuesFrom _ dExp r -> checkDataRange s r
+        >> if isDeclDataProp s (head dExp) then return desc else datErr (head dExp)
+    AS.DataHasValue dExp l -> do
         checkLiteral s l
         if isDeclDataProp s dExp then return desc
             else datErr dExp
-    DataCardinality (Cardinality _ _ dExp mr) -> if isDeclDataProp s dExp
+    AS.DataCardinality (AS.Cardinality _ _ dExp mr) -> if isDeclDataProp s dExp
         then case mr of
             Nothing -> return desc
             Just d -> checkDataRange s d >> return desc
@@ -199,22 +199,22 @@ checkFactList :: Sign -> [Fact] -> Result ()
 checkFactList = mapM_ . checkFact
 
 -- | sorts the data and object properties
-checkHasKey :: Sign -> [ObjectPropertyExpression] -> [DataPropertyExpression]
+checkHasKey :: Sign -> [AS.ObjectPropertyExpression] -> [AS.DataPropertyExpression]
     -> Result AnnFrameBit
 checkHasKey s ol dl = do
     let nol = filterObjProp s ol
-        ndl = map objPropToIRI (ol \\ nol) ++ dl
+        ndl = map AS.objPropToIRI (ol \\ nol) ++ dl
         key = ClassHasKey nol ndl
         decl = map (isDeclDataProp s) ndl
     if and decl then return key
         else fail $ "Keys failed " ++ showDoc ol "" ++ showDoc dl "\n"
 
-checkAnnotation :: Sign -> Annotation -> Result ()
-checkAnnotation s (Annotation ans apr av) = do
+checkAnnotation :: Sign -> AS.Annotation -> Result ()
+checkAnnotation s (AS.Annotation ans apr av) = do
     checkAnnos s [ans]
-    checkEntity s (mkEntity AnnotationProperty apr)
+    checkEntity s (AS.mkEntity AS.AnnotationProperty apr)
     case av of
-        AnnValLit lit -> checkLiteral s lit
+        AS.AnnValLit lit -> checkLiteral s lit
         _ -> return ()
 
 checkAnnos :: Sign -> [Annotations] -> Result ()
@@ -225,12 +225,12 @@ checkAnnoList s f anl = do
     checkAnnos s $ map fst anl
     f $ map snd anl
 
-checkListBit :: Sign -> Maybe Relation -> ListFrameBit -> Result ListFrameBit
+checkListBit :: Sign -> Maybe AS.Relation -> ListFrameBit -> Result ListFrameBit
 checkListBit s r fb = case fb of
     AnnotationBit anl -> case r of
-        Just (DRRelation _) -> checkAnnos s (map fst anl) >> return fb
+        Just (AS.DRRelation _) -> checkAnnos s (map fst anl) >> return fb
         _ -> checkAnnoList s (mapM_ $ checkEntity s .
-                    mkEntity AnnotationProperty) anl >> return fb
+                    AS.mkEntity AS.AnnotationProperty) anl >> return fb
     ExpressionBit anl -> do
         let annos = map fst anl
         checkAnnos s annos
@@ -247,7 +247,7 @@ checkListBit s r fb = case fb of
          else if length sorted == length ol then return fb
                     else fail $ "Static analysis found that there are" ++
                         " multiple types of properties in\n\n" ++
-                        show sorted ++ show (map objPropToIRI $ ol \\ sorted)
+                        show sorted ++ show (map AS.objPropToIRI $ ol \\ sorted)
     ObjectCharacteristics anl -> checkAnnos s (map fst anl) >> return fb
     DataBit anl -> checkAnnoList s (checkDataPropList s) anl >> return fb
     DataPropRange anl -> checkAnnoList s (mapM_ $ checkDataRange s) anl
@@ -269,7 +269,7 @@ checkAssertion s iri ans = do
     let entList = correctEntity s iri
         ab = AnnFrameBit ans $ AnnotationFrameBit Assertion
     if null entList
-        then let misc = Misc [Annotation [] iri $ AnnValue iri]
+        then let misc = Misc [AS.Annotation [] iri $ AS.AnnValue iri]
              in return [PlainAxiom misc ab] -- only for anonymous individuals
         else return $ map (\ x -> PlainAxiom (SimpleEntity x) ab) entList
 
@@ -277,7 +277,7 @@ checkExtended :: Sign -> Extended -> Result Extended
 checkExtended s e = case e of
     ClassEntity ce -> fmap ClassEntity $ checkClassExpression s ce
     ObjectEntity oe -> case oe of
-        ObjectInverseOf op -> let i = objPropToIRI op in
+        AS.ObjectInverseOf op -> let i = AS.objPropToIRI op in
             if Set.member i (objectProperties s)
             then return e else mkError "unknown object property" i
         _ -> return e
@@ -297,11 +297,11 @@ checkAxiom s ax@(PlainAxiom ext fb) = case fb of
         AnnotationFrameBit ty -> case ty of
             Assertion -> case ext of
                     -- this can only come from XML
-                Misc [Annotation _ iri _] -> checkAssertion s iri ans
+                Misc [AS.Annotation _ iri _] -> checkAssertion s iri ans
                     -- these can only come from Manchester Syntax
-                SimpleEntity (Entity _ _ iri) -> checkAssertion s iri ans
-                ClassEntity (Expression iri) -> checkAssertion s iri ans
-                ObjectEntity (ObjectProp iri) -> checkAssertion s iri ans
+                SimpleEntity (AS.Entity _ _ iri) -> checkAssertion s iri ans
+                ClassEntity (AS.Expression iri) -> checkAssertion s iri ans
+                ObjectEntity (AS.ObjectProp iri) -> checkAssertion s iri ans
                 _ -> do
                   next <- checkExtended s ext
                   -- could rarely happen, and only in our extended syntax
@@ -326,9 +326,9 @@ correctFrames s = fmap concat . mapM (checkFrame s)
 collectEntities :: Frame -> State Sign ()
 collectEntities f = case f of
     Frame (SimpleEntity e) _ ->  addEntity e
-    Frame (ClassEntity (Expression e)) _ -> addEntity $ mkEntity Class e
-    Frame (ObjectEntity (ObjectProp e)) _ ->
-        addEntity $ mkEntity ObjectProperty e
+    Frame (ClassEntity (AS.Expression e)) _ -> addEntity $ AS.mkEntity AS.Class e
+    Frame (ObjectEntity (AS.ObjectProp e)) _ ->
+        addEntity $ AS.mkEntity AS.ObjectProperty e
     _ -> return ()
 
 -- | collects all entites from the frames
@@ -359,11 +359,11 @@ check1Prefix ms s =
                       s' = dropBracketSuf $ dropCharPre '<' s
                   in iri' == s'
 
-checkPrefixMap :: PrefixMap -> Bool
+checkPrefixMap :: AS.PrefixMap -> Bool
 checkPrefixMap pm =
     let pl = map (`Map.lookup` pm) ["owl", "rdf", "rdfs", "xsd"]
     in and $ zipWith check1Prefix pl
-            (map snd $ tail $ Map.toList predefPrefixes)
+            (map snd $ tail $ Map.toList AS.predefPrefixes)
 
 newODoc :: OntologyDocument -> [Frame] -> Result OntologyDocument
 newODoc OntologyDocument {ontology = mo, prefixDeclaration = pd} fl =
@@ -374,7 +374,7 @@ newODoc OntologyDocument {ontology = mo, prefixDeclaration = pd} fl =
 
 -- | static analysis of ontology with incoming sign.
 basicOWL2Analysis :: (OntologyDocument, Sign, GlobalAnnos)
-    -> Result (OntologyDocument, ExtSign Sign Entity, [Named Axiom])
+    -> Result (OntologyDocument, ExtSign Sign AS.Entity, [Named Axiom])
 basicOWL2Analysis (inOnt, inSign, ga) = do
     let pm = Map.union (prefixDeclaration inOnt)
           . Map.map (iriToStringUnsecure . setAngles False)
@@ -391,8 +391,8 @@ basicOWL2Analysis (inOnt, inSign, ga) = do
 -- | extract labels from Frame-List (after processing with correctFrames)
 generateLabelMap :: Sign -> [Frame] -> Map.Map IRI String
 generateLabelMap sig = foldr (\ (Frame ext fbl) -> case ext of
-        SimpleEntity (Entity _ _ ir) -> case fbl of
-            [AnnFrameBit [Annotation _ apr (AnnValLit (Literal s' _))] _]
+        SimpleEntity (AS.Entity _ _ ir) -> case fbl of
+            [AnnFrameBit [AS.Annotation _ apr (AS.AnnValLit (AS.Literal s' _))] _]
                 | prefixName apr == "rdfs" && show (iriPath apr) == "label"
                   -> Map.insert ir s'
             _ -> id
@@ -412,9 +412,9 @@ findImplied ax sent =
          , wasTheorem = False }
    else sent { isAxiom = True }
 
-getNames1 :: Annotation -> [String]
+getNames1 :: AS.Annotation -> [String]
 getNames1 anno = case anno of
-      Annotation _ aIRI (AnnValLit (Literal value _)) ->
+      AS.Annotation _ aIRI (AS.AnnValLit (AS.Literal value _)) ->
           if show (iriPath aIRI) == "label"
              then [value]
              else []
@@ -450,7 +450,7 @@ getNames (PlainAxiom eith fb) = case eith of
 
 addEquiv :: Sign -> Sign -> [SymbItems] -> [SymbItems] ->
             Result (Sign, Sign, Sign,
-                     EndoMap Entity, EndoMap Entity)
+                     EndoMap AS.Entity, EndoMap AS.Entity)
 addEquiv ssig tsig l1 l2 = do
   let l1' = statSymbItems ssig l1
       l2' = statSymbItems tsig l2
@@ -461,8 +461,8 @@ addEquiv ssig tsig l1 l2 = do
       case
        (match1, match2) of
           ([e1], [e2]) ->
-           if entityKind e1 == entityKind e2 then do
-              s <- pairSymbols e1 e2
+           if AS.entityKind e1 == AS.entityKind e2 then do
+              s <- AS.pairSymbols e1 e2
               sig <- addSymbToSign emptySign s
               sig1 <- addSymbToSign emptySign e1
               sig2 <- addSymbToSign emptySign e2
@@ -476,9 +476,9 @@ addEquiv ssig tsig l1 l2 = do
     _ -> fail "terms not yet supported in alignments"
 
 corr2theo :: String -> Bool -> Sign -> Sign -> [SymbItems] -> [SymbItems] ->
-             EndoMap Entity -> EndoMap Entity -> REL_REF ->
+             EndoMap AS.Entity -> EndoMap AS.Entity -> REL_REF ->
              Result (Sign, [Named Axiom], Sign, Sign,
-                     EndoMap Entity, EndoMap Entity)
+                     EndoMap AS.Entity, EndoMap AS.Entity)
 corr2theo _aname flag ssig tsig l1 l2 eMap1 eMap2 rref = do
   let l1' = statSymbItems ssig l1
       l2' = statSymbItems tsig l2
@@ -489,8 +489,8 @@ corr2theo _aname flag ssig tsig l1 l2 eMap1 eMap2 rref = do
       case
        (match1, match2) of
           ([e1], [e2]) -> do
-           let e1' = if flag then e1 {cutIRI =  addString (cutIRI e1, "_source")} else e1
-               e2' = if flag then e2 {cutIRI =  addString (cutIRI e2, "_target")} else e2
+           let e1' = if flag then e1 {AS.cutIRI =  addString (AS.cutIRI e1, "_source")} else e1
+               e2' = if flag then e2 {AS.cutIRI =  addString (AS.cutIRI e2, "_target")} else e2
                sig = emptySign
                eMap1' = Map.union eMap1 $ Map.fromAscList [(e1', e1)]
                eMap2' = Map.union eMap2 $ Map.fromAscList [(e2', e2)]
@@ -502,53 +502,53 @@ corr2theo _aname flag ssig tsig l1 l2 eMap1 eMap2 rref = do
              let extPart = mkExtendedEntity e2'
                  axiom = PlainAxiom extPart $
                            ListFrameBit (Just $
-                              case (entityKind e1', entityKind e2') of
-                                (Class, Class) -> EDRelation Equivalent
-                                (ObjectProperty, ObjectProperty) ->
-                                   EDRelation Equivalent
-                                (NamedIndividual, NamedIndividual) -> SDRelation Same
+                              case (AS.entityKind e1', AS.entityKind e2') of
+                                (AS.Class, AS.Class) -> AS.EDRelation AS.Equivalent
+                                (AS.ObjectProperty, AS.ObjectProperty) ->
+                                   AS.EDRelation AS.Equivalent
+                                (AS.NamedIndividual, AS.NamedIndividual) -> AS.SDRelation AS.Same
                                 _ -> error $ "use subsumption only between"
                                               ++ "classes or roles:" ++
                                               show l1 ++ " " ++ show l2) $
-                           ExpressionBit [([], Expression $ cutIRI e1')]
+                           ExpressionBit [([], AS.Expression $ AS.cutIRI e1')]
              return (sigB, [makeNamed "" axiom], sig1, sig2, eMap1', eMap2')
             Subs -> do
              let extPart = mkExtendedEntity e2'
                  axiom = PlainAxiom extPart $
                            ListFrameBit (Just $
-                              case (entityKind e1', entityKind e2') of
-                                (Class, Class) -> SubClass
-                                (ObjectProperty, ObjectProperty) ->
-                                    SubPropertyOf
+                              case (AS.entityKind e1', AS.entityKind e2') of
+                                (AS.Class, AS.Class) -> AS.SubClass
+                                (AS.ObjectProperty, AS.ObjectProperty) ->
+                                    AS.SubPropertyOf
                                 _ -> error $ "use subsumption only between"
                                               ++ "classes or roles:" ++
                                               show l1 ++ " " ++ show l2) $
-                           ExpressionBit [([], Expression $ cutIRI e1')]
+                           ExpressionBit [([], AS.Expression $ AS.cutIRI e1')]
              return (sigB, [makeNamed "" axiom], sig1, sig2, eMap1', eMap2')
             Incomp -> do
              let extPart = mkExtendedEntity e1'
                  axiom = PlainAxiom extPart $
-                           ListFrameBit (Just $ EDRelation Disjoint) $
-                           ExpressionBit [([], Expression $ cutIRI e2')]
+                           ListFrameBit (Just $ AS.EDRelation AS.Disjoint) $
+                           ExpressionBit [([], AS.Expression $ AS.cutIRI e2')]
              return (sigB, [makeNamed "" axiom], sig1, sig2, eMap1', eMap2')
             IsSubs -> do
              let extPart = mkExtendedEntity e1'
                  axiom = PlainAxiom extPart $
-                           ListFrameBit (Just SubClass) $
-                           ExpressionBit [([], Expression $ cutIRI e2')]
+                           ListFrameBit (Just AS.SubClass) $
+                           ExpressionBit [([], AS.Expression $ AS.cutIRI e2')]
              return (sigB, [makeNamed "" axiom], sig1, sig2, eMap1', eMap2')
             InstOf -> do
              let extPart = mkExtendedEntity e1'
                  axiom = PlainAxiom extPart $
-                           ListFrameBit (Just Types) $
-                           ExpressionBit [([], Expression $ cutIRI e2')]
+                           ListFrameBit (Just AS.Types) $
+                           ExpressionBit [([], AS.Expression $ AS.cutIRI e2')]
              return
                  (sigB, [makeNamed "" axiom], sig1, sig2, eMap1', eMap2')
             HasInst -> do
              let extPart = mkExtendedEntity e2'
                  axiom = PlainAxiom extPart $
-                           ListFrameBit (Just Types) $
-                           ExpressionBit [([], Expression $ cutIRI e1')]
+                           ListFrameBit (Just AS.Types) $
+                           ExpressionBit [([], AS.Expression $ AS.cutIRI e1')]
              return
                  (sigB, [makeNamed "" axiom], sig1, sig2, eMap1', eMap2')
             RelName _r -> error "nyi" {- do

--- a/OWL2/Symbols.hs
+++ b/OWL2/Symbols.hs
@@ -13,7 +13,7 @@ Symbol items for Hets
 
 module OWL2.Symbols where
 
-import OWL2.AS
+import qualified OWL2.AS as AS
 import Common.IRI
 import Common.Id (Id)
 
@@ -21,7 +21,7 @@ import Data.Data
 
 -- * SYMBOL ITEMS FOR HETS
 
-data ExtEntityType = AnyEntity | PrefixO | EntityType EntityType
+data ExtEntityType = AnyEntity | PrefixO | EntityType AS.EntityType
   deriving (Show, Eq, Ord, Typeable, Data)
 
 data SymbItems = SymbItems ExtEntityType [IRI]
@@ -35,7 +35,7 @@ data SymbMapItems = SymbMapItems ExtEntityType [(IRI, Maybe IRI)]
     deriving (Show, Eq, Typeable, Data)
 
 -- | raw symbols
-data RawSymb = ASymbol Entity | AnUri IRI | APrefix String
+data RawSymb = ASymbol AS.Entity | AnUri IRI | APrefix String
     deriving (Show, Eq, Ord, Typeable, Data)
 
 idToRaw :: Id -> RawSymb

--- a/OWL2/Theorem.hs
+++ b/OWL2/Theorem.hs
@@ -13,14 +13,14 @@ Adds the "implied" annotation - for specifying theorems
 module OWL2.Theorem where
 
 import Common.IRI
-import OWL2.AS
+import qualified OWL2.AS as AS
 import OWL2.MS
 
 import Data.List
 
-implied :: Annotation
-implied = Annotation [] (mkIRI "Implied")
-  . AnnValLit . Literal "true" . Typed $ mkIRI "string"
+implied :: AS.Annotation
+implied = AS.Annotation [] (mkIRI "Implied")
+  . AS.AnnValLit . AS.Literal "true" . AS.Typed $ mkIRI "string"
 
 rmList :: Annotations -> Annotations
 rmList = filter (not . prove1)
@@ -86,9 +86,9 @@ addImpliedFrame a = case rmImpliedFrame a of
         Misc ans -> Frame (Misc $ implied : ans) l
         _ -> Frame eith $ map addImpliedFrameBit l
 
-prove1 :: Annotation -> Bool
+prove1 :: AS.Annotation -> Bool
 prove1 anno = case anno of
-      Annotation _ aIRI (AnnValLit (Literal value (Typed _))) ->
+      AS.Annotation _ aIRI (AS.AnnValLit (AS.Literal value (AS.Typed _))) ->
           show (iriPath aIRI) == "Implied" && isInfixOf "true" value
       _ -> False
 

--- a/OWL2/XML.hs
+++ b/OWL2/XML.hs
@@ -20,7 +20,7 @@ import Common.Lexer (value)
 import Common.IRI
 import Common.Id (stringToId, prependString, tokStr, getTokens)
 
-import OWL2.AS
+import qualified OWL2.AS as AS
 import OWL2.Extract
 import OWL2.Keywords
 import OWL2.MS
@@ -164,12 +164,12 @@ getName e =
 getInt :: Element -> Int
 getInt e = let [int] = elAttribs e in value 10 $ attrVal int
 
-getEntityType :: String -> EntityType
+getEntityType :: String -> AS.EntityType
 getEntityType ty = fromMaybe (err $ "no entity type " ++ ty)
-  . lookup ty $ map (\ e -> (show e, e)) entityTypes
+  . lookup ty $ map (\ e -> (show e, e)) AS.entityTypes
 
-getEntity :: XMLBase -> Element -> Entity
-getEntity b e = mkEntity (getEntityType $ (qName . elName) e) $ getIRI b e
+getEntity :: XMLBase -> Element -> AS.Entity
+getEntity b e = AS.mkEntity (getEntityType $ (qName . elName) e) $ getIRI b e
 
 getDeclaration :: XMLBase -> Element -> Axiom
 getDeclaration b e = case getName e of
@@ -183,16 +183,16 @@ isPlainLiteral s =
     "http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral" == s
 
 -- | put an "f" for float if not there already (eg. 123.45 --> 123.45f)
-correctLit :: Literal -> Literal
+correctLit :: AS.Literal -> AS.Literal
 correctLit l = case l of
-    Literal lf (Typed dt) ->
+    AS.Literal lf (AS.Typed dt) ->
         let nlf = if isSuffixOf "float" (show $ iriPath dt) && last lf /= 'f'
                 then lf ++ "f"
                 else lf
-        in Literal nlf (Typed dt)
+        in AS.Literal nlf (AS.Typed dt)
     _ -> l
 
-getLiteral :: XMLBase -> Element -> Literal
+getLiteral :: XMLBase -> Element -> AS.Literal
 getLiteral b e = case getName e of
     "Literal" ->
       let lf = strContent e
@@ -200,112 +200,112 @@ getLiteral b e = case getName e of
           mattr = vFindAttrBy (isSmth "lang") e
       in case mdt of
           Nothing -> case mattr of
-             Just lang -> Literal lf $ Untyped $ Just lang
-             Nothing -> Literal lf $ Untyped Nothing
+             Just lang -> AS.Literal lf $ AS.Untyped $ Just lang
+             Nothing -> AS.Literal lf $ AS.Untyped Nothing
           Just dt -> case mattr of
-             Just lang -> Literal lf $ Untyped $ Just lang
+             Just lang -> AS.Literal lf $ AS.Untyped $ Just lang
              Nothing -> if isPlainLiteral dt then
-                          Literal lf $ Untyped Nothing
-                         else correctLit $ Literal lf $ Typed $ appendBase b $
+                          AS.Literal lf $ AS.Untyped Nothing
+                         else correctLit $ AS.Literal lf $ AS.Typed $ appendBase b $
                             nullIRI{iriPath = stringToId dt}
     _ -> err "not literal"
 
-getValue :: XMLBase -> Element -> AnnotationValue
+getValue :: XMLBase -> Element -> AS.AnnotationValue
 getValue b e = case getName e of
-    "Literal" -> AnnValLit $ getLiteral b e
-    "AnonymousIndividual" -> AnnValue $ getIRI b e
-    _ -> AnnValue $ contentIRI b e
+    "Literal" -> AS.AnnValLit $ getLiteral b e
+    "AnonymousIndividual" -> AS.AnnValue $ getIRI b e
+    _ -> AS.AnnValue $ contentIRI b e
 
 getSubject :: XMLBase -> Element -> IRI
 getSubject b e = case getName e of
     "AnonymousIndividual" -> getIRI b e
     _ -> contentIRI b e
 
-getAnnotation :: XMLBase -> Element -> Annotation
+getAnnotation :: XMLBase -> Element -> AS.Annotation
 getAnnotation b e =
      let hd = filterCh "Annotation" e
          [ap] = filterCh "AnnotationProperty" e
          av = filterCL annotationValueList e
-     in Annotation (map (getAnnotation b) hd) (getIRI b ap) $ getValue b av
+     in AS.Annotation (map (getAnnotation b) hd) (getIRI b ap) $ getValue b av
 
 -- | returns a list of annotations
-getAllAnnos :: XMLBase -> Element -> [Annotation]
+getAllAnnos :: XMLBase -> Element -> [AS.Annotation]
 getAllAnnos b e = map (getAnnotation b) $ filterCh "Annotation" e
 
-getObjProp :: XMLBase -> Element -> ObjectPropertyExpression
+getObjProp :: XMLBase -> Element -> AS.ObjectPropertyExpression
 getObjProp b e = case getName e of
-  "ObjectProperty" -> ObjectProp $ getIRI b e
+  "ObjectProperty" -> AS.ObjectProp $ getIRI b e
   "ObjectInverseOf" ->
     let [ch] = elChildren e
         [cch] = elChildren ch
     in case getName ch of
       "ObjectInverseOf" -> getObjProp b cch
-      "ObjectProperty" -> ObjectInverseOf $ ObjectProp $ getIRI b ch
+      "ObjectProperty" -> AS.ObjectInverseOf $ AS.ObjectProp $ getIRI b ch
       _ -> err "not objectProperty"
   _ -> err "not objectProperty"
 
 -- | replaces eg. "minExclusive" with ">"
-properFacet :: ConstrainingFacet -> ConstrainingFacet
+properFacet :: AS.ConstrainingFacet -> AS.ConstrainingFacet
 properFacet cf
     | hasFullIRI cf =
         let p = showIRICompact cf \\ "http://www.w3.org/2001/XMLSchema#"
         in case p of
-            "minInclusive" -> facetToIRI MININCLUSIVE
-            "minExclusive" -> facetToIRI MINEXCLUSIVE
-            "maxInclusive" -> facetToIRI MAXINCLUSIVE
-            "maxExclusive" -> facetToIRI MAXEXCLUSIVE
+            "minInclusive" -> AS.facetToIRI MININCLUSIVE
+            "minExclusive" -> AS.facetToIRI MINEXCLUSIVE
+            "maxInclusive" -> AS.facetToIRI MAXINCLUSIVE
+            "maxExclusive" -> AS.facetToIRI MAXEXCLUSIVE
             _ -> cf
     | otherwise = cf
 
-getFacetValuePair :: XMLBase -> Element -> (ConstrainingFacet, RestrictionValue)
+getFacetValuePair :: XMLBase -> Element -> (AS.ConstrainingFacet, AS.RestrictionValue)
 getFacetValuePair b e = case getName e of
     "FacetRestriction" ->
        let [ch] = elChildren e
        in (properFacet $ getIRI b e, getLiteral b ch)
     _ -> err "not facet"
 
-getDataRange :: XMLBase -> Element -> DataRange
+getDataRange :: XMLBase -> Element -> AS.DataRange
 getDataRange b e =
   let ch@(ch1 : _) = elChildren e
   in case getName e of
-    "Datatype" -> DataType (getIRI b e) []
+    "Datatype" -> AS.DataType (getIRI b e) []
     "DatatypeRestriction" ->
         let dt = getIRI b $ filterC "Datatype" e
             fvp = map (getFacetValuePair b) $ filterCh "FacetRestriction" e
-        in DataType dt fvp
-    "DataComplementOf" -> DataComplementOf $ getDataRange b ch1
-    "DataOneOf" -> DataOneOf $ map (getLiteral b) $ filterCh "Literal" e
-    "DataIntersectionOf" -> DataJunction IntersectionOf
+        in AS.DataType dt fvp
+    "DataComplementOf" -> AS.DataComplementOf $ getDataRange b ch1
+    "DataOneOf" -> AS.DataOneOf $ map (getLiteral b) $ filterCh "Literal" e
+    "DataIntersectionOf" -> AS.DataJunction AS.IntersectionOf
             $ map (getDataRange b) ch
-    "DataUnionOf" -> DataJunction UnionOf $ map (getDataRange b) ch
+    "DataUnionOf" -> AS.DataJunction AS.UnionOf $ map (getDataRange b) ch
     _ -> err "not data range"
 
-getClassExpression :: XMLBase -> Element -> ClassExpression
+getClassExpression :: XMLBase -> Element -> AS.ClassExpression
 getClassExpression b e =
   let ch = elChildren e
       ch1 : _ = ch
       rch1 : _ = reverse ch
   in case getName e of
-    "Class" -> Expression $ getIRI b e
-    "ObjectIntersectionOf" -> ObjectJunction IntersectionOf
+    "Class" -> AS.Expression $ getIRI b e
+    "ObjectIntersectionOf" -> AS.ObjectJunction AS.IntersectionOf
             $ map (getClassExpression b) ch
-    "ObjectUnionOf" -> ObjectJunction UnionOf $ map (getClassExpression b) ch
-    "ObjectComplementOf" -> ObjectComplementOf $ getClassExpression b ch1
-    "ObjectOneOf" -> ObjectOneOf $ map (getIRI b) ch
-    "ObjectSomeValuesFrom" -> ObjectValuesFrom SomeValuesFrom
+    "ObjectUnionOf" -> AS.ObjectJunction AS.UnionOf $ map (getClassExpression b) ch
+    "ObjectComplementOf" -> AS.ObjectComplementOf $ getClassExpression b ch1
+    "ObjectOneOf" -> AS.ObjectOneOf $ map (getIRI b) ch
+    "ObjectSomeValuesFrom" -> AS.ObjectValuesFrom AS.SomeValuesFrom
             (getObjProp b ch1) $ getClassExpression b rch1
-    "ObjectAllValuesFrom" -> ObjectValuesFrom AllValuesFrom
+    "ObjectAllValuesFrom" -> AS.ObjectValuesFrom AS.AllValuesFrom
             (getObjProp b ch1) $ getClassExpression b rch1
-    "ObjectHasValue" -> ObjectHasValue (getObjProp b ch1) $ getIRI b rch1
-    "ObjectHasSelf" -> ObjectHasSelf $ getObjProp b ch1
-    "DataSomeValuesFrom" -> DataValuesFrom SomeValuesFrom (getIRI b ch1)
+    "ObjectHasValue" -> AS.ObjectHasValue (getObjProp b ch1) $ getIRI b rch1
+    "ObjectHasSelf" -> AS.ObjectHasSelf $ getObjProp b ch1
+    "DataSomeValuesFrom" -> AS.DataValuesFrom AS.SomeValuesFrom ([getIRI b ch1])
             $ getDataRange b rch1
-    "DataAllValuesFrom" -> DataValuesFrom AllValuesFrom (getIRI b ch1)
+    "DataAllValuesFrom" -> AS.DataValuesFrom AS.AllValuesFrom ([getIRI b ch1])
             $ getDataRange b rch1
-    "DataHasValue" -> DataHasValue (getIRI b ch1) $ getLiteral b rch1
+    "DataHasValue" -> AS.DataHasValue (getIRI b ch1) $ getLiteral b rch1
     _ -> getObjCard b e ch rch1
 
-getObjCard :: XMLBase -> Element -> [Element] -> Element -> ClassExpression
+getObjCard :: XMLBase -> Element -> [Element] -> Element -> AS.ClassExpression
 getObjCard b e ch rch1 =
     let ch1 : _ = ch
         i = getInt e
@@ -314,15 +314,15 @@ getObjCard b e ch rch1 =
                 then Just $ getClassExpression b rch1
                 else Nothing
     in case getName e of
-        "ObjectMinCardinality" -> ObjectCardinality $ Cardinality
-            MinCardinality i op ce
-        "ObjectMaxCardinality" -> ObjectCardinality $ Cardinality
-            MaxCardinality i op ce
-        "ObjectExactCardinality" -> ObjectCardinality $ Cardinality
-            ExactCardinality i op ce
+        "ObjectMinCardinality" -> AS.ObjectCardinality $ AS.Cardinality
+            AS.MinCardinality i op ce
+        "ObjectMaxCardinality" -> AS.ObjectCardinality $ AS.Cardinality
+            AS.MaxCardinality i op ce
+        "ObjectExactCardinality" -> AS.ObjectCardinality $ AS.Cardinality
+            AS.ExactCardinality i op ce
         _ -> getDataCard b e ch rch1
 
-getDataCard :: XMLBase -> Element -> [Element] -> Element -> ClassExpression
+getDataCard :: XMLBase -> Element -> [Element] -> Element -> AS.ClassExpression
 getDataCard b e ch rch1 =
     let ch1 : _ = ch
         i = getInt e
@@ -331,12 +331,12 @@ getDataCard b e ch rch1 =
                 then Just $ getDataRange b rch1
                 else Nothing
     in case getName e of
-        "DataMinCardinality" -> DataCardinality $ Cardinality
-              MinCardinality i dp dr
-        "DataMaxCardinality" -> DataCardinality $ Cardinality
-              MaxCardinality i dp dr
-        "DataExactCardinality" -> DataCardinality $ Cardinality
-              ExactCardinality i dp dr
+        "DataMinCardinality" -> AS.DataCardinality $ AS.Cardinality
+              AS.MinCardinality i dp dr
+        "DataMaxCardinality" -> AS.DataCardinality $ AS.Cardinality
+              AS.MaxCardinality i dp dr
+        "DataExactCardinality" -> AS.DataCardinality $ AS.Cardinality
+              AS.ExactCardinality i dp dr
         _ -> err "not class expression"
 
 getClassAxiom :: XMLBase -> Element -> Axiom
@@ -350,16 +350,16 @@ getClassAxiom b e =
     "SubClassOf" ->
        let [sub, super] = drop (length ch - 2) ch
        in PlainAxiom (ClassEntity $ getClassExpression b sub)
-        $ ListFrameBit (Just SubClass) $ ExpressionBit
+        $ ListFrameBit (Just AS.SubClass) $ ExpressionBit
                       [(as, getClassExpression b super)]
     "EquivalentClasses" -> PlainAxiom (Misc as) $ ListFrameBit
-      (Just $ EDRelation Equivalent) $ ExpressionBit $ emptyAnnoList cel
+      (Just $ AS.EDRelation AS.Equivalent) $ ExpressionBit $ emptyAnnoList cel
     "DisjointClasses" -> PlainAxiom (Misc as) $ ListFrameBit
-      (Just $ EDRelation Disjoint) $ ExpressionBit $ emptyAnnoList cel
+      (Just $ AS.EDRelation AS.Disjoint) $ ExpressionBit $ emptyAnnoList cel
     "DisjointUnion" -> PlainAxiom (ClassEntity $ getClassExpression b hd)
         $ AnnFrameBit as $ ClassDisjointUnion $ map (getClassExpression b) tl
     "DatatypeDefinition" ->
-        PlainAxiom (SimpleEntity $ mkEntity Datatype $ getIRI b dhd)
+        PlainAxiom (SimpleEntity $ AS.mkEntity AS.Datatype $ getIRI b dhd)
             $ AnnFrameBit as $ DatatypeBit $ getDataRange b dtl
     _ -> getKey b e
 
@@ -385,46 +385,46 @@ getOPAxiom b e =
        in if null opchain
              then let [o1, o2] = map (getObjProp b) $ filterChL objectPropList e
                   in PlainAxiom (ObjectEntity o1) $ ListFrameBit
-                        (Just SubPropertyOf) $ ObjectBit [(as, o2)]
+                        (Just AS.SubPropertyOf) $ ObjectBit [(as, o2)]
              else PlainAxiom (ObjectEntity op) $ AnnFrameBit as
                     $ ObjectSubPropertyChain opchain
     "EquivalentObjectProperties" ->
        let opl = map (getObjProp b) $ filterChL objectPropList e
-       in PlainAxiom (Misc as) $ ListFrameBit (Just $ EDRelation Equivalent)
+       in PlainAxiom (Misc as) $ ListFrameBit (Just $ AS.EDRelation AS.Equivalent)
             $ ObjectBit $ emptyAnnoList opl
     "DisjointObjectProperties" ->
        let opl = map (getObjProp b) $ filterChL objectPropList e
-       in PlainAxiom (Misc as) $ ListFrameBit (Just $ EDRelation Disjoint)
+       in PlainAxiom (Misc as) $ ListFrameBit (Just $ AS.EDRelation AS.Disjoint)
             $ ObjectBit $ emptyAnnoList opl
     "ObjectPropertyDomain" ->
        let ce = getClassExpression b $ filterCL classExpressionList e
        in PlainAxiom (ObjectEntity op) $ ListFrameBit
-            (Just $ DRRelation ADomain) $ ExpressionBit [(as, ce)]
+            (Just $ AS.DRRelation AS.ADomain) $ ExpressionBit [(as, ce)]
     "ObjectPropertyRange" ->
        let ce = getClassExpression b $ filterCL classExpressionList e
        in PlainAxiom (ObjectEntity op) $ ListFrameBit
-            (Just $ DRRelation ARange) $ ExpressionBit [(as, ce)]
+            (Just $ AS.DRRelation AS.ARange) $ ExpressionBit [(as, ce)]
     "InverseObjectProperties" ->
        let [hd, lst] = map (getObjProp b) $ filterChL objectPropList e
-       in PlainAxiom (ObjectEntity hd) $ ListFrameBit (Just InverseOf)
+       in PlainAxiom (ObjectEntity hd) $ ListFrameBit (Just AS.InverseOf)
             $ ObjectBit [(as, lst)]
     "FunctionalObjectProperty" -> PlainAxiom (ObjectEntity op) $ ListFrameBit
-            Nothing $ ObjectCharacteristics [(as, Functional)]
+            Nothing $ ObjectCharacteristics [(as, AS.Functional)]
     "InverseFunctionalObjectProperty" -> PlainAxiom (ObjectEntity op)
             $ ListFrameBit Nothing $ ObjectCharacteristics
-            [(as, InverseFunctional)]
+            [(as, AS.InverseFunctional)]
     "ReflexiveObjectProperty" -> PlainAxiom (ObjectEntity op) $ ListFrameBit
-            Nothing $ ObjectCharacteristics [(as, Reflexive)]
+            Nothing $ ObjectCharacteristics [(as, AS.Reflexive)]
     "IrreflexiveObjectProperty" -> PlainAxiom (ObjectEntity op) $ ListFrameBit
-            Nothing $ ObjectCharacteristics [(as, Irreflexive)]
+            Nothing $ ObjectCharacteristics [(as, AS.Irreflexive)]
     "SymmetricObjectProperty" -> PlainAxiom (ObjectEntity op) $ ListFrameBit
-            Nothing $ ObjectCharacteristics [(as, Symmetric)]
+            Nothing $ ObjectCharacteristics [(as, AS.Symmetric)]
     "AsymmetricObjectProperty" -> PlainAxiom (ObjectEntity op) $ ListFrameBit
-            Nothing $ ObjectCharacteristics [(as, Asymmetric)]
+            Nothing $ ObjectCharacteristics [(as, AS.Asymmetric)]
     "AntisymmetricObjectProperty" -> PlainAxiom (ObjectEntity op) $ ListFrameBit
-            Nothing $ ObjectCharacteristics [(as, Antisymmetric)]
+            Nothing $ ObjectCharacteristics [(as, AS.Antisymmetric)]
     "TransitiveObjectProperty" -> PlainAxiom (ObjectEntity op) $ ListFrameBit
-            Nothing $ ObjectCharacteristics [(as, Transitive)]
+            Nothing $ ObjectCharacteristics [(as, AS.Transitive)]
     _ -> getDPAxiom b e
 
 getDPAxiom :: XMLBase -> Element -> Axiom
@@ -433,29 +433,29 @@ getDPAxiom b e =
    in case getName e of
     "SubDataPropertyOf" ->
         let [hd, lst] = map (getIRI b) $ filterChL dataPropList e
-        in PlainAxiom (SimpleEntity $ mkEntity DataProperty hd)
-              $ ListFrameBit (Just SubPropertyOf) $ DataBit [(as, lst)]
+        in PlainAxiom (SimpleEntity $ AS.mkEntity AS.DataProperty hd)
+              $ ListFrameBit (Just AS.SubPropertyOf) $ DataBit [(as, lst)]
     "EquivalentDataProperties" ->
         let dpl = map (getIRI b) $ filterChL dataPropList e
-        in PlainAxiom (Misc as) $ ListFrameBit (Just $ EDRelation Equivalent)
+        in PlainAxiom (Misc as) $ ListFrameBit (Just $ AS.EDRelation AS.Equivalent)
             $ DataBit $ emptyAnnoList dpl
     "DisjointDataProperties" ->
         let dpl = map (getIRI b) $ filterChL dataPropList e
-        in PlainAxiom (Misc as) $ ListFrameBit (Just $ EDRelation Disjoint)
+        in PlainAxiom (Misc as) $ ListFrameBit (Just $ AS.EDRelation AS.Disjoint)
             $ DataBit $ emptyAnnoList dpl
     "DataPropertyDomain" ->
         let dp = getIRI b $ filterCL dataPropList e
             ce = getClassExpression b $ filterCL classExpressionList e
-        in PlainAxiom (SimpleEntity $ mkEntity DataProperty dp) $ ListFrameBit
-                (Just $ DRRelation ADomain) $ ExpressionBit [(as, ce)]
+        in PlainAxiom (SimpleEntity $ AS.mkEntity AS.DataProperty dp) $ ListFrameBit
+                (Just $ AS.DRRelation AS.ADomain) $ ExpressionBit [(as, ce)]
     "DataPropertyRange" ->
         let dp = getIRI b $ filterCL dataPropList e
             dr = getDataRange b $ filterCL dataRangeList e
-        in PlainAxiom (SimpleEntity $ mkEntity DataProperty dp)
+        in PlainAxiom (SimpleEntity $ AS.mkEntity AS.DataProperty dp)
                 $ ListFrameBit Nothing $ DataPropRange [(as, dr)]
     "FunctionalDataProperty" ->
         let dp = getIRI b $ filterCL dataPropList e
-        in PlainAxiom (SimpleEntity $ mkEntity DataProperty dp)
+        in PlainAxiom (SimpleEntity $ AS.mkEntity AS.DataProperty dp)
                 $ AnnFrameBit as DataFunctional
     _ -> getDataAssertion b e
 
@@ -467,13 +467,13 @@ getDataAssertion b e =
        lit = getLiteral b $ filterC "Literal" e
    in case getName e of
     "DataPropertyAssertion" ->
-         PlainAxiom (SimpleEntity $ mkEntity NamedIndividual ind)
+         PlainAxiom (SimpleEntity $ AS.mkEntity AS.NamedIndividual ind)
            $ ListFrameBit Nothing $ IndividualFacts
-               [(as, DataPropertyFact Positive dp lit)]
+               [(as, DataPropertyFact AS.Positive dp lit)]
     "NegativeDataPropertyAssertion" ->
-         PlainAxiom (SimpleEntity $ mkEntity NamedIndividual ind)
+         PlainAxiom (SimpleEntity $ AS.mkEntity AS.NamedIndividual ind)
             $ ListFrameBit Nothing $ IndividualFacts
-               [(as, DataPropertyFact Negative dp lit)]
+               [(as, DataPropertyFact AS.Negative dp lit)]
     _ -> getObjectAssertion b e
 
 getObjectAssertion :: XMLBase -> Element -> Axiom
@@ -483,13 +483,13 @@ getObjectAssertion b e =
        [hd, lst] = map (getIRI b) $ filterChL individualList e
    in case getName e of
     "ObjectPropertyAssertion" ->
-        PlainAxiom (SimpleEntity $ mkEntity NamedIndividual hd)
+        PlainAxiom (SimpleEntity $ AS.mkEntity AS.NamedIndividual hd)
            $ ListFrameBit Nothing $ IndividualFacts
-               [(as, ObjectPropertyFact Positive op lst)]
+               [(as, ObjectPropertyFact AS.Positive op lst)]
     "NegativeObjectPropertyAssertion" ->
-        PlainAxiom (SimpleEntity $ mkEntity NamedIndividual hd)
+        PlainAxiom (SimpleEntity $ AS.mkEntity AS.NamedIndividual hd)
            $ ListFrameBit Nothing $ IndividualFacts
-               [(as, ObjectPropertyFact Negative op lst)]
+               [(as, ObjectPropertyFact AS.Negative op lst)]
     _ -> getIndividualAssertion b e
 
 getIndividualAssertion :: XMLBase -> Element -> Axiom
@@ -499,10 +499,10 @@ getIndividualAssertion b e =
        l = emptyAnnoList ind
    in case getName e of
     "SameIndividual" ->
-        PlainAxiom (Misc as) $ ListFrameBit (Just (SDRelation Same))
+        PlainAxiom (Misc as) $ ListFrameBit (Just (AS.SDRelation AS.Same))
           $ IndividualSameOrDifferent l
     "DifferentIndividuals" ->
-        PlainAxiom (Misc as) $ ListFrameBit (Just (SDRelation Different))
+        PlainAxiom (Misc as) $ ListFrameBit (Just (AS.SDRelation AS.Different))
           $ IndividualSameOrDifferent l
     _ -> getClassAssertion b e
 
@@ -512,8 +512,8 @@ getClassAssertion b e = case getName e of
         let as = getAllAnnos b e
             ce = getClassExpression b $ filterCL classExpressionList e
             ind = getIRI b $ filterCL individualList e
-        in PlainAxiom (SimpleEntity $ mkEntity NamedIndividual ind)
-                $ ListFrameBit (Just Types) $ ExpressionBit [(as, ce)]
+        in PlainAxiom (SimpleEntity $ AS.mkEntity AS.NamedIndividual ind)
+                $ ListFrameBit (Just AS.Types) $ ExpressionBit [(as, ce)]
     _ -> getAnnoAxiom b e
 
 getAnnoAxiom :: XMLBase -> Element -> Axiom
@@ -527,20 +527,20 @@ getAnnoAxiom b e =
        let [s, v] = filterChL annotationValueList e
            sub = getSubject b s
        -- the misc will be converted to entities in static analysis
-       in PlainAxiom (Misc [Annotation [] sub $ AnnValue sub])
-           $ AnnFrameBit [Annotation as ap (getValue b v)]
+       in PlainAxiom (Misc [AS.Annotation [] sub $ AS.AnnValue sub])
+           $ AnnFrameBit [AS.Annotation as ap (getValue b v)]
                     $ AnnotationFrameBit Assertion
     "SubAnnotationPropertyOf" ->
         let [hd, lst] = map (getIRI b) $ filterCh "AnnotationProperty" e
-        in PlainAxiom (SimpleEntity $ mkEntity AnnotationProperty hd)
-            $ ListFrameBit (Just SubPropertyOf) $ AnnotationBit [(as, lst)]
+        in PlainAxiom (SimpleEntity $ AS.mkEntity AS.AnnotationProperty hd)
+            $ ListFrameBit (Just AS.SubPropertyOf) $ AnnotationBit [(as, lst)]
     "AnnotationPropertyDomain" ->
-        PlainAxiom (SimpleEntity $ mkEntity AnnotationProperty ap)
-               $ ListFrameBit (Just $ DRRelation ADomain)
+        PlainAxiom (SimpleEntity $ AS.mkEntity AS.AnnotationProperty ap)
+               $ ListFrameBit (Just $ AS.DRRelation AS.ADomain)
                       $ AnnotationBit [(as, anIri)]
     "AnnotationPropertyRange" ->
-        PlainAxiom (SimpleEntity $ mkEntity AnnotationProperty ap)
-               $ ListFrameBit (Just $ DRRelation ARange)
+        PlainAxiom (SimpleEntity $ AS.mkEntity AS.AnnotationProperty ap)
+               $ ListFrameBit (Just $ AS.DRRelation AS.ARange)
                       $ AnnotationBit [(as, anIri)]
     _ -> PlainAxiom (Misc []) . AnnFrameBit [] . AnnotationFrameBit
       . XmlError $ getName e
@@ -560,7 +560,7 @@ getFrames b e ax =
 getOnlyAxioms :: XMLBase -> Element -> [Axiom]
 getOnlyAxioms b e = map (getClassAxiom b) $ filterChildrenName isNotSmth e
 
-getImports :: Map.Map String String -> XMLBase -> Element -> [ImportIRI]
+getImports :: Map.Map String String -> XMLBase -> Element -> [AS.ImportIRI]
 getImports m b e = map (importIRI m b) $ filterCh importK e
 
 get1Map :: Element -> (String, String)
@@ -571,7 +571,7 @@ get1Map e =
 getPrefixMap :: Element -> [(String, String)]
 getPrefixMap e = map get1Map $ filterCh "Prefix" e
 
-getOntologyIRI :: XMLBase -> Element -> OntologyIRI
+getOntologyIRI :: XMLBase -> Element -> AS.OntologyIRI
 getOntologyIRI b e =
   let oi = findAttr (unqual "ontologyIRI") e
   in case oi of

--- a/OWL2/XMLConversion.hs
+++ b/OWL2/XMLConversion.hs
@@ -68,7 +68,7 @@ setIRI iri e =
             | isBlankNode iri = nodeID
             | otherwise = "abbreviatedIRI"
     in e {elAttribs = [Attr {attrKey = makeQN ty,
-                             attrVal = showIRI $ setReservedPrefix iri}]}
+                             attrVal = showIRI $ AS.setReservedPrefix iri}]}
 
 mwIRI :: IRI -> Element
 mwIRI iri = setIRI iri nullElem
@@ -97,7 +97,7 @@ mwText s = setText s nullElem
 mwSimpleIRI :: IRI -> Element
 mwSimpleIRI s = setName (if hasFullIRI s then iriK
                           else abbreviatedIRI) $ mwText $ showIRI
-                          $ setReservedPrefix s
+                          $ AS.setReservedPrefix s
 
 {- | generates a list of elements, all with the first string as name,
     and each with the content in this order: first, the list of elements
@@ -121,8 +121,8 @@ setInt i e = e {elAttribs = [Attr {attrKey = makeQN "cardinality",
     attrVal = show i}]}
 
 -- | the reverse of @properFacet@ in "OWL2.XML"
-correctFacet :: ConstrainingFacet -> ConstrainingFacet
-correctFacet c = let d = getPredefName c in setPrefix "http" $ mkIRI $
+correctFacet :: AS.ConstrainingFacet -> AS.ConstrainingFacet
+correctFacet c = let d = AS.getPredefName c in setPrefix "http" $ mkIRI $
     "//www.w3.org/2001/XMLSchema#" ++ case d of
         ">" -> "minExclusive"
         "<" -> "maxExclusive"
@@ -134,122 +134,122 @@ correctFacet c = let d = getPredefName c in setPrefix "http" $ mkIRI $
 setDt :: Bool -> IRI -> Element -> Element
 setDt b dt e = e {elAttribs = elAttribs e ++ [Attr {attrKey
     = makeQN (if b then "datatypeIRI" else "facet"),
-      attrVal = showIRI $ if b then setReservedPrefix dt else correctFacet dt}]}
+      attrVal = showIRI $ if b then AS.setReservedPrefix dt else correctFacet dt}]}
 
-setLangTag :: Maybe LanguageTag -> Element -> Element
+setLangTag :: Maybe AS.LanguageTag -> Element -> Element
 setLangTag ml e = case ml of
     Nothing -> e
     Just lt -> e {elAttribs = elAttribs e ++ [Attr {attrKey
         = setQNPrefix "xml" (makeQN "lang"), attrVal = lt}]}
 
-xmlEntity :: Entity -> Element
-xmlEntity (Entity _ ty ent) = mwNameIRI (case ty of
-    Class -> classK
-    Datatype -> datatypeK
-    ObjectProperty -> objectPropertyK
-    DataProperty -> dataPropertyK
-    AnnotationProperty -> annotationPropertyK
-    NamedIndividual -> namedIndividualK) ent
+xmlEntity :: AS.Entity -> Element
+xmlEntity (AS.Entity _ ty ent) = mwNameIRI (case ty of
+    AS.Class -> classK
+    AS.Datatype -> datatypeK
+    AS.ObjectProperty -> objectPropertyK
+    AS.DataProperty -> dataPropertyK
+    AS.AnnotationProperty -> annotationPropertyK
+    AS.NamedIndividual -> namedIndividualK) ent
 
-xmlLiteral :: Literal -> Element
+xmlLiteral :: AS.Literal -> Element
 xmlLiteral l = case l of
-  Literal lf tu ->
+  AS.Literal lf tu ->
     let part = setName literalK $ mwText lf
     in case tu of
-        Typed dt -> setDt True dt part
-        Untyped lang -> setLangTag lang $ setDt True (splitIRI $ mkIRI
+        AS.Typed dt -> setDt True dt part
+        AS.Untyped lang -> setLangTag lang $ setDt True (splitIRI $ mkIRI
             "http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral")
             part
-  NumberLit f -> setDt True (nullIRI {iriScheme = "http:",
-        iriPath = stringToId $ "//www.w3.org/2001/XMLSchema#" ++ numberName f})
+  AS.NumberLit f -> setDt True (nullIRI {iriScheme = "http:",
+        iriPath = stringToId $ "//www.w3.org/2001/XMLSchema#" ++ AS.numberName f})
         $ setName literalK $ mwText $ show f
 
 xmlIndividual :: IRI -> Element
 xmlIndividual iri =
-    mwNameIRI (if isAnonymous iri then anonymousIndividualK
+    mwNameIRI (if AS.isAnonymous iri then anonymousIndividualK
                 else namedIndividualK) iri
 
-xmlFVPair :: (ConstrainingFacet, RestrictionValue) -> Element
+xmlFVPair :: (AS.ConstrainingFacet, AS.RestrictionValue) -> Element
 xmlFVPair (cf, rv) = setDt False cf $ makeElement facetRestrictionK
     [xmlLiteral rv]
 
-xmlObjProp :: ObjectPropertyExpression -> Element
+xmlObjProp :: AS.ObjectPropertyExpression -> Element
 xmlObjProp ope = case ope of
-    ObjectProp op -> mwNameIRI objectPropertyK op
-    ObjectInverseOf i -> makeElement objectInverseOfK [xmlObjProp i]
+    AS.ObjectProp op -> mwNameIRI objectPropertyK op
+    AS.ObjectInverseOf i -> makeElement objectInverseOfK [xmlObjProp i]
 
-xmlDataRange :: DataRange -> Element
+xmlDataRange :: AS.DataRange -> Element
 xmlDataRange dr = case dr of
-    DataType dt cfl ->
+    AS.DataType dt cfl ->
         let dtelem = mwNameIRI datatypeK dt
         in if null cfl then dtelem
             else makeElement datatypeRestrictionK
             $ dtelem : map xmlFVPair cfl
-    DataJunction jt drl -> makeElement (
+    AS.DataJunction jt drl -> makeElement (
         case jt of
-            IntersectionOf -> dataIntersectionOfK
-            UnionOf -> dataUnionOfK)
+            AS.IntersectionOf -> dataIntersectionOfK
+            AS.UnionOf -> dataUnionOfK)
         $ map xmlDataRange drl
-    DataComplementOf drn -> makeElement dataComplementOfK
+    AS.DataComplementOf drn -> makeElement dataComplementOfK
         [xmlDataRange drn]
-    DataOneOf ll -> makeElement dataOneOfK
+    AS.DataOneOf ll -> makeElement dataOneOfK
         $ map xmlLiteral ll
 
-xmlClassExpression :: ClassExpression -> Element
+xmlClassExpression :: AS.ClassExpression -> Element
 xmlClassExpression ce = case ce of
-    Expression c -> mwNameIRI classK c
-    ObjectJunction jt cel -> makeElement (
+    AS.Expression c -> mwNameIRI classK c
+    AS.ObjectJunction jt cel -> makeElement (
         case jt of
-            IntersectionOf -> objectIntersectionOfK
-            UnionOf -> objectUnionOfK)
+            AS.IntersectionOf -> objectIntersectionOfK
+            AS.UnionOf -> objectUnionOfK)
         $ map xmlClassExpression cel
-    ObjectComplementOf cex -> makeElement objectComplementOfK
+    AS.ObjectComplementOf cex -> makeElement objectComplementOfK
         [xmlClassExpression cex]
-    ObjectOneOf il -> makeElement objectOneOfK
+    AS.ObjectOneOf il -> makeElement objectOneOfK
         $ map xmlIndividual il
-    ObjectValuesFrom qt ope cex -> makeElement (
+    AS.ObjectValuesFrom qt ope cex -> makeElement (
         case qt of
-            AllValuesFrom -> objectAllValuesFromK
-            SomeValuesFrom -> objectSomeValuesFromK)
+            AS.AllValuesFrom -> objectAllValuesFromK
+            AS.SomeValuesFrom -> objectSomeValuesFromK)
         [xmlObjProp ope, xmlClassExpression cex]
-    ObjectHasValue ope i -> makeElement objectHasValueK
+    AS.ObjectHasValue ope i -> makeElement objectHasValueK
         [xmlObjProp ope, xmlIndividual i]
-    ObjectHasSelf ope -> makeElement objectHasSelfK [xmlObjProp ope]
-    ObjectCardinality (Cardinality ct i op mce) -> setInt i $ makeElement (
+    AS.ObjectHasSelf ope -> makeElement objectHasSelfK [xmlObjProp ope]
+    AS.ObjectCardinality (AS.Cardinality ct i op mce) -> setInt i $ makeElement (
         case ct of
-            MinCardinality -> objectMinCardinalityK
-            MaxCardinality -> objectMaxCardinalityK
-            ExactCardinality -> objectExactCardinalityK)
+            AS.MinCardinality -> objectMinCardinalityK
+            AS.MaxCardinality -> objectMaxCardinalityK
+            AS.ExactCardinality -> objectExactCardinalityK)
         $ xmlObjProp op :
         case mce of
             Nothing -> []
             Just cexp -> [xmlClassExpression cexp]
-    DataValuesFrom qt dp dr -> makeElement (
+    AS.DataValuesFrom qt dp dr -> makeElement (
         case qt of
-            AllValuesFrom -> dataAllValuesFromK
-            SomeValuesFrom -> dataSomeValuesFromK)
-        [mwNameIRI dataPropertyK dp, xmlDataRange dr]
-    DataHasValue dp l -> makeElement dataHasValueK
+            AS.AllValuesFrom -> dataAllValuesFromK
+            AS.SomeValuesFrom -> dataSomeValuesFromK)
+        [mwNameIRI dataPropertyK (head dp), xmlDataRange dr]
+    AS.DataHasValue dp l -> makeElement dataHasValueK
         [mwNameIRI dataPropertyK dp, xmlLiteral l]
-    DataCardinality (Cardinality ct i dp mdr) -> setInt i $ makeElement (
+    AS.DataCardinality (AS.Cardinality ct i dp mdr) -> setInt i $ makeElement (
         case ct of
-            MinCardinality -> dataMinCardinalityK
-            MaxCardinality -> dataMaxCardinalityK
-            ExactCardinality -> dataExactCardinalityK)
+            AS.MinCardinality -> dataMinCardinalityK
+            AS.MaxCardinality -> dataMaxCardinalityK
+            AS.ExactCardinality -> dataExactCardinalityK)
         $ mwNameIRI dataPropertyK dp :
             case mdr of
                 Nothing -> []
                 Just dr -> [xmlDataRange dr]
 
-xmlAnnotation :: Annotation -> Element
-xmlAnnotation (Annotation al ap av) = makeElement annotationK
+xmlAnnotation :: AS.Annotation -> Element
+xmlAnnotation (AS.Annotation al ap av) = makeElement annotationK
     $ map xmlAnnotation al ++ [mwNameIRI annotationPropertyK ap,
     case av of
-        AnnValue iri -> xmlSubject iri
-        AnnValLit l -> xmlLiteral l]
+        AS.AnnValue iri -> xmlSubject iri
+        AS.AnnValLit l -> xmlLiteral l]
 
 xmlSubject :: IRI -> Element
-xmlSubject iri = if isAnonymous iri then xmlIndividual iri
+xmlSubject iri = if AS.isAnonymous iri then xmlIndividual iri
                   else mwSimpleIRI iri
 
 xmlAnnotations :: Annotations -> [Element]
@@ -260,61 +260,61 @@ xmlAL f al = let annos = map (xmlAnnotations . fst) al
                  other = map (\ (_, b) -> f b) al
              in zip annos other
 
-xmlLFB :: Extended -> Maybe Relation -> ListFrameBit -> [Element]
+xmlLFB :: Extended -> Maybe AS.Relation -> ListFrameBit -> [Element]
 xmlLFB ext mr lfb = case lfb of
     AnnotationBit al ->
         let list = xmlAL mwSimpleIRI al
-            SimpleEntity (Entity _ _ ap) = ext
+            SimpleEntity (AS.Entity _ _ ap) = ext
         in case fromMaybe (error "expected domain, range, subproperty") mr of
-            SubPropertyOf ->
+            AS.SubPropertyOf ->
                 let list2 = xmlAL (mwNameIRI annotationPropertyK) al
                 in make1 True subAnnotationPropertyOfK annotationPropertyK
                          mwNameIRI ap list2
-            DRRelation ADomain -> make1 True annotationPropertyDomainK
+            AS.DRRelation AS.ADomain -> make1 True annotationPropertyDomainK
                         annotationPropertyK mwNameIRI ap list
-            DRRelation ARange -> make1 True annotationPropertyRangeK
+            AS.DRRelation AS.ARange -> make1 True annotationPropertyRangeK
                         annotationPropertyK mwNameIRI ap list
             _ -> error "bad annotation bit"
     ExpressionBit al ->
         let list = xmlAL xmlClassExpression al in case ext of
             Misc anno -> [makeElement (case fromMaybe
                 (error "expected equiv--, disjoint--, class") mr of
-                    EDRelation Equivalent -> equivalentClassesK
-                    EDRelation Disjoint -> disjointClassesK
+                    AS.EDRelation AS.Equivalent -> equivalentClassesK
+                    AS.EDRelation AS.Disjoint -> disjointClassesK
                     _ -> error "bad equiv or disjoint classes bit"
                 ) $ xmlAnnotations anno ++ map snd list]
             ClassEntity c -> make2 True (case fromMaybe
                 (error "expected equiv--, disjoint--, sub-- class") mr of
-                    SubClass -> subClassOfK
-                    EDRelation Equivalent -> equivalentClassesK
-                    EDRelation Disjoint -> disjointClassesK
+                    AS.SubClass -> subClassOfK
+                    AS.EDRelation AS.Equivalent -> equivalentClassesK
+                    AS.EDRelation AS.Disjoint -> disjointClassesK
                     _ -> error "bad equiv, disjoint, subClass bit")
                 xmlClassExpression c list
             ObjectEntity op -> make2 True (case fromMaybe
                 (error "expected domain, range") mr of
-                    DRRelation ADomain -> objectPropertyDomainK
-                    DRRelation ARange -> objectPropertyRangeK
+                    AS.DRRelation AS.ADomain -> objectPropertyDomainK
+                    AS.DRRelation AS.ARange -> objectPropertyRangeK
                     _ -> "bad object domain or range bit") xmlObjProp op list
-            SimpleEntity (Entity _ ty ent) -> case ty of
-                DataProperty -> make1 True dataPropertyDomainK dataPropertyK
+            SimpleEntity (AS.Entity _ ty ent) -> case ty of
+                AS.DataProperty -> make1 True dataPropertyDomainK dataPropertyK
                         mwNameIRI ent list
-                NamedIndividual -> make2 False classAssertionK
+                AS.NamedIndividual -> make2 False classAssertionK
                         xmlIndividual ent list
                 _ -> error "bad expression bit"
     ObjectBit al ->
         let list = xmlAL xmlObjProp al in case ext of
             Misc anno -> [makeElement (case fromMaybe
                 (error "expected equiv--, disjoint-- obj prop") mr of
-                    EDRelation Equivalent -> equivalentObjectPropertiesK
-                    EDRelation Disjoint -> disjointObjectPropertiesK
+                    AS.EDRelation AS.Equivalent -> equivalentObjectPropertiesK
+                    AS.EDRelation AS.Disjoint -> disjointObjectPropertiesK
                     _ -> error "bad object bit (equiv, disjoint)"
                 ) $ xmlAnnotations anno ++ map snd list]
             ObjectEntity o -> make2 True (case fromMaybe
                 (error "expected sub, Inverse, equiv, disjoint op") mr of
-                    SubPropertyOf -> subObjectPropertyOfK
-                    InverseOf -> inverseObjectPropertiesK
-                    EDRelation Equivalent -> equivalentObjectPropertiesK
-                    EDRelation Disjoint -> disjointObjectPropertiesK
+                    AS.SubPropertyOf -> subObjectPropertyOfK
+                    AS.InverseOf -> inverseObjectPropertiesK
+                    AS.EDRelation AS.Equivalent -> equivalentObjectPropertiesK
+                    AS.EDRelation AS.Disjoint -> disjointObjectPropertiesK
                     _ -> error "bad object bit (subpropertyof, inverseof)"
                 ) xmlObjProp o list
             _ -> error "bad object bit"
@@ -322,15 +322,15 @@ xmlLFB ext mr lfb = case lfb of
         let list = xmlAL (mwNameIRI dataPropertyK) al in case ext of
             Misc anno -> [makeElement (case fromMaybe
                 (error "expected equiv--, disjoint-- data prop") mr of
-                    EDRelation Equivalent -> equivalentDataPropertiesK
-                    EDRelation Disjoint -> disjointDataPropertiesK
+                    AS.EDRelation AS.Equivalent -> equivalentDataPropertiesK
+                    AS.EDRelation AS.Disjoint -> disjointDataPropertiesK
                     _ -> error "bad data bit"
                 ) $ xmlAnnotations anno ++ map snd list]
-            SimpleEntity (Entity _ _ ent) -> make1 True (case fromMaybe
+            SimpleEntity (AS.Entity _ _ ent) -> make1 True (case fromMaybe
                     (error "expected sub, equiv or disjoint data") mr of
-                        SubPropertyOf -> subDataPropertyOfK
-                        EDRelation Equivalent -> equivalentDataPropertiesK
-                        EDRelation Disjoint -> disjointDataPropertiesK
+                        AS.SubPropertyOf -> subDataPropertyOfK
+                        AS.EDRelation AS.Equivalent -> equivalentDataPropertiesK
+                        AS.EDRelation AS.Disjoint -> disjointDataPropertiesK
                         _ -> error "bad data bit"
                     ) dataPropertyK mwNameIRI ent list
             _ -> error "bad data bit"
@@ -338,14 +338,14 @@ xmlLFB ext mr lfb = case lfb of
         let list = xmlAL xmlIndividual al in case ext of
             Misc anno -> [makeElement (case fromMaybe
                 (error "expected same--, different-- individuals") mr of
-                    SDRelation Same -> sameIndividualK
-                    SDRelation Different -> differentIndividualsK
+                    AS.SDRelation AS.Same -> sameIndividualK
+                    AS.SDRelation AS.Different -> differentIndividualsK
                     _ -> error "bad individual bit (s or d)"
                 ) $ xmlAnnotations anno ++ map snd list]
-            SimpleEntity (Entity _ _ i) -> make2 True (case fromMaybe
+            SimpleEntity (AS.Entity _ _ i) -> make2 True (case fromMaybe
                 (error "expected same--, different-- individuals") mr of
-                    SDRelation Same -> sameIndividualK
-                    SDRelation Different -> differentIndividualsK
+                    AS.SDRelation AS.Same -> sameIndividualK
+                    AS.SDRelation AS.Different -> differentIndividualsK
                     _ -> error "bad individual bit (s or d)"
                 ) xmlIndividual i list
             _ -> error "bad individual same or different"
@@ -354,44 +354,44 @@ xmlLFB ext mr lfb = case lfb of
             annos = map (xmlAnnotations . fst) al
             list = zip annos (map snd al)
         in map (\ (x, y) -> makeElement (case y of
-                Functional -> functionalObjectPropertyK
-                InverseFunctional -> inverseFunctionalObjectPropertyK
-                Reflexive -> reflexiveObjectPropertyK
-                Irreflexive -> irreflexiveObjectPropertyK
-                Symmetric -> symmetricObjectPropertyK
-                Asymmetric -> asymmetricObjectPropertyK
-                Transitive -> transitiveObjectPropertyK
-                Antisymmetric -> antisymmetricObjectPropertyK
+                AS.Functional -> functionalObjectPropertyK
+                AS.InverseFunctional -> inverseFunctionalObjectPropertyK
+                AS.Reflexive -> reflexiveObjectPropertyK
+                AS.Irreflexive -> irreflexiveObjectPropertyK
+                AS.Symmetric -> symmetricObjectPropertyK
+                AS.Asymmetric -> asymmetricObjectPropertyK
+                AS.Transitive -> transitiveObjectPropertyK
+                AS.Antisymmetric -> antisymmetricObjectPropertyK
             ) $ x ++ [xmlObjProp op]) list
     DataPropRange al ->
-        let SimpleEntity (Entity _ DataProperty dp) = ext
+        let SimpleEntity (AS.Entity _ AS.DataProperty dp) = ext
             list = xmlAL xmlDataRange al
         in make1 True dataPropertyRangeK dataPropertyK mwNameIRI dp list
     IndividualFacts al ->
-        let SimpleEntity (Entity _ NamedIndividual i) = ext
+        let SimpleEntity (AS.Entity _ AS.NamedIndividual i) = ext
             annos = map (xmlAnnotations . fst) al
             list = zip annos (map snd al)
         in map (\ (x, f) -> case f of
             ObjectPropertyFact pn op ind ->
                makeElement (case pn of
-                    Positive -> objectPropertyAssertionK
-                    Negative -> negativeObjectPropertyAssertionK
+                    AS.Positive -> objectPropertyAssertionK
+                    AS.Negative -> negativeObjectPropertyAssertionK
                 ) $ x ++ [xmlObjProp op] ++ map xmlIndividual [i, ind]
             DataPropertyFact pn dp lit ->
                 makeElement (case pn of
-                    Positive -> dataPropertyAssertionK
-                    Negative -> negativeDataPropertyAssertionK
+                    AS.Positive -> dataPropertyAssertionK
+                    AS.Negative -> negativeDataPropertyAssertionK
                 ) $ x ++ [mwNameIRI dataPropertyK dp] ++
                         [xmlIndividual i] ++ [xmlLiteral lit]
             ) list
 
 xmlAssertion :: IRI -> Annotations -> [Element]
-xmlAssertion iri = map (\ (Annotation as ap av) ->
+xmlAssertion iri = map (\ (AS.Annotation as ap av) ->
     makeElement annotationAssertionK $ xmlAnnotations as
         ++ [mwNameIRI annotationPropertyK ap]
         ++ [xmlSubject iri, case av of
-                AnnValue avalue -> xmlSubject avalue
-                AnnValLit l -> xmlLiteral l])
+                AS.AnnValue avalue -> xmlSubject avalue
+                AS.AnnValLit l -> xmlLiteral l])
 
 xmlAFB :: Extended -> Annotations -> AnnFrameBit -> [Element]
 xmlAFB ext anno afb = case afb of
@@ -402,24 +402,24 @@ xmlAFB ext anno afb = case afb of
             Assertion -> if null anno then [makeElement declarationK
                                                 [xmlEntity ent]]
                           else
-                           let Entity _ _ iri = ent in xmlAssertion iri anno
+                           let AS.Entity _ _ iri = ent in xmlAssertion iri anno
             XmlError _ -> error "xmlAFB"
-        Misc ans -> let [Annotation _ iri _] = ans in xmlAssertion iri anno
+        Misc ans -> let [AS.Annotation _ iri _] = ans in xmlAssertion iri anno
         ClassEntity ent -> case ent of
-            Expression c -> [makeElement declarationK
-                    $ xmlAnnotations anno ++ [xmlEntity $ mkEntity Class c]]
+            AS.Expression c -> [makeElement declarationK
+                    $ xmlAnnotations anno ++ [xmlEntity $ AS.mkEntity AS.Class c]]
             _ -> [] -- very rare cases
         ObjectEntity ent -> case ent of
-            ObjectProp o -> [makeElement declarationK
+            AS.ObjectProp o -> [makeElement declarationK
                     $ xmlAnnotations anno ++
-                    [xmlEntity $ mkEntity ObjectProperty o]]
+                    [xmlEntity $ AS.mkEntity AS.ObjectProperty o]]
             _ -> [] -- very rare cases
     DataFunctional ->
-        let SimpleEntity (Entity _ _ dp) = ext
+        let SimpleEntity (AS.Entity _ _ dp) = ext
         in [makeElement functionalDataPropertyK
             $ xmlAnnotations anno ++ [mwNameIRI dataPropertyK dp]]
     DatatypeBit dr ->
-        let SimpleEntity (Entity _ _ dt) = ext
+        let SimpleEntity (AS.Entity _ _ dt) = ext
         in [makeElement datatypeDefinitionK
                 $ xmlAnnotations anno ++ [mwNameIRI datatypeK dt,
                     xmlDataRange dr]]
@@ -464,7 +464,7 @@ signToDec s = concatMap (uncurry $ mkElemeDecl s)
     , (datatypeK, datatypes)
     , (namedIndividualK, individuals)]
 
-xmlImport :: ImportIRI -> Element
+xmlImport :: AS.ImportIRI -> Element
 xmlImport i = setName importK $ mwText $ showIRI i
 
 setPref :: String -> Element -> Element
@@ -474,11 +474,11 @@ setPref s e = e {elAttribs = Attr {attrKey = makeQN "name"
 set1Map :: (String, String) -> Element
 set1Map (s, iri) = setPref s $ mwIRI $ splitIRI $ mkIRI iri
 
-xmlPrefixes :: PrefixMap -> [Element]
-xmlPrefixes pm = let allpm = Map.union pm predefPrefixes in
+xmlPrefixes :: AS.PrefixMap -> [Element]
+xmlPrefixes pm = let allpm = Map.union pm AS.predefPrefixes in
     map (setName prefixK . set1Map) $ Map.toList allpm
 
-setOntIRI :: OntologyIRI -> Element -> Element
+setOntIRI :: AS.OntologyIRI -> Element -> Element
 setOntIRI iri e =
     if elem iri [nullIRI, dummyIRI] then e
      else e {elAttribs = Attr {attrKey = makeQN "ontologyIRI",

--- a/OWL2/XMLConversion.hs
+++ b/OWL2/XMLConversion.hs
@@ -16,7 +16,7 @@ import Common.AS_Annotation (Named, sentence)
 import Common.IRI hiding (showIRI)
 import Common.Id
 
-import OWL2.AS
+import qualified OWL2.AS as AS
 import OWL2.MS
 import OWL2.Sign
 import OWL2.XML

--- a/RDF/AS.hs
+++ b/RDF/AS.hs
@@ -20,7 +20,7 @@ module RDF.AS where
 
 import Common.Id
 import Common.IRI
-import OWL2.AS
+import qualified OWL2.AS as AS
 
 import Data.Data
 import Data.List
@@ -67,8 +67,8 @@ data Object = Object Subject
 data PredicateObjectList = PredicateObjectList Predicate [Object]
     deriving (Show, Eq, Ord, Typeable, Data)
 
-data RDFLiteral = RDFLiteral Bool LexicalForm TypedOrUntyped
-  | RDFNumberLit FloatLit
+data RDFLiteral = RDFLiteral Bool AS.LexicalForm AS.TypedOrUntyped
+  | RDFNumberLit AS.FloatLit
     deriving (Show, Eq, Ord, Typeable, Data)
 
 -- * Datatypes for Hets manipulation

--- a/RDF/Logic_RDF.hs
+++ b/RDF/Logic_RDF.hs
@@ -31,7 +31,7 @@ import Data.Monoid
 import Logic.Logic
 
 import RDF.AS
-import RDF.ATC_RDF ()
+--import RDF.ATC_RDF ()
 import RDF.Parse
 import RDF.Symbols
 import RDF.Print
@@ -39,8 +39,17 @@ import RDF.Sign
 import RDF.Morphism
 import RDF.Sublogic
 import RDF.StaticAnalysis
+import ATerm.Conversion
 
 data RDF = RDF deriving Show
+
+instance ShATermConvertible SymbItems
+instance ShATermConvertible SymbMapItems
+instance ShATermConvertible Sign
+instance ShATermConvertible Axiom
+instance ShATermConvertible TurtleDocument
+instance ShATermConvertible RDFMorphism
+instance ShATermConvertible RDFEntity
 
 instance Language RDF where
   language_name _ = "RDF"

--- a/RDF/Morphism.hs
+++ b/RDF/Morphism.hs
@@ -21,7 +21,7 @@ import Common.Lib.State
 import Common.Lib.MapSet (setToMap)
 import Common.Result
 
-import OWL2.AS
+import qualified OWL2.AS as AS
 import RDF.AS
 -}
 import RDF.Sign

--- a/RDF/Parse.hs
+++ b/RDF/Parse.hs
@@ -19,7 +19,7 @@ import Common.Token (criticalKeywords)
 import Common.IRI
 import qualified Common.GlobalAnnotations as GA (PrefixMap)
 
-import OWL2.AS
+import qualified OWL2.AS as AS
 import OWL2.Parse hiding (stringLiteral, literal, skips, uriP)
 import RDF.AS
 import RDF.Symbols
@@ -95,19 +95,19 @@ stringLiteral :: CharParser st RDFLiteral
 stringLiteral = do
   (s, b) <- try longLiteral <|> shortLiteral
   do
-      string cTypeS
+      string AS.cTypeS
       d <- datatypeUri
-      return $ RDFLiteral b s $ Typed d
+      return $ RDFLiteral b s $ AS.Typed d
     <|> do
         string "@"
         t <- skips $ optionMaybe languageTag
-        return $ RDFLiteral b s $ Untyped t
-    <|> skips (return $ RDFLiteral b s $ Typed $ mkIRI "string")
+        return $ RDFLiteral b s $ AS.Untyped t
+    <|> skips (return $ RDFLiteral b s $ AS.Typed $ mkIRI "string")
 
 literal :: CharParser st RDFLiteral
 literal = do
     f <- skips $ try floatingPointLit
-         <|> fmap decToFloat decimalLit
+         <|> fmap AS.decToFloat decimalLit
     return $ RDFNumberLit f
   <|> stringLiteral
 

--- a/RDF/Print.hs
+++ b/RDF/Print.hs
@@ -18,7 +18,7 @@ import Common.IRI
 import Common.Doc hiding (sepBySemis, sepByCommas)
 import Common.DocUtils hiding (ppWithCommas)
 
-import OWL2.AS
+import qualified OWL2.AS as AS
 import OWL2.Print ()
 
 import RDF.AS
@@ -51,8 +51,8 @@ instance Pretty RDFLiteral where
         RDFLiteral b lexi ty -> text (if not b
                 then '"' : lexi ++ "\""
                 else "\"\"\"" ++ lexi ++ "\"\"\"") <> case ty of
-            Typed u -> keyword cTypeS <> pretty u
-            Untyped tag -> if isNothing tag then empty
+            AS.Typed u -> keyword AS.cTypeS <> pretty u
+            AS.Untyped tag -> if isNothing tag then empty
                     else let Just tag2 = tag in text "@" <> text tag2
         RDFNumberLit f -> text (show f)
 

--- a/RDF/StaticAnalysis.hs
+++ b/RDF/StaticAnalysis.hs
@@ -12,7 +12,7 @@ Static analysis for RDF
 
 module RDF.StaticAnalysis where
 
-import OWL2.AS
+import qualified OWL2.AS as AS
 import Common.IRI
 import OWL2.Parse
 import RDF.AS
@@ -95,8 +95,8 @@ resolveObject :: Base -> RDFPrefixMap -> Object -> Object
 resolveObject b pm o = case o of
     Object s -> Object $ resolveSubject b pm s
     ObjectLiteral lit -> case lit of
-        RDFLiteral bool lf (Typed dt) ->
-                ObjectLiteral $ RDFLiteral bool lf $ Typed $ resolveIRI b pm dt
+        RDFLiteral bool lf (AS.Typed dt) ->
+                ObjectLiteral $ RDFLiteral bool lf $ AS.Typed $ resolveIRI b pm dt
         _ -> o
 
 resolveTriples :: Base -> RDFPrefixMap -> Triples -> Triples

--- a/RDF/run.hs
+++ b/RDF/run.hs
@@ -1,6 +1,6 @@
 import System.Environment
 
-import OWL2.AS
+import qualified OWL2.AS as AS
 import RDF.AS
 import RDF.Parse
 import RDF.Print


### PR DESCRIPTION
Resolve ambiguities using qualified imports for OWL2.AS
Removed ATC support for OWL2 and RDF _temporarily_ because the generation script for ATC instances doesn't use qualified imports which introduces ambiguities to the generated files. 