### PR TITLE
1742 extend owl syntax to swrl rules

### DIFF
--- a/OWL2/AS.hs
+++ b/OWL2/AS.hs
@@ -609,6 +609,8 @@ data Axiom =
      [DataPropertyExpression]
   | Assertion Assertion
   | AnnotationAxiom AnnotationAxiom
+  | Rule Rule
+  | DGAxiom AxiomAnnotations DGName DGNodes DGEdges MainClasses
   deriving (Show, Eq, Ord, Typeable, Data)
 
 -- ClassAxiom
@@ -701,6 +703,53 @@ type SourceIndividual = Individual
 type TargetIndividual = Individual
 type TargetValue = Literal
 
+-- SWRL Rules
+
+data Rule = DLSafeRule AxiomAnnotations Body Head
+  | DGRule AxiomAnnotations DGBody DGHead 
+  deriving (Show, Eq, Ord, Data)
+type Body = Atom
+type Head = Atom
+type DGBody = DGAtom
+type DGHead = DGAtom
+
+data IndividualArg = IArg Individual | IndividualVar
+  deriving (Show, Eq, Ord, Data)
+data DataArg = DArg Literal | DataVar
+  deriving (Show, Eq, Ord, Data)
+
+type IndividualVar = Variable
+type DataVar = Variable
+type Variable = IRI
+
+data Atom = ClassAtom ClassExpression IndividualArg
+  | DataRangeAtom DataRange DataArg
+  | ObjectPropertyAtom ObjectPropertyExpression IndividualArg IndividualArg
+  | DataPropertyAtom DataProperty IndividualArg DataArg
+  -- At least one DataArg
+  | BuiltInAtom IRI [DataArg]
+  | SameIndividualAtom IndividualArg IndividualArg
+  | DifferentIndividualAtom IndividualArg IndividualArg
+  deriving (Show, Eq, Ord, Data)
+  
+data DGAtom = DGClassAtom ClassExpression IndividualArg
+  | DGObjectPropertyAtom ObjectPropertyExpression IndividualArg IndividualArg
+  deriving (Show, Eq, Ord, Data)
+
+type DGName = IRI
+-- At least one
+type DGNodes = [DGNodeAssertion]
+-- At least one
+type DGEdges = [DGEdgeAssertion]
+-- At least one
+type MainClasses = [Class]
+
+data DGNodeAssertion = DGNodeAssertion Class DGNode
+  deriving (Show, Eq, Ord, Data)
+type DGNode = IRI
+
+data DGEdgeAssertion = DGEdgeAssertion ObjectProperty DGNode DGNode
+  deriving (Show, Eq, Ord, Data)
 
 -- Root
 data OntologyDocument = OntologyDocument [PrefixDeclaration] Ontology

--- a/OWL2/AS.hs
+++ b/OWL2/AS.hs
@@ -722,6 +722,10 @@ type IndividualVar = Variable
 type DataVar = Variable
 type Variable = IRI
 
+-- | See `UnkownUnaryAtom`
+data UnkownArg = IndividualArg IndividualArg | DataArg DataArg | Variable Variable
+  deriving (Show, Eq, Ord, Data)
+
 data Atom = ClassAtom ClassExpression IndividualArg
   | DataRangeAtom DataRange DataArg
   | ObjectPropertyAtom ObjectPropertyExpression IndividualArg IndividualArg
@@ -730,6 +734,13 @@ data Atom = ClassAtom ClassExpression IndividualArg
   | BuiltInAtom IRI [DataArg]
   | SameIndividualAtom IndividualArg IndividualArg
   | DifferentIndividualsAtom IndividualArg IndividualArg
+
+{-|
+  Ambiguous predicates used in SWRL Rules which type cannot be inferred during parsing
+  This predicates get resolved and replaced with a specific one in static analysis.
+-}
+  | UnknownUnaryAtom IRI UnkownArg
+  | UnknownBinaryAtom IRI UnkownArg UnkownArg
   deriving (Show, Eq, Ord, Data)
   
 data DGAtom = DGClassAtom ClassExpression IndividualArg

--- a/OWL2/AS.hs
+++ b/OWL2/AS.hs
@@ -708,14 +708,14 @@ type TargetValue = Literal
 data Rule = DLSafeRule AxiomAnnotations Body Head
   | DGRule AxiomAnnotations DGBody DGHead 
   deriving (Show, Eq, Ord, Data)
-type Body = Atom
-type Head = Atom
-type DGBody = DGAtom
-type DGHead = DGAtom
+type Body = [Atom]
+type Head = [Atom]
+type DGBody = [DGAtom]
+type DGHead = [DGAtom]
 
-data IndividualArg = IArg Individual | IndividualVar
+data IndividualArg = IArg Individual | IVar IndividualVar
   deriving (Show, Eq, Ord, Data)
-data DataArg = DArg Literal | DataVar
+data DataArg = DArg Literal | DVar DataVar
   deriving (Show, Eq, Ord, Data)
 
 type IndividualVar = Variable
@@ -729,7 +729,7 @@ data Atom = ClassAtom ClassExpression IndividualArg
   -- At least one DataArg
   | BuiltInAtom IRI [DataArg]
   | SameIndividualAtom IndividualArg IndividualArg
-  | DifferentIndividualAtom IndividualArg IndividualArg
+  | DifferentIndividualsAtom IndividualArg IndividualArg
   deriving (Show, Eq, Ord, Data)
   
 data DGAtom = DGClassAtom ClassExpression IndividualArg

--- a/OWL2/AS.hs
+++ b/OWL2/AS.hs
@@ -706,7 +706,7 @@ type TargetValue = Literal
 -- SWRL Rules
 
 data Rule = DLSafeRule AxiomAnnotations Body Head
-  | DGRule AxiomAnnotations DGBody DGHead 
+  | DGRule AxiomAnnotations DGBody DGHead
   deriving (Show, Eq, Ord, Data)
 type Body = [Atom]
 type Head = [Atom]

--- a/OWL2/ParseAS.hs
+++ b/OWL2/ParseAS.hs
@@ -696,6 +696,110 @@ parseAnnotationAxiom pm = AnnotationAxiom <$> (
         (parseAnnotationPropertyRange pm)
     )
 
+parseIndividualArg :: GA.PrefixMap -> CharParser st IndividualArg
+parseIndividualArg pm =
+    IArg <$> parseAnonymousIndividual <|>
+    IVar <$> parseEnclosedWithKeyword "IndividualVariable" (parseIRI pm)
+
+
+parseDataArg :: GA.PrefixMap -> CharParser st DataArg
+parseDataArg pm =
+    DArg <$> parseLiteral <|>
+    DVar <$> parseEnclosedWithKeyword "LiteralVariable" (parseIRI pm)
+
+parseClassAtom :: GA.PrefixMap -> CharParser st Atom
+parseClassAtom pm = parseEnclosedWithKeyword "ClassAtom" $
+    ClassAtom <$> parseClassExpression pm <*> parseIndividualArg pm
+
+parseDataRangeAtom :: GA.PrefixMap -> CharParser st Atom
+parseDataRangeAtom pm = parseEnclosedWithKeyword "DataRangeAtom" $
+    DataRangeAtom <$> parseDataRange pm <*> parseDataArg pm
+
+parseObjectPropertyAtom :: GA.PrefixMap -> CharParser st Atom
+parseObjectPropertyAtom pm = parseEnclosedWithKeyword "ObjectPropertyAtom" $
+    ObjectPropertyAtom <$>
+        parseObjectPropertyExpression pm <*>
+        parseIndividualArg pm <*>
+        parseIndividualArg pm
+
+parseDataPropertyAtom :: GA.PrefixMap -> CharParser st Atom
+parseDataPropertyAtom pm = parseEnclosedWithKeyword "DataPropertyAtom" $
+    DataPropertyAtom <$>
+        parseIRI pm <*>
+        parseIndividualArg pm <*>
+        parseDataArg pm
+
+parseBuiltInAtom :: GA.PrefixMap -> CharParser st Atom
+parseBuiltInAtom pm = parseEnclosedWithKeyword "BuiltInAtom" $
+    BuiltInAtom <$> parseIRI pm <*> many1 (parseDataArg pm)
+
+parseSameIndividualAtom :: GA.PrefixMap -> CharParser st Atom
+parseSameIndividualAtom pm = parseEnclosedWithKeyword "SameIndividualAtom" $
+    SameIndividualAtom <$> parseIndividualArg pm <*> parseIndividualArg pm
+
+parseDifferentIndividualsAtom :: GA.PrefixMap -> CharParser st Atom
+parseDifferentIndividualsAtom pm = parseEnclosedWithKeyword "DifferentIndividualsAtom" $
+    DifferentIndividualsAtom <$> parseIndividualArg pm <*> parseIndividualArg pm
+
+parseAtom :: GA.PrefixMap -> CharParser st Atom
+parseAtom pm =
+    parseClassAtom pm <|>
+    parseDataRangeAtom pm <|>
+    parseObjectPropertyAtom <|>
+    parseDataPropertyAtom <|>
+    parseBuiltInAtom <|>
+    parseSameIndividualAtom <|>
+    parseDifferentIndividualsAtom <?>
+    "Atom"
+
+parseBody :: GA.PrefixMap -> CharParser st Body
+parseBody pm = do
+    parseEnclosedWithKeyword "Body" $ many (parseAtom pm)
+
+parseHead :: GA.PrefixMap -> CharParser st Body
+parseHead pm = do
+    parseEnclosedWithKeyword "Head" $ many (parseAtom pm)
+
+parseDLSafeRule :: GA.PrefixMap -> CharParser st Rule
+parseDLSafeRule pm = parseEnclosedWithKeyword "DLSafeRule" $
+    DLSafeRule <$>
+        parseAnnotations pm <*>
+        parseBody pm <*>
+        parseHead pm
+
+
+parseDGClassAtom  :: GA.PrefixMap -> CharParser st DGAtom
+parseDGClassAtom pm = parseEnclosedWithKeyword "ClassAtom" $
+    DGClassAtom <$> parseClassExpression pm <*> parseIndividualArg pm
+
+parseDGObjectPropertyAtom :: GA.PrefixMap -> CharParser st DGAtom
+parseDGObjectPropertyAtom pm = parseEnclosedWithKeyword "ObjectPropertyAtom" $
+    DGObjectPropertyAtom <$>
+        parseObjectPropertyExpression pm <*>
+        parseIndividualArg pm <*>
+        parseIndividualArg
+
+-- TODO: Parse DGAxiom
+
+parseDGAtom :: GA.PrefixMap -> CharParser st DGAtom
+parseDGAtom pm = parseDGClassAtom pm <|> parseDGObjectPropertyAtom pm
+
+parseDGBody :: GA.PrefixMap -> CharParser st Rule
+parseDGBody pm = parseEnclosedWithKeyword "Body" $ many (parseDGAtom pm)
+
+parseDGHead :: GA.PrefixMap -> CharParser st Rule
+parseDGHead pm = parseEnclosedWithKeyword "Head" $ many (parseDGAtom pm)
+
+parseDGRule :: GA.PrefixMap -> CharParser st Rule
+parseDGRule pm = parseEnclosedWithKeyword "DescriptionGraphRule" $ 
+    DGRule <$>
+        parseAnnotations pm <*>
+        parseDGBody pm <*>
+        parseDGHead pm
+
+parseRule :: GA.PrefixMap -> CharParser st Rule
+parseRule pm = parseDLSafeRule pm <|> parseDGRule pm
+
 parseAxiom :: GA.PrefixMap -> CharParser st Axiom
 parseAxiom pm =
     (parseDeclaration pm) <|>
@@ -706,8 +810,7 @@ parseAxiom pm =
     (parseHasKey pm) <|>
     (parseAssertion pm) <|>
     (parseAnnotationAxiom pm) <|>
-    ((lookAhead $ keyword "DLSafeRule") >>
-         fail "SWRL Rules aren't supported yet") <?>
+    (parseRule) <?>
     "Axiom"
 
 

--- a/OWL2/ParseAS.hs
+++ b/OWL2/ParseAS.hs
@@ -698,16 +698,16 @@ parseAnnotationAxiom pm = AnnotationAxiom <$> (
 
 parseIndividualArg :: GA.PrefixMap -> CharParser st IndividualArg
 parseIndividualArg pm =
-    IArg <$> parseAnonymousIndividual pm <|>
-    -- Apparently the keyword is "Variable" instead of "IndividualVariable"
-    IVar <$> parseEnclosedWithKeyword "Variable" (parseIRI pm)
+        -- Apparently the keyword is "Variable" instead of "IndividualVariable"
+    IVar <$> parseEnclosedWithKeyword "Variable" (parseIRI pm) <|>
+    IArg <$> parseAnonymousIndividual pm
 
 
 parseDataArg :: GA.PrefixMap -> CharParser st DataArg
 parseDataArg pm =
-    DArg <$> parseLiteral pm <|>
     -- Apparently the keyword is "Literal" instead of "LiteralVariable"
-    DVar <$> parseEnclosedWithKeyword "Variable" (parseIRI pm)
+    DVar <$> parseEnclosedWithKeyword "Variable" (parseIRI pm) <|>
+    DArg <$> parseLiteral pm
 
 parseClassAtom :: GA.PrefixMap -> CharParser st Atom
 parseClassAtom pm = parseEnclosedWithKeyword "ClassAtom" $

--- a/OWL2/ParseAS.hs
+++ b/OWL2/ParseAS.hs
@@ -699,13 +699,15 @@ parseAnnotationAxiom pm = AnnotationAxiom <$> (
 parseIndividualArg :: GA.PrefixMap -> CharParser st IndividualArg
 parseIndividualArg pm =
     IArg <$> parseAnonymousIndividual pm <|>
-    IVar <$> parseEnclosedWithKeyword "IndividualVariable" (parseIRI pm)
+    -- Apparently the keyword is "Variable" instead of "IndividualVariable"
+    IVar <$> parseEnclosedWithKeyword "Variable" (parseIRI pm)
 
 
 parseDataArg :: GA.PrefixMap -> CharParser st DataArg
 parseDataArg pm =
     DArg <$> parseLiteral pm <|>
-    DVar <$> parseEnclosedWithKeyword "LiteralVariable" (parseIRI pm)
+    -- Apparently the keyword is "Literal" instead of "LiteralVariable"
+    DVar <$> parseEnclosedWithKeyword "Variable" (parseIRI pm)
 
 parseClassAtom :: GA.PrefixMap -> CharParser st Atom
 parseClassAtom pm = parseEnclosedWithKeyword "ClassAtom" $


### PR DESCRIPTION
Abstract / Functional Syntax according to https://www.cs.ox.ac.uk/files/2445/rulesyntaxTR.pdf implemented.