### PR TITLE
1988 correct iri parser

### DIFF
--- a/Common/IRI.hs
+++ b/Common/IRI.hs
@@ -682,7 +682,7 @@ iqueryPart = many1 iprivate <|> uchar ":@/?"
 -- RFC3987, section 2.2
 
 uifragment :: IRIParser st String
-uifragment = char '#' <:> flat (many $ uchar ":@/?")
+uifragment = char '#' <:> flat (many $ uchar ":@/?[]")
 
 -- Reference, Relative and Absolute IRI forms
 

--- a/Common/IRI.hs
+++ b/Common/IRI.hs
@@ -501,7 +501,7 @@ pnCharsPAux c =
 / ipath-empty -}
 
 iriParser :: IRIParser st IRI
-iriParser = iriWithPos $ do
+iriParser = (<|>) (try urnParser) $ iriWithPos $ do
   us <- option "" $ try uscheme
   (ua, up) <- ihierPart
   uq <- option "" uiquery

--- a/Common/IRI.hs
+++ b/Common/IRI.hs
@@ -375,7 +375,8 @@ compoundCurie = do
 curie :: IRIParser st IRI
 curie = iriWithPos $ do
     pn <- try (do
-        n <- ncname
+        n <- option "" ncname -- although the standard doesn't allow an empty
+                              -- prefix the java OWL API does.
         c <- string ":"
         return $ n -- ++ c Don't add the colon to the prefix!
       )

--- a/Common/IRI.hs
+++ b/Common/IRI.hs
@@ -470,7 +470,7 @@ pnCharsPAux c =
 
 iriParser :: IRIParser st IRI
 iriParser = iriWithPos $ do
-  us <- try uscheme
+  us <- option "" $ try uscheme
   (ua, up) <- ihierPart
   uq <- option "" uiquery
   uf <- option "" uifragment


### PR DESCRIPTION
Closes #1988 
Introduced URN Parser
Made the IRI parser less strict to increase compatibility with the java OWL API's IRI parser.