### PR TITLE
1742 extend owl ms syntax to swrl rules

### DIFF
--- a/OWL2/ColonKeywords.hs
+++ b/OWL2/ColonKeywords.hs
@@ -47,7 +47,8 @@ colonKeywords =
   , subClassOfC
   , subPropertyChainC
   , subPropertyOfC
-  , typesC ]
+  , typesC
+  , ruleC ]
 
 namespaceC :: String
 namespaceC = "Namespace:"
@@ -153,3 +154,6 @@ disjointPropertiesC = "DisjointProperties:"
 
 equivalentPropertiesC :: String
 equivalentPropertiesC = "EquivalentProperties:"
+
+ruleC :: String
+ruleC = "Rule:"

--- a/OWL2/ParseMS.hs
+++ b/OWL2/ParseMS.hs
@@ -841,8 +841,8 @@ parseBuiltInAtom pm pred =
     argN <- sepByComma $ parseDArg pm
     return $ BuiltInAtom pred (arg1 : arg2 : argN)) <|>
   (do -- first arg a literal, at least two arguments
-  arg1 <- DArg <$> literal pm
-  commaP
+    arg1 <- DArg <$> literal pm
+    commaP
     argN <- sepByComma (parseDArg pm)
     return $ BuiltInAtom pred (arg1 : argN))
 
@@ -864,14 +864,12 @@ parseAtom pm =  parseClassExprAtom pm <|>
   parseSameIndividualsAtom pm <|>
   parseDifferentIndividualsAtom pm <|> do
     pred <- expUriP pm
-    parensP (
-      try (parseClassAtom pm pred) <|>
-      -- parseDataRangeAtom pm pred <|>
-      try (parseObjectPropertyAtom pm pred) <|>
-      try (parseDataPropertyAtom pm pred) <|>
-      try (parseBuiltInAtom pm pred) <|>
-      parseUnknownAtom pm pred <?>
-      "Rule Atom")
+    choice $ map (try . parensP) [
+      (parseClassAtom pm pred),
+      (parseObjectPropertyAtom pm pred),
+      (parseDataPropertyAtom pm pred),
+      (parseBuiltInAtom pm pred),
+      parseUnknownAtom pm pred]
 
 parseRule :: GA.PrefixMap -> CharParser st Axiom
 parseRule pm = do

--- a/OWL2/ParseMS.hs
+++ b/OWL2/ParseMS.hs
@@ -762,7 +762,7 @@ misc pm =
 -}
 
 parseVariable :: GA.PrefixMap -> CharParser st Variable
-parseVariable pm = do 
+parseVariable pm = optParensP $ do 
   char '?'
   expUriP pm
 

--- a/OWL2/ParseMS.hs
+++ b/OWL2/ParseMS.hs
@@ -781,7 +781,7 @@ parseClassExprAtom pm = do
 -- identified as such during parsing is if iArg is an individual. If it is a Variable
 -- it could also be a DataRangeAtom.
 parseClassAtom :: GA.PrefixMap -> IRI -> CharParser st Atom
-parseClassAtom pm pred = ClassAtom (Expression pred) <*>
+parseClassAtom pm pred = ClassAtom (Expression pred) <$>
   (IArg <$> parseNoVariable (expUriP pm))
 
 -- Cannot be distinguished from built in atoms with one argument

--- a/OWL2/ParseMS.hs
+++ b/OWL2/ParseMS.hs
@@ -754,8 +754,7 @@ parseClassExprAtom pm = do
 -- identified as such during parsing is if iArg is an individual. If it is a Variable
 -- it could also be a DataRangeAtom.
 parseClassAtom :: GA.PrefixMap -> IRI -> CharParser st Atom
-parseClassAtom pm pred = ClassAtom <$> 
-  return (Expression pred) <*>
+parseClassAtom pm pred = ClassAtom (Expression pred) <*>
   (IArg <$> expUriP pm)
 
 -- Cannot be distinguished from built in atoms with one argument


### PR DESCRIPTION
Extended OWL MS Parser to parse SWRL Rules. Closes #1742.  However, there are ambiguities which get parsed to `OWL2.AS.UnkownUnaryAtom` and `OWL2.AS.UnkownBinaryAtom`. The following table indicates all possible combinations of predicates and arguments. If there is more than one possible construct, the syntax is ambiguous:
syntax | possible constructs
---|---
`<predicate>(<iri>)`                 | ClassAtom
`<predicate>(<literal>)`             | DataRangeAtom, BuiltInAtom
`<predicate>(?<var>)`                | ClassAtom, DataRangeAtom, BuiltInAtom
`<predicate>(<iri>, <iri>)`          | ObjectPropertyAtom
`<predicate>(<literal>, <iri>)`      | -invalid-
`<predicate>(?<var>, <iri>)`         | ObjectPropertyAtom
`<predicate>(<iri>, <literal>)`      | DataPropertyAtom
`<predicate>(<literal>, <literal>)`  | BuiltInAtom
`<predicate>(?<var>, <literal>)`     | ObjectPropertyAtom, DataPropertyAtom
`<predicate>(<iri>, ?<var>)`         | ObjectPropertyAtom, DataPropertyAtom
`<predicate>(<literal>, ?<var>)`     | BuiltInAtom
`<predicate>(?<var>, ?<var>)`        | ObjectPropertyAtom, DataPropertyAtom, BuiltInAtom
`<predicate>(<any>, <any>, <any>, ...)` | BuiltInAtom