### PR TITLE
Fixing iri formatting and owl2 static analysis

### DIFF
--- a/Common/IRI.hs
+++ b/Common/IRI.hs
@@ -862,9 +862,13 @@ iriToStringAbbrev (IRI { prefixName = pname
                        , iriPath = aPath
                        , iriQuery = aQuery
                        , iriFragment = aFragment
+                       , iFragment = aIFragment
                        }) =
   let pref = if null pname then "" else pname ++ ":" in
-  (pref ++) . (show aPath ++) . (aQuery ++) . (aFragment ++)
+    if null aIFragment then
+      (pref ++) . (show aPath ++) . (aQuery ++) . (aFragment ++)
+    else
+      (pref ++) . (aIFragment ++)
 
 iriToStringAbbrevMerge :: IRI -> ShowS
 iriToStringAbbrevMerge (IRI { iriPath = aPath

--- a/OWL2/PrintAS.hs
+++ b/OWL2/PrintAS.hs
@@ -20,6 +20,8 @@ printIRI :: GA.PrefixMap -> IRI -> Doc
 printIRI pds iri
     | isAbbrev iri && prefName `M.member` pds
         = text (prefName ++ ":" ++ (iFragment iri))
+    
+    | isAbbrev iri && null prefName = (text ":") <> pretty iri  
 
     | otherwise = pretty iri
   where prefName = prefixName iri

--- a/OWL2/PrintMS.hs
+++ b/OWL2/PrintMS.hs
@@ -1827,7 +1827,7 @@ printIRI :: GA.PrefixMap -> IRI -> Doc
 printIRI pds iri
     | isAbbrev iri && prefName `M.member` pds
         = text (prefName ++ ":" ++ (iFragment iri))
-
+    | isAbbrev iri && null prefName = (text ":") <> pretty iri
     | otherwise = pretty iri
   where prefName = prefixName iri
 

--- a/OWL2/StaticAnalysis.hs
+++ b/OWL2/StaticAnalysis.hs
@@ -96,12 +96,12 @@ checkObjPropList s ol = do
     unless (and ls) $ fail $ "undeclared object properties:\n" ++
                       showDoc (map (\o -> case o of
                                      AS.ObjectProp _ -> o
-                                     AS.ObjectInverseOf x -> x) ol) ""
+                                     AS.ObjectInverseOf x -> x) (filter (not . isDeclObjProp s) ol)) ""
 
 checkDataPropList :: Sign -> [AS.DataPropertyExpression] -> Result ()
 checkDataPropList s dl = do
     let ls = map (isDeclDataProp s) dl
-    unless (and ls) $ fail $ "undeclared data properties:\n" ++ showDoc dl ""
+    unless (and ls) $ fail $ "undeclared data properties:\n" ++ showDoc (filter (not . isDeclDataProp s) dl) ""
 
 -- | checks if a DataRange is valid
 checkDataRange :: Sign -> AS.DataRange -> Result ()


### PR DESCRIPTION
- Fixed `iriToStringAbbrev` (therefore also `instance Show IRI`) to show an abbreviated IRI only with `prefixName` and `iFragement` as those properties hold all information using the extended data type of #1996  .
- Adjusted OWL2 printers to print the empty prefix if abbreviated
- Adjusted check for predefined prefixes using the extended data type of #1996 
- Fixed OWL2.StaticAnalysis to report only the Object- or DataPropertyExpressions that are not declared when checking for a list