### PR TITLE
Removed most 'try' usages

### DIFF
--- a/OWL2/ParseAS.hs
+++ b/OWL2/ParseAS.hs
@@ -19,28 +19,21 @@ import Data.Map (union, toList, fromList, lookup)
 import Data.Maybe
 
 
-{- | @p <|?> q@ behaves like @<|>@ but pretends it hasn't consumed any input
-when an options failes. -}
-(<|?>) :: (GenParser t st a ) -> (GenParser t st a) -> GenParser t st a
-p <|?> q = try p <|> try q
-infixr 1 <|?>
 
-{- | @manySkip p@ parses 0 or more occurences of @p@ while skipping spaces
-(and comments) inbetween -}
-manySkip :: CharParser st a -> CharParser st [a]
-manySkip p = many (p << skips)
+import Debug.Trace
+parserTrace :: String -> CharParser st ()
+parserTrace s = pt <|> return ()
+    where
+        pt = try $ do
+           x <- try $ many1 anyToken
+           trace (s++": " ++ show x) $ try $ eof
+           fail (show x)
 
-{- | @many1Skip p@ parses 1 or more occurences of @p@ while skipping spaces
-(and comments) inbetween -}
-many1Skip :: CharParser st a -> CharParser st [a]
-many1Skip p = many1 (p << skips)
+parserTraced :: String -> CharParser st a -> CharParser st a
+parserTraced s p = do
+  parserTrace s
+  p <|> trace (s ++ " backtracked") (fail s)
 
-{- | @manyNSkip n p@ parses @n@ or more occurences of @p@ while skipping spaces
-(and comments) inbetween -}
-manyNSkip :: Int -> CharParser st a -> CharParser st [a]
-manyNSkip n p =
-    foldr (\ _ r -> (p << skips) <:> r) (return []) [1 .. n] <++>
-    many (p << skips)
 
 {- | @followedBy c p@ first parses @p@ then looks ahead for @c@. Doesn't consume
 any input on failure. -}
@@ -52,7 +45,13 @@ followedBy cond p = try $ do
 
 -- | Performs an arbitrary lookahead over choices of parsers
 arbitraryLookaheadOption :: [CharParser st a] -> CharParser st a
-arbitraryLookaheadOption p = lookAhead $ choice (try <$> p)
+arbitraryLookaheadOption p = try $ lookAhead $ choice p
+
+{- | @manyN n p@ parses @n@ or more occurences of @p@ -}
+manyN :: Int -> CharParser st a -> CharParser st [a]
+manyN n p =
+    foldr (\ _ r -> p <:> r) (return []) [1 .. n] <++>
+    many p
 
 -- | alias for @return Nothing@
 never :: CharParser st (Maybe a)
@@ -67,18 +66,13 @@ comment = try $ do
     manyTill anyChar newlineOrEof
 
 -- | Skips whitespaces and comments
-skips :: CharParser st ()
-skips = skipMany (forget space <|> forget comment <?> "")
-
--- | Skips whitespaces and comments preceeding a given parser
-skipsp :: CharParser st a -> CharParser st a
-skipsp d = skips >> d
+skips :: CharParser st a -> CharParser st a
+skips = (<< skipMany (forget space <|> forget comment <?> ""))
 
 
 -- | Parses plain string with skip
 keyword :: String -> CharParser st ()
-keyword s = do
-    skipsp $ try (string s >> notFollowedBy alphaNum)
+keyword s = try $ skips (string s >> notFollowedBy alphaNum)
 
 -- | Parses a full iri
 fullIri :: CharParser st IRI
@@ -93,7 +87,7 @@ ncNameChar c = isAlphaNum c || elem c ".+-_\183"
 
 -- | Parses a prefix name (PNAME_NS of SPARQL)
 prefix :: CharParser st String
-prefix = option "" (satisfy ncNameStart <:> many (satisfy ncNameChar))
+prefix = skips $ option "" (satisfy ncNameStart <:> many (satisfy ncNameChar))
     << char ':'
 
 {- | @expandIRI pm iri@ returns the expanded @iri@ with a declaration from @pm@.
@@ -111,7 +105,7 @@ expandIRI pm iri
 
 -- | Parses an abbreviated or full iri
 parseIRI :: GA.PrefixMap -> CharParser st IRI
-parseIRI pm = expandIRI pm <$> (fullIri <|?> compoundIriCurie) <?> "IRI"
+parseIRI pm = skips (expandIRI pm <$> (fullIri <|> compoundIriCurie) <?> "IRI")
 
 
 {- | @parseEnclosedWithKeyword k p@ parses the keyword @k@ followed @p@
@@ -119,20 +113,15 @@ enclosed in parentheses. Skips spaces and comments before and after @p@. -}
 parseEnclosedWithKeyword :: String -> CharParser st a -> CharParser st a
 parseEnclosedWithKeyword s p = do
     keyword s
-    skips
-    char '('
-    skips
-    r <- p
-    skips
-    char ')'
+    skips $ char '('
+    r <- skips p
+    skips $ char ')'
     return r
 
 parsePrefixDeclaration :: CharParser st PrefixDeclaration
 parsePrefixDeclaration = parseEnclosedWithKeyword "Prefix" $ do
     p <- prefix
-    skips
-    char '='
-    skips
+    skips $ char '='
     iri <- fullIri
     return $ PrefixDeclaration p iri
 
@@ -145,16 +134,16 @@ parseDirectlyImportsDocument pm =
 -- ## Entities
 parseEntity' :: GA.PrefixMap -> EntityType -> String -> CharParser st Entity
 parseEntity' pm t k = parseEnclosedWithKeyword k $ do
-    iri <- skipsp (parseIRI pm)
+    iri <- parseIRI pm
     return $ mkEntity t iri
 
 parseEntity :: GA.PrefixMap -> CharParser st Entity
 parseEntity pm =
-    parseEntity' pm Class "Class" <|?>
-    parseEntity' pm Datatype "Datatype" <|?>
-    parseEntity' pm ObjectProperty "ObjectProperty" <|?>
-    parseEntity' pm DataProperty "DataProperty" <|?>
-    parseEntity' pm AnnotationProperty "AnnotationProperty" <|?>
+    parseEntity' pm Class "Class" <|>
+    parseEntity' pm Datatype "Datatype" <|>
+    parseEntity' pm ObjectProperty "ObjectProperty" <|>
+    parseEntity' pm DataProperty "DataProperty" <|>
+    parseEntity' pm AnnotationProperty "AnnotationProperty" <|>
     parseEntity' pm NamedIndividual "NamedIndividual" <?>
     "Entity"
 
@@ -162,68 +151,62 @@ parseEntity pm =
 
 
 charOrEscaped :: CharParser st Char
-charOrEscaped = try (string "\\\"" >> return '"')
-            <|> try (string "\\\\" >> return '\\') <|> anyChar
+charOrEscaped = (try $ string "\\\"" >> return '"')
+            <|> (try $ string "\\\\" >> return '\\') <|> anyChar
 
-parseTypedLiteral :: GA.PrefixMap -> CharParser st Literal
-parseTypedLiteral pm = do
-    char '"'
-    s <- manyTill charOrEscaped (try $ char '"')
-    string "^^"
-    iri <- (parseIRI pm)
-    return $ Literal s (Typed iri)
+parseTypeSignature :: GA.PrefixMap -> CharParser st IRI
+parseTypeSignature pm = do
+    string "^^" 
+    parseIRI pm
 
 parseLanguageTag :: CharParser st String
 parseLanguageTag = do
     char '@'
-    many1 (letter <|?> char '-')
-
-parseUntypedLiteral :: CharParser st Literal
-parseUntypedLiteral = do
-    char '"'
-    s <- manyTill charOrEscaped (try $ char '"')
-    languageTag <- optionMaybe (try parseLanguageTag)
-    return $ Literal s (Untyped languageTag)
+    many1 (letter <|> char '-')
 
 parseLiteral :: GA.PrefixMap -> CharParser st Literal
-parseLiteral pm =
-    skipsp (parseTypedLiteral pm) <|?> skipsp parseUntypedLiteral <?> "Literal"
+parseLiteral pm = do
+    char '"'
+    s <- manyTill charOrEscaped (try $ char '"')
+    
+    typ <- (Typed <$> parseTypeSignature pm) <|>
+        (Untyped <$> optionMaybe parseLanguageTag)
+
+    return $ Literal s typ
 
 -- ## Individuals
 
 parseAnonymousIndividual :: GA.PrefixMap -> CharParser st AnonymousIndividual
-parseAnonymousIndividual pm =  expandIRI pm <$> iriCurie
+parseAnonymousIndividual pm =  skips $ expandIRI pm <$> iriCurie
 
 
 parseIndividual :: GA.PrefixMap -> CharParser st Individual
-parseIndividual pm = skipsp (parseIRI pm)
-    <|?> skipsp (parseAnonymousIndividual pm)
+parseIndividual pm = parseIRI pm
+    <|> parseAnonymousIndividual pm
     <?> "Individual"
 
 -- # Annotations
 parseAnnotationValue :: GA.PrefixMap -> CharParser st AnnotationValue
 parseAnnotationValue pm =
-     ((parseLiteral pm) >>= return . AnnValLit) <|?>
-     (skipsp (parseIRI pm) >>= return . AnnValue) <|?>
-     (skipsp (parseAnonymousIndividual pm) >>= return . AnnAnInd) <?>
+     (parseLiteral pm >>= return . AnnValLit) <|>
+     (parseIRI pm >>= return . AnnValue) <|>
+     (parseAnonymousIndividual pm >>= return . AnnAnInd) <?>
      "AnnotationValue"
 
 parseAnnotationSubject :: GA.PrefixMap -> CharParser st AnnotationSubject
 parseAnnotationSubject pm =
-    (AnnSubAnInd <$> skipsp (parseAnonymousIndividual pm)) <|?>
-    (AnnSubIri <$> skipsp (parseIRI pm))
+    (AnnSubAnInd <$> parseAnonymousIndividual pm) <|>
+    (AnnSubIri <$> parseIRI pm)
 
 parseAnnotations :: GA.PrefixMap -> CharParser st [Annotation]
-parseAnnotations pm = manySkip (parseAnnotation pm)
+parseAnnotations pm = many $ parseAnnotation pm
 
 parseAnnotation :: GA.PrefixMap -> CharParser st Annotation
 parseAnnotation pm = (flip (<?>)) "Annotation" $
     parseEnclosedWithKeyword "Annotation" $ do
-        an <- (manySkip (try (parseAnnotation pm)))
-        skips
+        an <- (many (parseAnnotation pm))
         property <- (parseIRI pm)
-        skips
-        v <- (parseAnnotationValue pm)
+        v <- parseAnnotationValue pm
         return $ Annotation an property v
 
 
@@ -232,11 +215,11 @@ parseAnnotation pm = (flip (<?>)) "Annotation" $
 parseDataJunction' ::
     GA.PrefixMap -> String -> JunctionType -> CharParser st DataRange
 parseDataJunction' pm k t = parseEnclosedWithKeyword k $
-    DataJunction t <$> manyNSkip 2 (parseDataRange pm)
+    DataJunction t <$> manyN 2 (parseDataRange pm)
 
 parseDataJunction :: GA.PrefixMap -> CharParser st DataRange
 parseDataJunction pm =
-    parseDataJunction' pm "DataUnionOf" UnionOf <|?>
+    parseDataJunction' pm "DataUnionOf" UnionOf <|>
     parseDataJunction' pm "DataIntersectionOf" IntersectionOf
 
 parseDataComplementOf :: GA.PrefixMap -> CharParser st DataRange
@@ -245,30 +228,29 @@ parseDataComplementOf pm = parseEnclosedWithKeyword "DataComplementOf" $
 
 parseDataOneOf :: GA.PrefixMap -> CharParser st DataRange
 parseDataOneOf pm = parseEnclosedWithKeyword "DataOneOf" $
-    DataOneOf <$> many1Skip (parseLiteral pm)
+    DataOneOf <$> many1 (parseLiteral pm)
 
 parseDatatypeResComponent ::
     GA.PrefixMap -> CharParser st (ConstrainingFacet, RestrictionValue)
 parseDatatypeResComponent pm =
     (,) <$>
-    skipsp (parseIRI pm) <*>
+    (parseIRI pm) <*>
     (parseLiteral pm)
 
 parseDatatypeRestriction :: GA.PrefixMap -> CharParser st DataRange
 parseDatatypeRestriction pm =
     parseEnclosedWithKeyword "DatatypeRestriction" $ do
         dataType <- (parseIRI pm)
-        skips
-        restrictions <- many1Skip (parseDatatypeResComponent pm)
+        restrictions <- many1 (parseDatatypeResComponent pm)
         return $ DataType dataType restrictions
 
 parseDataRange :: GA.PrefixMap -> CharParser st DataRange
 parseDataRange pm =
-    (parseDataJunction pm) <|?>
-    (parseDataComplementOf pm) <|?>
-    (parseDataOneOf pm) <|?>
-    (parseDatatypeRestriction pm) <|?>
-    (DataType <$> skipsp (parseIRI pm) <*> return []) <?>
+    (parseDataJunction pm) <|>
+    (parseDataComplementOf pm) <|>
+    (parseDataOneOf pm) <|>
+    (parseDatatypeRestriction pm) <|>
+    (DataType <$> (parseIRI pm) <*> return []) <?>
     "DataRange"
 
 {- # Axioms
@@ -277,8 +259,7 @@ parseDataRange pm =
 
 parseDeclaration :: GA.PrefixMap -> CharParser st Axiom
 parseDeclaration pm = parseEnclosedWithKeyword "Declaration" $ do
-    annotations <- manySkip (parseAnnotation pm)
-    skips
+    annotations <- many (parseAnnotation pm)
     entity <- (parseEntity pm)
     return $ Declaration annotations entity
 
@@ -286,11 +267,11 @@ parseDeclaration pm = parseEnclosedWithKeyword "Declaration" $ do
 
 parseObjectIntersectionOf :: GA.PrefixMap -> CharParser st ClassExpression
 parseObjectIntersectionOf pm = parseEnclosedWithKeyword "ObjectIntersectionOf" $
-    ObjectJunction IntersectionOf <$> manyNSkip 2 (parseClassExpression pm)
+    ObjectJunction IntersectionOf <$> manyN 2 (parseClassExpression pm)
 
 parseObjectUnionOf :: GA.PrefixMap -> CharParser st ClassExpression
 parseObjectUnionOf pm = parseEnclosedWithKeyword "ObjectUnionOf" $
-    ObjectJunction UnionOf <$> manyNSkip 2 (parseClassExpression pm)
+    ObjectJunction UnionOf <$> manyN 2 (parseClassExpression pm)
 
 parseObjectComplementOf :: GA.PrefixMap -> CharParser st ClassExpression
 parseObjectComplementOf pm = parseEnclosedWithKeyword "ObjectComplementOf" $
@@ -298,10 +279,10 @@ parseObjectComplementOf pm = parseEnclosedWithKeyword "ObjectComplementOf" $
 
 parseObjectOneOf :: GA.PrefixMap -> CharParser st ClassExpression
 parseObjectOneOf pm = parseEnclosedWithKeyword "ObjectOneOf" $
-    ObjectOneOf <$> many1Skip (parseIndividual pm)
+    ObjectOneOf <$> many1 (parseIndividual pm)
 
 parseObjectProperty :: GA.PrefixMap -> CharParser st ObjectPropertyExpression
-parseObjectProperty pm = ObjectProp <$> skipsp (parseIRI pm)
+parseObjectProperty pm = ObjectProp <$> (parseIRI pm)
 
 parseInverseObjectProperty ::
     GA.PrefixMap -> CharParser st ObjectPropertyExpression
@@ -311,7 +292,7 @@ parseInverseObjectProperty pm = parseEnclosedWithKeyword "ObjectInverseOf" $
 parseObjectPropertyExpression ::
     GA.PrefixMap -> CharParser st ObjectPropertyExpression
 parseObjectPropertyExpression pm =
-    (parseInverseObjectProperty pm) <|?>
+    (parseInverseObjectProperty pm) <|>
     (parseObjectProperty pm) <?>
     "ObjectPropertyExpression"
 
@@ -320,7 +301,6 @@ parseObjectSomeValuesFrom :: GA.PrefixMap -> CharParser st ClassExpression
 parseObjectSomeValuesFrom pm =
     parseEnclosedWithKeyword "ObjectSomeValuesFrom" $ do
         objectPropertyExpr <- (parseObjectPropertyExpression pm)
-        skips
         classExpr <- (parseClassExpression pm)
         return $ ObjectValuesFrom SomeValuesFrom objectPropertyExpr classExpr
 
@@ -328,14 +308,12 @@ parseObjectAllValuesFrom :: GA.PrefixMap -> CharParser st ClassExpression
 parseObjectAllValuesFrom pm =
     parseEnclosedWithKeyword "ObjectAllValuesFrom" $ do
         objectPropertyExpr <- (parseObjectPropertyExpression pm)
-        skips
         classExpr <- (parseClassExpression pm)
         return $ ObjectValuesFrom AllValuesFrom objectPropertyExpr classExpr
 
 parseObjectHasValue :: GA.PrefixMap -> CharParser st ClassExpression
 parseObjectHasValue pm = parseEnclosedWithKeyword "ObjectHasValue" $ do
     objectPropertyExpr <- (parseObjectPropertyExpression pm)
-    skips
     val <- (parseIndividual pm)
     return $ ObjectHasValue objectPropertyExpr val
 
@@ -349,17 +327,15 @@ parseCardinality' :: CardinalityType
                      -> CharParser st b
                      -> CharParser st (Cardinality a b)
 parseCardinality' c k pa pb = parseEnclosedWithKeyword k $ do
-    n <- value 10 <$> getNumber
-    skips
+    n <- skips $ value 10 <$> getNumber
     objectPropertyExpr <- pa
-    skips
-    classExpr <- optionMaybe (pb << skips)
+    classExpr <- optionMaybe pb
     return $ Cardinality c n objectPropertyExpr classExpr
 
 parseObjectCardinality :: GA.PrefixMap -> CharParser st ClassExpression
 parseObjectCardinality pm = ObjectCardinality <$> (
-        cardinality "ObjectMinCardinality" MinCardinality <|?>
-        cardinality "ObjectMaxCardinality" MaxCardinality <|?>
+        cardinality "ObjectMinCardinality" MinCardinality <|>
+        cardinality "ObjectMaxCardinality" MaxCardinality <|>
         cardinality "ObjectExactCardinality" ExactCardinality
     )
     where cardinality s t = parseCardinality' t s a b
@@ -368,8 +344,8 @@ parseObjectCardinality pm = ObjectCardinality <$> (
 
 parseDataCardinality :: GA.PrefixMap -> CharParser st ClassExpression
 parseDataCardinality pm = DataCardinality <$> (
-        cardinality "DataMinCardinality" MinCardinality <|?>
-        cardinality "DataMaxCardinality" MaxCardinality <|?>
+        cardinality "DataMinCardinality" MinCardinality <|>
+        cardinality "DataMaxCardinality" MaxCardinality <|>
         cardinality "DataExactCardinality" ExactCardinality
     )
     where cardinality s t = parseCardinality' t s a b
@@ -380,50 +356,46 @@ parseDataCardinality pm = DataCardinality <$> (
 parseDataSomeValuesFrom :: GA.PrefixMap -> CharParser st ClassExpression
 parseDataSomeValuesFrom pm = parseEnclosedWithKeyword "DataSomeValuesFrom" $ do
     exprs <- many1 (followedBy
-        (skipsp (parseDataRange pm))
-        (skipsp (parseIRI pm)))
-    skips
+        ((parseDataRange pm))
+        ((parseIRI pm)))
     range <- (parseDataRange pm)
     return $ DataValuesFrom SomeValuesFrom exprs range
 
 parseDataAllValuesFrom :: GA.PrefixMap -> CharParser st ClassExpression
 parseDataAllValuesFrom pm = parseEnclosedWithKeyword "DataAllValuesFrom" $ do
-    exprs <- many1 (followedBy (parseDataRange pm) (skipsp (parseIRI pm)))
-    skips
+    exprs <- many1 (followedBy (parseDataRange pm) ((parseIRI pm)))
     range <- (parseDataRange pm)
     return $ DataValuesFrom AllValuesFrom exprs range
 
 parseDataHasValue :: GA.PrefixMap -> CharParser st ClassExpression
 parseDataHasValue pm = parseEnclosedWithKeyword "DataHasValue" $
-    DataHasValue <$> skipsp (parseIRI pm) <*> (parseLiteral pm)
+    DataHasValue <$> (parseIRI pm) <*> (parseLiteral pm)
 
 
 parseClassExpression :: GA.PrefixMap -> CharParser st ClassExpression
 parseClassExpression pm =
-    (parseObjectIntersectionOf pm) <|?>
-    (parseObjectUnionOf pm) <|?>
-    (parseObjectComplementOf pm) <|?>
-    (parseObjectOneOf pm) <|?>
-    (parseObjectCardinality pm) <|?>
-    (parseObjectSomeValuesFrom pm) <|?>
-    (parseObjectAllValuesFrom pm) <|?>
-    (parseObjectHasValue pm) <|?>
-    (parseObjectHasSelf pm) <|?>
-    (parseDataSomeValuesFrom pm) <|?>
-    (parseDataAllValuesFrom pm) <|?>
-    (parseDataHasValue pm) <|?>
-    (parseDataCardinality pm) <|?>
-    (Expression <$> skipsp (parseIRI pm)) <?>
+    (parseObjectIntersectionOf pm) <|>
+    (parseObjectUnionOf pm) <|>
+    (parseObjectComplementOf pm) <|>
+    (parseObjectOneOf pm) <|>
+    (parseObjectCardinality pm) <|>
+    (parseObjectSomeValuesFrom pm) <|>
+    (parseObjectAllValuesFrom pm) <|>
+    (parseObjectHasValue pm) <|>
+    (parseObjectHasSelf pm) <|>
+    (parseDataSomeValuesFrom pm) <|>
+    (parseDataAllValuesFrom pm) <|>
+    (parseDataHasValue pm) <|>
+    (parseDataCardinality pm) <|>
+    (Expression <$> (parseIRI pm)) <?>
     "ClassExpression"
 
 -- ## Class Axioms
 
 parseSubClassOf :: GA.PrefixMap -> CharParser st ClassAxiom
 parseSubClassOf pm = parseEnclosedWithKeyword "SubClassOf" $ do
-    annotations <- manySkip (parseAnnotation pm)
-    skips
+    annotations <- many (parseAnnotation pm)
     subClassExpression <- (parseClassExpression pm)
-    skips
     superClassExpression <- (parseClassExpression pm)
     return $ SubClassOf annotations subClassExpression superClassExpression
 
@@ -431,26 +403,26 @@ parseEquivalentClasses :: GA.PrefixMap -> CharParser st ClassAxiom
 parseEquivalentClasses pm = parseEnclosedWithKeyword "EquivalentClasses" $
     EquivalentClasses <$>
     (parseAnnotations pm) <*>
-    manyNSkip 2 (parseClassExpression pm)
+    manyN 2 (parseClassExpression pm)
 
 parseDisjointClasses :: GA.PrefixMap -> CharParser st ClassAxiom
 parseDisjointClasses pm = parseEnclosedWithKeyword "DisjointClasses" $
     DisjointClasses <$>
     (parseAnnotations pm) <*>
-    manyNSkip 2 (parseClassExpression pm)
+    manyN 2 (parseClassExpression pm)
 
 parseDisjointUnion :: GA.PrefixMap -> CharParser st ClassAxiom
 parseDisjointUnion pm = parseEnclosedWithKeyword "DisjointUnion" $
     DisjointUnion <$>
     (parseAnnotations pm) <*>
-    skipsp (parseIRI pm) <*>
-    manyNSkip 2 (parseClassExpression pm)
+    (parseIRI pm) <*>
+    manyN 2 (parseClassExpression pm)
 
 parseClassAxiom :: GA.PrefixMap -> CharParser st Axiom
 parseClassAxiom pm = ClassAxiom <$> (
-        (parseSubClassOf pm) <|?>
-        (parseEquivalentClasses pm) <|?>
-        (parseDisjointClasses pm) <|?>
+        (parseSubClassOf pm) <|>
+        (parseEquivalentClasses pm) <|>
+        (parseDisjointClasses pm) <|>
         (parseDisjointUnion pm) <?> "ClassAxiom"
     )
 
@@ -462,7 +434,7 @@ parseEquivalentObjectProperties pm =
     parseEnclosedWithKeyword "EquivalentObjectProperties" $
     EquivalentObjectProperties <$>
     (parseAnnotations pm) <*>
-    manyNSkip 2 (parseObjectPropertyExpression pm)
+    manyN 2 (parseObjectPropertyExpression pm)
 
 parseDisjointObjectProperties ::
     GA.PrefixMap -> CharParser st ObjectPropertyAxiom
@@ -470,7 +442,7 @@ parseDisjointObjectProperties pm =
     parseEnclosedWithKeyword "DisjointObjectProperties" $
     DisjointObjectProperties <$>
     (parseAnnotations pm) <*>
-    manyNSkip 2 (parseObjectPropertyExpression pm)
+    manyN 2 (parseObjectPropertyExpression pm)
 
 parseObjectPropertyDomain :: GA.PrefixMap -> CharParser st ObjectPropertyAxiom
 parseObjectPropertyDomain pm =
@@ -504,12 +476,12 @@ parseObjectPropertyExpressionChain ::
     GA.PrefixMap -> CharParser st PropertyExpressionChain
 parseObjectPropertyExpressionChain pm =
     parseEnclosedWithKeyword "ObjectPropertyChain" $
-    manyNSkip 2 (parseObjectPropertyExpression pm)
+    manyN 2 (parseObjectPropertyExpression pm)
 
 parseSubObjectPropertyExpression ::
     GA.PrefixMap -> CharParser st SubObjectPropertyExpression
 parseSubObjectPropertyExpression pm =
-    SubObjPropExpr_exprchain <$> (parseObjectPropertyExpressionChain pm) <|?>
+    SubObjPropExpr_exprchain <$> (parseObjectPropertyExpressionChain pm) <|>
     SubObjPropExpr_obj <$> (parseObjectPropertyExpression pm) <?>
     "SubObjectPropertyExpression"
 
@@ -533,19 +505,19 @@ parseCOPA pm c s = parseEnclosedWithKeyword s $
 
 parseObjectPropertyAxiom :: GA.PrefixMap -> CharParser st Axiom
 parseObjectPropertyAxiom pm = ObjectPropertyAxiom <$> (
-        (parseSubObjectPropertyOf pm) <|?>
-        (parseEquivalentObjectProperties pm) <|?>
-        (parseDisjointObjectProperties pm) <|?>
-        (parseObjectPropertyDomain pm) <|?>
-        (parseObjectPropertyRange pm) <|?>
-        (parseInverseObjectProperties pm) <|?>
-        parseCOPA pm FunctionalObjectProperty "FunctionalObjectProperty" <|?>
+        (parseSubObjectPropertyOf pm) <|>
+        (parseEquivalentObjectProperties pm) <|>
+        (parseDisjointObjectProperties pm) <|>
+        (parseObjectPropertyDomain pm) <|>
+        (parseObjectPropertyRange pm) <|>
+        (parseInverseObjectProperties pm) <|>
+        parseCOPA pm FunctionalObjectProperty "FunctionalObjectProperty" <|>
         parseCOPA pm InverseFunctionalObjectProperty
-            "InverseFunctionalObjectProperty" <|?>
-        parseCOPA pm ReflexiveObjectProperty "ReflexiveObjectProperty" <|?>
-        parseCOPA pm IrreflexiveObjectProperty "IrreflexiveObjectProperty" <|?>
-        parseCOPA pm SymmetricObjectProperty "SymmetricObjectProperty" <|?>
-        parseCOPA pm AsymmetricObjectProperty "AsymmetricObjectProperty" <|?>
+            "InverseFunctionalObjectProperty" <|>
+        parseCOPA pm ReflexiveObjectProperty "ReflexiveObjectProperty" <|>
+        parseCOPA pm IrreflexiveObjectProperty "IrreflexiveObjectProperty" <|>
+        parseCOPA pm SymmetricObjectProperty "SymmetricObjectProperty" <|>
+        parseCOPA pm AsymmetricObjectProperty "AsymmetricObjectProperty" <|>
         parseCOPA pm TransitiveObjectProperty "TransitiveObjectProperty" <?>
         "ObjectPropertyAxiom"
     )
@@ -556,29 +528,29 @@ parseSubDataPropertyOf :: GA.PrefixMap -> CharParser st DataPropertyAxiom
 parseSubDataPropertyOf pm = parseEnclosedWithKeyword "SubDataPropertyOf" $
     SubDataPropertyOf <$>
     parseAnnotations pm <*>
-    skipsp (parseIRI pm) <*>
-    skipsp (parseIRI pm)
+    (parseIRI pm) <*>
+    (parseIRI pm)
 
 parseEquivalentDataProperties :: GA.PrefixMap -> CharParser st DataPropertyAxiom
 parseEquivalentDataProperties pm =
     parseEnclosedWithKeyword "EquivalentDataProperties" $
     EquivalentDataProperties <$>
     (parseAnnotations pm) <*>
-    manyNSkip 2 (parseIRI pm)
+    manyN 2 (parseIRI pm)
 
 parseDisjointDataProperties :: GA.PrefixMap -> CharParser st DataPropertyAxiom
 parseDisjointDataProperties pm =
     parseEnclosedWithKeyword "DisjointDataProperties" $
     DisjointDataProperties <$>
     parseAnnotations pm <*>
-    manyNSkip 2 (parseIRI pm)
+    manyN 2 (parseIRI pm)
 
 parseDataPropertyDomain :: GA.PrefixMap -> CharParser st DataPropertyAxiom
 parseDataPropertyDomain pm =
     parseEnclosedWithKeyword "DataPropertyDomain" $
     DataPropertyDomain <$>
     parseAnnotations pm <*>
-    skipsp (parseIRI pm) <*>
+    (parseIRI pm) <*>
     parseClassExpression pm
 
 parseDataPropertyRange :: GA.PrefixMap -> CharParser st DataPropertyAxiom
@@ -586,7 +558,7 @@ parseDataPropertyRange pm =
     parseEnclosedWithKeyword "DataPropertyRange" $
     DataPropertyRange <$>
     parseAnnotations pm <*>
-    skipsp (parseIRI pm) <*>
+    (parseIRI pm) <*>
     parseDataRange pm
 
 parseFunctionalDataProperty :: GA.PrefixMap -> CharParser st DataPropertyAxiom
@@ -594,15 +566,15 @@ parseFunctionalDataProperty pm =
     parseEnclosedWithKeyword "FunctionalDataProperty" $
     FunctionalDataProperty <$>
     parseAnnotations pm <*>
-    skipsp (parseIRI pm)
+    (parseIRI pm)
 
 parseDataPropertyAxiom :: GA.PrefixMap -> CharParser st Axiom
 parseDataPropertyAxiom pm = DataPropertyAxiom <$> (
-        parseSubDataPropertyOf pm <|?>
-        parseEquivalentDataProperties pm <|?>
-        parseDisjointDataProperties pm <|?>
-        parseDataPropertyDomain pm <|?>
-        parseDataPropertyRange pm <|?>
+        parseSubDataPropertyOf pm <|>
+        parseEquivalentDataProperties pm <|>
+        parseDisjointDataProperties pm <|>
+        parseDataPropertyDomain pm <|>
+        parseDataPropertyRange pm <|>
         parseFunctionalDataProperty pm <?>
         "DataPropertyAxiom"
     )
@@ -612,27 +584,24 @@ parseDataTypeDefinition :: GA.PrefixMap -> CharParser st Axiom
 parseDataTypeDefinition pm = parseEnclosedWithKeyword "DatatypeDefinition" $
     DatatypeDefinition <$>
     parseAnnotations pm <*>
-    skipsp (parseIRI pm) <*>
+    (parseIRI pm) <*>
     parseDataRange pm
+
+
+
+skipChar :: Char -> CharParser st ()
+skipChar = forget . skips . char
+
+parensP :: CharParser st a -> CharParser st a
+parensP = between (skipChar '(') (skipChar ')')
 
 -- ## HasKey
 parseHasKey :: GA.PrefixMap -> CharParser st Axiom
 parseHasKey pm = parseEnclosedWithKeyword "HasKey" $ do
     annotations <- (parseAnnotations pm)
-    skips
     classExpr <- (parseClassExpression pm)
-    skips
-    char '('
-    skips
-    objectPropertyExprs <- manySkip (parseObjectPropertyExpression pm)
-    skips
-    char ')'
-    skips
-    char '('
-    skips
-    dataPropertyExprs <- manySkip (parseIRI pm)
-    skips
-    char ')'
+    objectPropertyExprs <- parensP $ many (parseObjectPropertyExpression pm)
+    dataPropertyExprs <- parensP $ many (parseIRI pm)
     return $ HasKey annotations classExpr objectPropertyExprs dataPropertyExprs
 
 -- ## Assertion
@@ -640,13 +609,13 @@ parseSameIndividual :: GA.PrefixMap -> CharParser st Assertion
 parseSameIndividual pm = parseEnclosedWithKeyword "SameIndividual" $
     SameIndividual <$>
     (parseAnnotations pm) <*>
-    manyNSkip 2 (parseIndividual pm)
+    manyN 2 (parseIndividual pm)
 
 parseDifferentIndividuals :: GA.PrefixMap -> CharParser st Assertion
 parseDifferentIndividuals pm = parseEnclosedWithKeyword "DifferentIndividuals" $
     DifferentIndividuals <$>
     (parseAnnotations pm) <*>
-    manyNSkip 2 (parseIndividual pm)
+    manyN 2 (parseIndividual pm)
 
 parseClassAssertion :: GA.PrefixMap -> CharParser st Assertion
 parseClassAssertion pm = parseEnclosedWithKeyword "ClassAssertion" $
@@ -678,7 +647,7 @@ parseDataPropertyAssertion pm =
     parseEnclosedWithKeyword "DataPropertyAssertion" $
     DataPropertyAssertion <$>
     (parseAnnotations pm) <*>
-    skipsp (parseIRI pm) <*>
+    (parseIRI pm) <*>
     (parseIndividual pm) <*>
     (parseLiteral pm)
 
@@ -687,18 +656,18 @@ parseNegativeDataPropertyAssertion pm =
     parseEnclosedWithKeyword "NegativeDataPropertyAssertion" $
     NegativeDataPropertyAssertion <$>
     (parseAnnotations pm) <*>
-    skipsp (parseIRI pm) <*>
+    (parseIRI pm) <*>
     (parseIndividual pm) <*>
     (parseLiteral pm)
 
 parseAssertion :: GA.PrefixMap -> CharParser st Axiom
 parseAssertion pm = Assertion <$> (
-        (parseSameIndividual pm) <|?>
-        (parseDifferentIndividuals pm) <|?>
-        (parseClassAssertion pm) <|?>
-        (parseObjectPropertyAssertion pm) <|?>
-        (parseNegativeObjectPropertyAssertion pm) <|?>
-        (parseDataPropertyAssertion pm) <|?>
+        (parseSameIndividual pm) <|>
+        (parseDifferentIndividuals pm) <|>
+        (parseClassAssertion pm) <|>
+        (parseObjectPropertyAssertion pm) <|>
+        (parseNegativeObjectPropertyAssertion pm) <|>
+        (parseDataPropertyAssertion pm) <|>
         (parseNegativeDataPropertyAssertion pm)
     )
 
@@ -707,7 +676,7 @@ parseAnnotationAssertion :: GA.PrefixMap -> CharParser st AnnotationAxiom
 parseAnnotationAssertion pm = parseEnclosedWithKeyword "AnnotationAssertion" $
     AnnotationAssertion <$>
     (parseAnnotations pm) <*>
-    skipsp (parseIRI pm) <*>
+    (parseIRI pm) <*>
     (parseAnnotationSubject pm) <*>
     (parseAnnotationValue pm)
 
@@ -716,43 +685,45 @@ parseSubAnnotationPropertyOf pm =
     parseEnclosedWithKeyword "SubAnnotationPropertyOf" $
     SubAnnotationPropertyOf <$>
     (parseAnnotations pm) <*>
-    skipsp (parseIRI pm) <*>
-    skipsp (parseIRI pm)
+    (parseIRI pm) <*>
+    (parseIRI pm)
 
 parseAnnotationPropertyDomain :: GA.PrefixMap -> CharParser st AnnotationAxiom
 parseAnnotationPropertyDomain pm =
     parseEnclosedWithKeyword "AnnotationPropertyDomain" $
     AnnotationPropertyDomain <$>
     (parseAnnotations pm) <*>
-    skipsp (parseIRI pm) <*>
-    skipsp (parseIRI pm)
+    (parseIRI pm) <*>
+    (parseIRI pm)
 
 parseAnnotationPropertyRange :: GA.PrefixMap -> CharParser st AnnotationAxiom
 parseAnnotationPropertyRange pm =
     parseEnclosedWithKeyword "AnnotationPropertyRange" $
     AnnotationPropertyRange <$>
     (parseAnnotations pm) <*>
-    skipsp (parseIRI pm) <*>
-    skipsp (parseIRI pm)
+    (parseIRI pm) <*>
+    (parseIRI pm)
 
 parseAnnotationAxiom :: GA.PrefixMap -> CharParser st Axiom
 parseAnnotationAxiom pm = AnnotationAxiom <$> (
-        (parseAnnotationAssertion pm) <|?>
-        (parseSubAnnotationPropertyOf pm) <|?>
-        (parseAnnotationPropertyDomain pm) <|?>
+        (parseAnnotationAssertion pm) <|>
+        (parseSubAnnotationPropertyOf pm) <|>
+        (parseAnnotationPropertyDomain pm) <|>
         (parseAnnotationPropertyRange pm)
     )
 
 parseAxiom :: GA.PrefixMap -> CharParser st Axiom
 parseAxiom pm =
-    (parseDeclaration pm) <|?>
-    (parseClassAxiom pm) <|?>
-    (parseObjectPropertyAxiom pm) <|?>
-    (parseDataPropertyAxiom pm) <|?>
-    (parseDataTypeDefinition pm) <|?>
-    (parseHasKey pm) <|?>
-    (parseAssertion pm) <|?>
-    (parseAnnotationAxiom pm) <?>
+    (parseDeclaration pm) <|>
+    (parseClassAxiom pm) <|>
+    (parseObjectPropertyAxiom pm) <|>
+    (parseDataPropertyAxiom pm) <|>
+    (parseDataTypeDefinition pm) <|>
+    (parseHasKey pm) <|>
+    (parseAssertion pm) <|>
+    (parseAnnotationAxiom pm) <|>
+    ((lookAhead $ keyword "DLSafeRule") >>
+         fail "SWRL Rules aren't supported yet") <?>
     "Axiom"
 
 
@@ -768,14 +739,10 @@ parseOntology pm =
     in
         parseEnclosedWithKeyword "Ontology" $ do
         ontologyIri <- parseIriIfNotImportOrAxiomOrAnnotation
-        skips
         versionIri <- parseIriIfNotImportOrAxiomOrAnnotation
-        skips
-        imports <- manySkip (parseDirectlyImportsDocument pm)
-        skips
-        annotations <- manySkip (parseAnnotation pm)
-        skips
-        axioms <- manySkip (parseAxiom pm)
+        imports <- many (parseDirectlyImportsDocument pm)
+        annotations <- many (parseAnnotation pm)
+        axioms <- many (parseAxiom pm)
         return $ Ontology ontologyIri versionIri (imports) annotations axioms
 
 prefixFromMap :: GA.PrefixMap -> [PrefixDeclaration]
@@ -788,8 +755,7 @@ prefixToMap = fromList . map (\ (PrefixDeclaration name iri) -> (name, iri))
 -- | Parses an OntologyDocument from Owl2 Functional Syntax
 parseOntologyDocument :: GA.PrefixMap -> CharParser st OntologyDocument
 parseOntologyDocument gapm = do
-    prefixes <- manySkip parsePrefixDeclaration
-    skips
+    prefixes <- many parsePrefixDeclaration
     let pm = union gapm (prefixToMap prefixes)
     onto <- parseOntology pm
     return $ OntologyDocument (prefixFromMap pm) onto

--- a/OWL2/ParseAS.hs
+++ b/OWL2/ParseAS.hs
@@ -19,22 +19,6 @@ import Data.Map (union, toList, fromList, lookup)
 import Data.Maybe
 
 
-
-import Debug.Trace
-parserTrace :: String -> CharParser st ()
-parserTrace s = pt <|> return ()
-    where
-        pt = try $ do
-           x <- try $ many1 anyToken
-           trace (s++": " ++ show x) $ try $ eof
-           fail (show x)
-
-parserTraced :: String -> CharParser st a -> CharParser st a
-parserTraced s p = do
-  parserTrace s
-  p <|> trace (s ++ " backtracked") (fail s)
-
-
 {- | @followedBy c p@ first parses @p@ then looks ahead for @c@. Doesn't consume
 any input on failure. -}
 followedBy :: CharParser st b -> CharParser st a -> CharParser st a


### PR DESCRIPTION
The implementation of the OWL AS Parser heavily relies on `try`s. All of those that could be spared got removed and instead of skipping spaces at the beginning of a parser all parsers now skip spaces at the end.