### PR TITLE
remove majority of warnings

### DIFF
--- a/ATC/Grothendieck.der.hs
+++ b/ATC/Grothendieck.der.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE UndecidableInstances, FlexibleInstances, OverlappingInstances #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE FlexibleInstances #-}
 {- |
 Module      :  ./ATC/Grothendieck.der.hs
 Description :  manually created ShATermConvertible instances
@@ -23,7 +24,6 @@ import ATerm.Conversion
 import Common.AS_Annotation
 import Common.GlobalAnnotations
 import Common.Lib.Graph
-import Common.LibName
 import Common.OrderedMap
 import qualified Common.Lib.SizedList as SizedList
 import Common.Result
@@ -81,7 +81,7 @@ fromShATermLG' lg i att = case getATerm' i att of
                (attN, t) -> (setATerm' i t attN, t)
 
 -- generic undecidable instance
-instance (ShATermConvertible a, Typeable a) => ShATermLG a where
+instance {-# OVERLAPS #-} (ShATermConvertible a, Typeable a) => ShATermLG a where
   toShATermLG = toShATermAux
   fromShATermLG _ = fromShATermAux
 
@@ -288,7 +288,7 @@ instance (ShATermLG a) => ShATermLG (Maybe a) where
                     (att1, Just a') }
             u -> fromShATermError "Prelude.Maybe" u
 
-instance ShATermLG a => ShATermLG [a] where
+instance {-# OVERLAPS #-} ShATermLG a => ShATermLG [a] where
    toShATermLG att ts = do
            (att2, inds) <- foldM (\ (att0, l) t -> do
                     (att1, i) <- toShATermLG' att0 t

--- a/Adl/Logic_Adl.hs
+++ b/Adl/Logic_Adl.hs
@@ -34,7 +34,7 @@ import Common.DocUtils
 
 import Control.Monad
 import qualified Data.Map as Map
-import Data.Monoid
+import Data.Monoid ()
 
 import Logic.Logic
 

--- a/CASL/Logic_CASL.hs
+++ b/CASL/Logic_CASL.hs
@@ -57,7 +57,7 @@ import Common.ProofTree
 import Common.Consistency
 import Common.DocUtils
 
-import Data.Monoid
+import Data.Monoid ()
 import qualified Data.Set as Set
 
 import Logic.Logic

--- a/CSL/Logic_CSL.hs
+++ b/CSL/Logic_CSL.hs
@@ -34,7 +34,7 @@ import CSL.Symbol
 import CSL.Tools
 
 import qualified Data.Map as Map
-import Data.Monoid
+import Data.Monoid ()
 
 import Logic.Logic
 

--- a/CSMOF/Logic_CSMOF.hs
+++ b/CSMOF/Logic_CSMOF.hs
@@ -21,7 +21,7 @@ import Logic.Logic
 
 import Common.DefaultMorphism
 
-import Data.Monoid
+import Data.Monoid ()
 
 data CSMOF = CSMOF deriving Show
 

--- a/Common/Doc.hs
+++ b/Common/Doc.hs
@@ -270,14 +270,6 @@ renderExtText stripCs ga =
 instance Show Doc where
     show = renderText emptyGlobalAnnos
 
-removeTrailingSpaces :: Int -> String -> String
-removeTrailingSpaces n s = case s of
-  "" -> ""
-  c : r -> case c of
-    ' ' -> removeTrailingSpaces (n + 1) r
-    _ -> (if c == '\n' then "" else replicate n ' ')
-         ++ c : removeTrailingSpaces 0 r
-
 renderHtml :: GlobalAnnos -> Doc -> String
 renderHtml = renderExtHtml (StripComment False) $ MkLabel False
 

--- a/Common/IRI.hs
+++ b/Common/IRI.hs
@@ -95,13 +95,13 @@ import Data.Map as Map (Map, lookup)
 import Data.Maybe
 import Data.List
 
-import Control.Monad (when)
+-- import Control.Monad (when)
 
 import Common.Id as Id
 import Common.Lexer
 import Common.Parsec
 import Common.Percent
-import Common.Token (mixId, comps)
+import Common.Token (comps)
 
 -- * The IRI datatype
 
@@ -268,14 +268,14 @@ isNullIRI :: IRI -> Bool
 isNullIRI i = i == nullIRI
 
 -- | set the Range attribute of IRIs
-setIRIRange :: Range -> IRI -> IRI
-setIRIRange r i = i { iriPos = r }
+-- setIRIRange :: Range -> IRI -> IRI
+-- setIRIRange r i = i { iriPos = r }
 
 -- | checks if a string (bound to be localPart of an IRI) contains \":\/\/\"
-cssIRI :: String -> String
-cssIRI i 
-  | isInfixOf "://" i = "Full"
-  | otherwise = "Abbreviated"
+-- cssIRI :: String -> String
+-- cssIRI i
+--   | isInfixOf "://" i = "Full"
+--   | otherwise = "Abbreviated"
 
 iRIRange :: IRI -> [Pos]
 iRIRange i = let Range rs = iriPos i in case rs of
@@ -439,14 +439,14 @@ curie = iriWithPos $ do
     pn <- option "" $ try (do
         n <- option "" ncname 
                               
-        c <- string ":"
+        _ <- string ":"
         return $ n -- ++ c Don't add the colon to the prefix!
       )
     i <- referenceAux False
     return nullIRI { prefixName = pn, iFragment = iriToString id i $ [], isAbbrev = True }
 
-reference :: IRIParser st IRI
-reference = referenceAux True
+-- reference :: IRIParser st IRI
+-- reference = referenceAux True
 
 dolChar :: IRIParser st String
 dolChar = ucharAux True "@:"
@@ -695,31 +695,31 @@ iisegment-nz-nc = 1*( iunreserved / pct-encoded / sub-delims
 {- iipchar         = iunreserved / pct-encoded / sub-delims / ":"
 / "@" -}
 
-idParser :: IRIParser st Id
-idParser = mixId ([],[]) ([],[]) 
+-- idParser :: IRIParser st Id
+-- idParser = mixId ([],[]) ([],[])
 
 ipathAbEmpty :: IRIParser st Id
 ipathAbEmpty = do
   s <- flat $ many slashIsegment
   return $ stringToId s
 
-ipathAbEmpty1 :: Bool -> IRIParser st Id
-ipathAbEmpty1 slash = do
-  when slash $ do char '/'; return ()
-  si <- isegmentorId "/"
-  case si of
-    Left s ->     do char '/'
-                     i <- ipathAbEmpty1 False
-                     return $ prependString s i
-              <|> do return $ stringToId ""  
-    Right i -> return i
+-- ipathAbEmpty1 :: Bool -> IRIParser st Id
+-- ipathAbEmpty1 slash = do
+--   when slash $ do char '/'; return ()
+--   si <- isegmentorId "/"
+--   case si of
+--     Left s ->     do char '/'
+--                      i <- ipathAbEmpty1 False
+--                      return $ prependString s i
+--               <|> do return $ stringToId ""
+--     Right i -> return i
 
-isegmentorId :: String -> IRIParser st (Either String Id)
-isegmentorId lead =
-      do s <- isegment
-         return (Left ('/':s))
---  <|> do id <- idParser
---         return (Right (prependString "/" id))
+-- isegmentorId :: String -> IRIParser st (Either String Id)
+-- isegmentorId lead =
+--       do s <- isegment
+--          return (Left ('/':s))
+-- --  <|> do id <- idParser
+-- --         return (Right (prependString "/" id))
   
 ipathAbs :: IRIParser st Id
 ipathAbs = do

--- a/Common/Json.hs
+++ b/Common/Json.hs
@@ -230,5 +230,5 @@ myDataToJson md =
 class ToJson a where
   asJson :: a -> Json
 
-instance Data a => ToJson a where
+instance {-# OVERLAPPABLE #-} Data a => ToJson a where
   asJson = myDataToJson . normalizeMyDataForSerialization . dataToMyData

--- a/Common/Lib/Maybe.hs
+++ b/Common/Lib/Maybe.hs
@@ -15,7 +15,7 @@ and only contains the Monad instance for the newtype MaybeT m.
 
 module Common.Lib.Maybe (MaybeT (..), liftToMaybeT) where
 
-import Control.Applicative
+import Control.Applicative ()
 import Control.Monad
 
 -- | A monad transformer which adds Maybe semantics to an existing monad.

--- a/Common/Lib/Pretty.hs
+++ b/Common/Lib/Pretty.hs
@@ -218,7 +218,7 @@ module Common.Lib.Pretty (
 
 
 import Prelude
-import Data.Monoid ( Monoid (mempty, mappend) )
+import Data.Monoid ( Monoid (mempty) )
 import Data.String ( IsString (fromString) )
 
 infixl 6 <+>

--- a/Common/Lib/State.hs
+++ b/Common/Lib/State.hs
@@ -17,7 +17,7 @@ Control.Monad.State, but now Control.Monad.Trans.State can be used instead.
 
 module Common.Lib.State where
 
-import Control.Applicative
+import Control.Applicative ()
 import Control.Monad
 
 -- | Our fixed state monad

--- a/Common/ResultT.hs
+++ b/Common/ResultT.hs
@@ -14,7 +14,7 @@ Portability :  portable
 module Common.ResultT where
 
 import Common.Result
-import Control.Applicative
+import Control.Applicative ()
 import Control.Monad
 import qualified Control.Monad.Fail as MFail
 import Control.Monad.Trans
@@ -52,7 +52,6 @@ instance MonadTrans ResultT where
 -- | Inspired by the MonadIO-class
 class Monad m => MonadResult m where
     liftR :: Result a -> m a
-
 
 instance Monad m => MonadResult (ResultT m) where
     liftR = ResultT . return

--- a/Common/ToXml.hs
+++ b/Common/ToXml.hs
@@ -88,5 +88,5 @@ myDataToXml d =
 class ToXml a where
   asXml :: a -> Element
 
-instance Data a => ToXml a where
+instance {-# OVERLAPPABLE #-} Data a => ToXml a where
   asXml = myDataToXml . normalizeMyDataForSerialization . dataToMyData

--- a/CommonLogic/Logic_CommonLogic.hs
+++ b/CommonLogic/Logic_CommonLogic.hs
@@ -33,7 +33,7 @@ import CommonLogic.OMDoc
 import CommonLogic.Sublogic
 
 import qualified Data.Map as Map
-import Data.Monoid
+import Data.Monoid ()
 
 import Logic.Logic
 

--- a/Comorphisms/ExtModal2OWL.hs
+++ b/Comorphisms/ExtModal2OWL.hs
@@ -19,7 +19,6 @@ import Common.ProofTree
 
 -- OWL = codomain
 import OWL2.Logic_OWL2
-import Common.IRI
 import OWL2.AS
 import OWL2.ProfilesAndSublogics
 import OWL2.ManchesterPrint ()

--- a/Comorphisms/SuleCFOL2TPTP.hs
+++ b/Comorphisms/SuleCFOL2TPTP.hs
@@ -49,8 +49,6 @@ import TPTP.Sign as TSign
 import TPTP.Logic_TPTP
 import TPTP.Sublogic
 
-import qualified Comorphisms.SuleCFOL2SoftFOL as CASL2SoftFOL
-
 data TPTP_FOF = TPTP_FOF
 
 instance Show TPTP_FOF where

--- a/DFOL/Logic_DFOL.hs
+++ b/DFOL/Logic_DFOL.hs
@@ -18,7 +18,7 @@ module DFOL.Logic_DFOL where
 
 import Common.Result
 
-import Data.Monoid
+import Data.Monoid ()
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import Control.Monad (unless)

--- a/DMU/Logic_DMU.hs
+++ b/DMU/Logic_DMU.hs
@@ -30,7 +30,7 @@ import ATerm.Lib
 import Text.ParserCombinators.Parsec
 
 import Data.List
-import Data.Monoid
+import Data.Monoid ()
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import Data.Typeable

--- a/Framework/Logic_Framework.hs
+++ b/Framework/Logic_Framework.hs
@@ -26,7 +26,7 @@ import Framework.ATC_Framework ()
 
 import Logic.Logic
 
-import Data.Monoid
+import Data.Monoid ()
 
 import Common.DefaultMorphism
 

--- a/GUI/GtkUtils.hs
+++ b/GUI/GtkUtils.hs
@@ -82,20 +82,19 @@ import Static.GTheory
 
 import Common.DocUtils (showDoc)
 import Common.IO
-import Common.Utils (getTempFile)
 
 import Control.Concurrent (forkIO)
 import Control.Monad (when)
 
 import qualified Data.Text as Text
 
-import System.Directory ( removeFile, doesFileExist
+import System.Directory ( doesFileExist
                         , canonicalizePath)
 import System.FilePath (takeFileName, takeDirectory)
 
 -- | Returns a GladeXML Object of a xmlstring.
 getGTKBuilder :: (String, String) -> IO Builder
-getGTKBuilder (name, xmlstr) = do
+getGTKBuilder (_, xmlstr) = do
   builder <- builderNew
   builderAddFromString builder xmlstr
   return builder

--- a/HasCASL/Logic_HasCASL.hs
+++ b/HasCASL/Logic_HasCASL.hs
@@ -37,7 +37,7 @@ import Logic.Logic
 import Common.Doc
 import Common.DocUtils
 
-import Data.Monoid
+import Data.Monoid ()
 
 data HasCASL = HasCASL deriving Show
 

--- a/LF/Logic_LF.hs
+++ b/LF/Logic_LF.hs
@@ -29,7 +29,7 @@ import Common.Result
 import Common.ExtSign
 
 import qualified Data.Map as Map
-import Data.Monoid
+import Data.Monoid ()
 
 data LF = LF deriving Show
 

--- a/Logic/Grothendieck.hs
+++ b/Logic/Grothendieck.hs
@@ -811,7 +811,7 @@ gsigIntersect _lg both gsig1@(G_sign lid1 (ExtSign _sigma1 _) _)
 homogeneousGsigIntersect :: Bool -> G_sign -> G_sign -> Result G_sign
 homogeneousGsigIntersect _both (G_sign lid1 sigma1@(ExtSign _sig1 syms1) _) (G_sign lid2 sigma2 _) = do
   sigma2'@(ExtSign sig2 _) <- coerceSign lid2 lid1 "Intersection of signatures" sigma2
-  sigma3@(ExtSign sig3 _) <- ext_signature_intersect lid1 sigma1 sigma2'
+  ExtSign sig3 _ <- ext_signature_intersect lid1 sigma1 sigma2'
   let syms2 = symset_of lid1 sig2
       symI = Set.intersection syms1 syms2
   return $ G_sign lid1

--- a/Logic/Logic.hs
+++ b/Logic/Logic.hs
@@ -1,5 +1,11 @@
-{-# LANGUAGE MultiParamTypeClasses, FunctionalDependencies, DeriveDataTypeable
-  , FlexibleInstances, UndecidableInstances, ExistentialQuantification #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE MonoLocalBinds #-}
 {- |
 Module      :  ./Logic/Logic.hs
 Description :  central interface (type class) for logics in Hets
@@ -150,7 +156,7 @@ import Common.ToXml
 
 import qualified Data.Set as Set
 import qualified Data.Map as Map
-import Data.Monoid
+import Data.Monoid ()
 import Data.Ord
 import Data.Typeable
 import Control.Monad (unless)

--- a/Logic/Modification.hs
+++ b/Logic/Modification.hs
@@ -1,5 +1,9 @@
-{-# LANGUAGE MultiParamTypeClasses, FunctionalDependencies
-  , FlexibleInstances, UndecidableInstances, ExistentialQuantification #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE MonoLocalBinds #-}
 {- |
 Module      :  ./Logic/Modification.hs
 Description :  interface (type class) for comorphism modifications in Hets

--- a/Logic/Morphism.hs
+++ b/Logic/Morphism.hs
@@ -1,6 +1,11 @@
-{-# LANGUAGE MultiParamTypeClasses, FunctionalDependencies, DeriveDataTypeable
-  , FlexibleInstances, UndecidableInstances, OverlappingInstances
-  , ExistentialQuantification, GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {- |
 Module      :  ./Logic/Morphism.hs
 Description :  interface (type class) for logic projections (morphisms) in Hets
@@ -186,15 +191,17 @@ instance (Morphism cid
 -- default is ok
 
 newtype S2 s = S2 { sentence2 :: s }
-  deriving (Eq, Ord, Show, Typeable, Data, ShATermConvertible, Pretty
-           , GetRange, ToJson, ToXml)
+  deriving (Eq, Ord, Show, Typeable, ShATermConvertible, Pretty, GetRange, Data)
+
+deriving instance {-# OVERLAPPING #-} Data a => ToJson (S2 a)
+deriving instance {-# OVERLAPPING #-} Data a => ToXml (S2 a)
 
 instance (Morphism cid
             lid1 sublogics1 basic_spec1 sentence1 symb_items1 symb_map_items1
                 sign1 morphism1 sign_symbol1 symbol1 proof_tree1
             lid2 sublogics2 basic_spec2 sentence2 symb_items2 symb_map_items2
                 sign2 morphism2 sign_symbol2 symbol2 proof_tree2
-         , Category sign1 morphism1, Ord sign_symbol1, GetRange sign_symbol1)
+         , Category sign1 morphism1, Ord sign_symbol1, GetRange sign_symbol1, Data sentence2)
     => Sentences (SpanDomain cid) (S2 sentence2) sign1 morphism1
        sign_symbol1 where
 
@@ -223,7 +230,7 @@ instance (Morphism cid
                 sign1 morphism1 sign_symbol1 symbol1 proof_tree1
             lid2 sublogics2 basic_spec2 sentence2 symb_items2 symb_map_items2
                 sign2 morphism2 sign_symbol2 symbol2 proof_tree2
-         , Ord symbol1, GetRange symbol1, Pretty symbol1, Typeable symbol1)
+         , Ord symbol1, GetRange symbol1, Pretty symbol1, Typeable symbol1, Data sentence2)
         => StaticAnalysis (SpanDomain cid) () (S2 sentence2) () ()
            sign1 morphism1 sign_symbol1 symbol1 where
  ensures_amalgamability l _ = statFail l "ensures_amalgamability"
@@ -247,14 +254,14 @@ instance (SemiLatticeWithTop sublogics1, SemiLatticeWithTop sublogics2)
             lub (SublogicsPair x1 y1) (SublogicsPair x2 y2) =
                 SublogicsPair (lub x1 x2) (lub y1 y2)
 
-instance (SemiLatticeWithTop sublogics1, MinSublogic sublogics2 sentence2)
+instance {-# OVERLAPS #-} (SemiLatticeWithTop sublogics1, MinSublogic sublogics2 sentence2)
   => MinSublogic (SublogicsPair sublogics1 sublogics2) (S2 sentence2) where
   minSublogic (S2 sen2) = SublogicsPair top (minSublogic sen2)
 
 {- just a dummy implementation, it should be the sublogic of sen2 in J
 paired with its image through morMapSublogicSen? -}
 
-instance (MinSublogic sublogics1 alpha, SemiLatticeWithTop sublogics2)
+instance {-# OVERLAPS #-} (MinSublogic sublogics1 alpha, SemiLatticeWithTop sublogics2)
          => MinSublogic (SublogicsPair sublogics1 sublogics2) alpha where
   minSublogic x = SublogicsPair (minSublogic x) top
 
@@ -294,13 +301,13 @@ instance (SublogicName sublogics1, SublogicName sublogics2)
            in if null s1 then s2 else if null s2 then s1 else
               s1 ++ "|" ++ s2
 
-instance ( MinSublogic sublogics1 ()
+instance (MinSublogic sublogics1 ()
          , Morphism cid
             lid1 sublogics1 basic_spec1 sentence1 symb_items1 symb_map_items1
                 sign1 morphism1 sign_symbol1 symbol1 proof_tree1
             lid2 sublogics2 basic_spec2 sentence2 symb_items2 symb_map_items2
                 sign2 morphism2 sign_symbol2 symbol2 proof_tree2
-         , Ord proof_tree2, Show proof_tree2)
+         , Ord proof_tree2, Show proof_tree2, Data sentence2)
          => Logic (SpanDomain cid) (SublogicsPair sublogics1 sublogics2) ()
           (S2 sentence2) () () sign1 morphism1 sign_symbol1 symbol1 proof_tree2
     where

--- a/Maude/Logic_Maude.hs
+++ b/Maude/Logic_Maude.hs
@@ -16,7 +16,6 @@ module Maude.Logic_Maude where
 
 import Logic.Logic
 
-import Common.Doc
 import Common.DocUtils
 
 import Maude.AS_Maude (MaudeText (..))
@@ -36,7 +35,7 @@ import Maude.Shellout
 import Common.AS_Annotation
 import Common.ExtSign
 
-import Data.Monoid
+import Data.Monoid ()
 
 import System.IO.Unsafe
 

--- a/Maude/Meta/HasSorts.hs
+++ b/Maude/Meta/HasSorts.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE OverlappingInstances, TypeSynonymInstances #-}
+{-# LANGUAGE TypeSynonymInstances #-}
 {- |
 Module      :  ./Maude/Meta/HasSorts.hs
 Description :  Accessing the Sorts of Maude data types
@@ -79,7 +79,7 @@ instance (Ord a, HasSorts a) => HasSorts (Set a) where
     getSorts = Set.fold (Set.union . getSorts) Set.empty
     mapSorts = Set.map . mapSorts
 
-instance (Ord a, HasSorts a) => HasSorts (Map k a) where
+instance {-# OVERLAPS #-} (Ord a, HasSorts a) => HasSorts (Map k a) where
     getSorts = Map.foldr (Set.union . getSorts) Set.empty
     mapSorts = Map.map . mapSorts
 

--- a/Maude/Sign.hs
+++ b/Maude/Sign.hs
@@ -136,7 +136,7 @@ instance HasSorts Sign where
         sentences = mapSorts mp $ sentences sign -}
     }
 
-instance HasSorts KindRel where
+instance {-# OVERLAPS #-} HasSorts KindRel where
     getSorts = getSortsKindRel
     mapSorts = renameSortKindRel
 

--- a/OWL2/ParseOWL.hs
+++ b/OWL2/ParseOWL.hs
@@ -16,7 +16,7 @@ import OWL2.AS
 
 import qualified Data.ByteString.Lazy as L
 import Data.List
-import Data.Maybe
+import Data.Maybe ()
 import qualified Data.Map as Map
 
 import Common.XmlParser

--- a/OWL2/ProveHermit.hs
+++ b/OWL2/ProveHermit.hs
@@ -25,8 +25,6 @@ import Logic.Prover
 
 import OWL2.Morphism
 import OWL2.Sign
-import OWL2.Profiles
-import OWL2.Sublogic
 import OWL2.ProfilesAndSublogics
 import OWL2.ProverState
 import OWL2.AS

--- a/PGIP/GraphQL/Resolver/DGraph.hs
+++ b/PGIP/GraphQL/Resolver/DGraph.hs
@@ -20,7 +20,7 @@ import Database.Esqueleto
 import Control.Monad.IO.Class (MonadIO (..))
 
 resolve :: HetcatsOpts -> Cache -> String -> IO (Maybe GraphQLResult.Result)
-resolve opts sessionReference locIdVar =
+resolve opts _ locIdVar =
   onDatabase (databaseConfig opts) $ resolveDB locIdVar
 
 resolveDB :: MonadIO m => String -> DBMonad m (Maybe GraphQLResult.Result)

--- a/PGIP/GraphQL/Resolver/OMS.hs
+++ b/PGIP/GraphQL/Resolver/OMS.hs
@@ -25,7 +25,7 @@ import Control.Monad.IO.Class (MonadIO (..))
 import Control.Monad.Fail
 
 resolve :: HetcatsOpts -> Cache -> String -> IO (Maybe GraphQLResult.Result)
-resolve opts sessionReference locIdVar =
+resolve opts _ locIdVar =
   onDatabase (databaseConfig opts) $ resolveDB locIdVar
 
 resolveDB :: (MonadIO m, MonadFail m) => String -> DBMonad m (Maybe GraphQLResult.Result)

--- a/PGIP/GraphQL/Resolver/Serialization.hs
+++ b/PGIP/GraphQL/Resolver/Serialization.hs
@@ -15,7 +15,7 @@ import Database.Esqueleto
 import Control.Monad.IO.Class (MonadIO (..))
 
 resolve :: HetcatsOpts -> Cache -> String -> IO (Maybe GraphQLResult.Result)
-resolve opts sessionReference idVar =
+resolve opts _ idVar =
   onDatabase (databaseConfig opts) $ resolveDB idVar
 
 resolveDB :: MonadIO m => String -> DBMonad m (Maybe GraphQLResult.Result)

--- a/PGIP/GraphQL/Resolver/Signature.hs
+++ b/PGIP/GraphQL/Resolver/Signature.hs
@@ -18,7 +18,7 @@ import Database.Esqueleto
 import Control.Monad.IO.Class (MonadIO (..))
 
 resolve :: HetcatsOpts -> Cache -> Int -> IO (Maybe GraphQLResult.Result)
-resolve opts sessionReference idVar =
+resolve opts _ idVar =
   onDatabase (databaseConfig opts) $ resolveDB idVar
 
 resolveDB :: MonadIO m => Int -> DBMonad m (Maybe GraphQLResult.Result)

--- a/PGIP/GraphQL/Resolver/SignatureMorphism.hs
+++ b/PGIP/GraphQL/Resolver/SignatureMorphism.hs
@@ -23,7 +23,7 @@ import Control.Monad.IO.Class (MonadIO (..))
 import Control.Monad.Fail
 
 resolve :: HetcatsOpts -> Cache -> Int -> IO (Maybe GraphQLResult.Result)
-resolve opts sessionReference idVar =
+resolve opts _ idVar =
   onDatabase (databaseConfig opts) $ resolveDB idVar
 
 resolveDB :: (MonadIO m, MonadFail m) => Int -> DBMonad m (Maybe GraphQLResult.Result)

--- a/PGIP/GraphQL/Resolver/ToResult.hs
+++ b/PGIP/GraphQL/Resolver/ToResult.hs
@@ -68,7 +68,7 @@ conjectureToResult :: Entity DatabaseSchema.Sentence
                    -> [GraphQLResultReasoningAttempt.ReasoningAttempt]
                    -> GraphQLResultSentence.Sentence
 conjectureToResult (Entity _ sentenceValue) (Entity _ locIdBaseValue) fileRangeM
-  (Entity _ conjectureValue) actionResult symbolResults proofAttemptResults =
+  (Entity _ _) actionResult symbolResults proofAttemptResults =
   GraphQLResultSentence.Conjecture GraphQLResultConjecture.Conjecture
     { GraphQLResultConjecture.__typename = "Conjecture"
     , GraphQLResultConjecture.fileRange = fmap fileRangeToResult fileRangeM

--- a/PGIP/Output/Proof.hs
+++ b/PGIP/Output/Proof.hs
@@ -11,18 +11,18 @@ module PGIP.Output.Proof
   ) where
 
 import PGIP.Output.Formatting
-import PGIP.Output.Mime
+import PGIP.Output.Mime ()
 import PGIP.Output.Provers (Prover, prepareFormatProver)
 import PGIP.Shared
 
 import Interfaces.GenericATPState (tsTimeLimit, tsExtraOpts)
-import Logic.Comorphism (AnyComorphism)
+import Logic.Comorphism ()
 
 import qualified Logic.Prover as LP
 
-import Proofs.AbstractState (G_proof_tree, ProverOrConsChecker)
+import Proofs.AbstractState (G_proof_tree)
 
-import Common.Json (ppJson, asJson)
+import Common.Json (asJson)
 import Common.JSONOrXML
 import Common.ToXml (asXml)
 import Common.Utils (readMaybe)
@@ -32,7 +32,7 @@ import Data.Time.LocalTime
 
 import Numeric
 
-import Text.XML.Light (ppTopElement)
+import Text.XML.Light ()
 import Text.Printf (printf)
 
 type ProofFormatter =

--- a/Persistence/DBConfig.hs
+++ b/Persistence/DBConfig.hs
@@ -97,7 +97,7 @@ parseDatabaseConfig dbFile dbConfigFile subconfigKey performMigration =
 
     parseDBConfig :: BS.ByteString -> IO DBConfig
     parseDBConfig content =
-      let parsedContent = Yaml.decode content :: Maybe DBConfig
+      let parsedContent = Yaml.decodeThrow content :: Maybe DBConfig
       in case parsedContent of
         Nothing ->
           fail "Persistence.DBConfig: Could not parse database config file."
@@ -105,7 +105,7 @@ parseDatabaseConfig dbFile dbConfigFile subconfigKey performMigration =
 
     parseExtDBConfig :: String -> BS.ByteString -> IO DBConfig
     parseExtDBConfig key content =
-      let parsedContent = Yaml.decode content :: Maybe ExtDBConfig
+      let parsedContent = Yaml.decodeThrow content :: Maybe ExtDBConfig
       in case parsedContent of
         Nothing ->
           fail "Persistence.DBConfig: Could not parse database config file."

--- a/Persistence/Database.hs
+++ b/Persistence/Database.hs
@@ -17,7 +17,7 @@ import Control.Monad.Trans.Reader
 import Control.Monad.Logger
 import Control.Monad.IO.Unlift
 
-import Data.List (intercalate, isInfixOf)
+import Data.List (intercalate)
 import Data.Text (Text, pack)
 
 import Database.Persist.Sql

--- a/Propositional/Logic_Propositional.hs
+++ b/Propositional/Logic_Propositional.hs
@@ -50,7 +50,7 @@ import Common.ProofTree
 import Common.Id
 
 import qualified Data.Map as Map
-import Data.Monoid
+import Data.Monoid ()
 
 -- | Lid for propositional logic
 data Propositional = Propositional deriving Show

--- a/QBF/Logic_QBF.hs
+++ b/QBF/Logic_QBF.hs
@@ -47,7 +47,7 @@ import ATC.ProofTree ()
 import Common.ProofTree
 
 import qualified Data.Map as Map
-import Data.Monoid
+import Data.Monoid ()
 
 -- | Lid for propositional logic
 data QBF = QBF deriving Show

--- a/QVTR/Logic_QVTR.hs
+++ b/QVTR/Logic_QVTR.hs
@@ -22,7 +22,7 @@ import Logic.Logic
 
 import Common.DefaultMorphism
 
-import Data.Monoid
+import Data.Monoid ()
 
 data QVTR = QVTR deriving Show
 

--- a/RDF/StaticAnalysis.hs
+++ b/RDF/StaticAnalysis.hs
@@ -14,7 +14,7 @@ module RDF.StaticAnalysis where
 
 import qualified OWL2.AS as AS
 import Common.IRI
-import OWL2.Parse
+import OWL2.Parse ()
 import RDF.AS
 import RDF.Sign
 import RDF.Parse (predefinedPrefixes)
@@ -23,7 +23,7 @@ import Data.Maybe
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 
-import Text.ParserCombinators.Parsec hiding (State)
+import Text.ParserCombinators.Parsec ()
 
 import Common.AS_Annotation hiding (Annotation)
 import Common.Id

--- a/RelationalScheme/Logic_Rel.hs
+++ b/RelationalScheme/Logic_Rel.hs
@@ -17,7 +17,7 @@ module RelationalScheme.Logic_Rel where
 import Common.DocUtils
 import Common.Id
 
-import Data.Monoid
+import Data.Monoid ()
 import qualified Data.Set as Set
 
 import Logic.Logic

--- a/SoftFOL/Morphism.hs
+++ b/SoftFOL/Morphism.hs
@@ -19,7 +19,7 @@ import Common.Id
 
 import qualified Data.Set as Set
 import qualified Data.Map as Map
-import Data.Monoid
+import Data.Monoid ()
 
 symOf :: Sign -> Set.Set SFSymbol
 symOf sig =

--- a/Static/GTheory.hs
+++ b/Static/GTheory.hs
@@ -107,7 +107,7 @@ prettyGTheory sm g = case simplifyTh g of
 
 -- | compute sublogic of a theory
 sublogicOfTh :: G_theory -> G_sublogics
-sublogicOfTh theory@(G_theory lid _ sign@(ExtSign sigma _) _ sens _) =
+sublogicOfTh (G_theory lid _ (ExtSign sigma _) _ sens _) =
   let sub = sublogicOfTheo lid (sigma, sentence . snd <$> OMap.toList sens)
    in G_sublogics lid sub
 
@@ -169,9 +169,9 @@ joinG_sentences (G_theory lid1 syn sig1 ind sens1 _)
 
 -- | Intersect the sentences of two G_theories, G_sign is the intersection of their signatures
 intersectG_sentences :: Monad m => G_sign -> G_theory -> G_theory -> m G_theory
-intersectG_sentences gsig@(G_sign lidS signS indS) 
-                    (G_theory lid1 syn sig1 ind sens1 _)
-                    (G_theory lid2 _ sig2 _ sens2 _) = do
+intersectG_sentences (G_sign lidS signS indS)
+                    (G_theory lid1 _ _ _ sens1 _)
+                    (G_theory lid2 _ _ _ sens2 _) = do
   sens1' <- coerceThSens lid1 lidS "intersectG_sentences1" sens1
   sens2' <- coerceThSens lid2 lidS "intersectG_sentences2" sens2
   return $ G_theory lidS Nothing signS indS (intersectSens sens1' sens2') startThId

--- a/Static/PrintDevGraph.hs
+++ b/Static/PrintDevGraph.hs
@@ -395,6 +395,7 @@ instance Pretty GlobalEntry where
     AlignEntry ae -> pretty ae
     ArchOrRefEntry b ae -> (if b then topKey archS else keyword refinementS)
       <+> pretty ae
+    _ -> Doc.empty
 
 instance Pretty DGraph where
   pretty dg = vcat

--- a/Syntax/Parse_AS_Library.hs
+++ b/Syntax/Parse_AS_Library.hs
@@ -108,9 +108,6 @@ networkDefn l = do
     return . Network_defn name n
          . catRange $ [kGraph, kEqu, kEnd]
 
-emptyParams :: GENERICITY
-emptyParams = Genericity (Params []) (Imported []) nullRange
-
 -- CASL spec-defn or DOL OMSDefn
 specDefn :: LogicGraph -> AParser st LIB_ITEM
 specDefn l = do

--- a/THF/Logic_THF.hs
+++ b/THF/Logic_THF.hs
@@ -20,7 +20,7 @@ import ATC.ProofTree ()
 import Common.DefaultMorphism
 import Common.ProofTree
 
-import Data.Monoid
+import Data.Monoid ()
 import Data.Map (isSubmapOf)
 import qualified Data.Map (toList, foldr)
 import qualified Data.Set (fromList)

--- a/THF/Utils.hs
+++ b/THF/Utils.hs
@@ -44,7 +44,7 @@ import Common.Id (Token (..), Id, mkId, nullRange)
 import Common.AS_Annotation (Named, SenAttr (..))
 import Common.Result
 
-import Control.Applicative
+import Control.Applicative ()
 import Control.Monad.State
 import Control.Monad.Identity
 

--- a/TPTP/ConsChecker.hs
+++ b/TPTP/ConsChecker.hs
@@ -15,32 +15,13 @@ module TPTP.ConsChecker
 import Logic.Prover
 
 import Common.ProofTree
-import qualified Common.Result as Result
-import Common.AS_Annotation as AS_Anno
 import Common.SZSOntology
-import Common.Timing
-import Common.Utils
 
 import TPTP.Sign
 import TPTP.Morphism
-import TPTP.Translate
 import TPTP.Prover.ProverState
 import TPTP.Sublogic
 
-import GUI.GenericATP
-import Proofs.BatchProcessing
-import Interfaces.GenericATPState
-
-import System.Directory
-
-import Control.Monad (when)
-import qualified Control.Concurrent as Concurrent
-
-import Data.Char
-import Data.List
-import Data.Maybe
-
-import Data.Time.LocalTime (TimeOfDay, midnight)
 import Data.Time (timeToTimeOfDay)
 import Data.Time.Clock (secondsToDiffTime)
 import qualified SoftFOL.ProveDarwin as Darwin

--- a/TPTP/Logic_TPTP.hs
+++ b/TPTP/Logic_TPTP.hs
@@ -41,7 +41,7 @@ import Common.DefaultMorphism
 import Common.ProofTree
 import Logic.Logic as Logic
 
-import Data.Monoid
+import Data.Monoid ()
 import qualified Data.Set as Set
 import qualified SoftFOL.ProveDarwin as Darwin
 

--- a/TPTP/Translate.hs
+++ b/TPTP/Translate.hs
@@ -20,7 +20,6 @@ module TPTP.Translate
     ) where
 
 import Data.Char
-import qualified Data.Set as Set
 
 import Common.Id
 import Common.ProofUtils

--- a/Taxonomy/MMiSSOntologyGraph.hs
+++ b/Taxonomy/MMiSSOntologyGraph.hs
@@ -105,7 +105,7 @@ createNode gid ginfo _ nMap (nodeID, (name, _, objectType)) =
 
 createLink :: A.Descr -> A.GraphInfo -> A.NodeMapping -> LEdge String
            -> IO A.NodeMapping
-createLink gid ginfo nMap (node1, node2, edgeLabel) = do
+createLink gid ginfo nMap (node1, node2, edgeLabel_) = do
     dNodeID_1 <- case Map.lookup node1 nMap of
                    Nothing -> return (-1)
                    Just n -> return n
@@ -114,10 +114,10 @@ createLink gid ginfo nMap (node1, node2, edgeLabel) = do
                    Just n -> return n
     if dNodeID_1 == -1 || dNodeID_2 == -1 then return nMap else do
       A.Result _ err <-
-        if elem edgeLabel ["isa", "instanceOf", "livesIn", "proves"]
-        then A.addlink gid edgeLabel edgeLabel Nothing
+        if elem edgeLabel_ ["isa", "instanceOf", "livesIn", "proves"]
+        then A.addlink gid edgeLabel_ edgeLabel_ Nothing
              dNodeID_2 dNodeID_1 ginfo
-        else A.addlink gid edgeLabel edgeLabel Nothing
+        else A.addlink gid edgeLabel_ edgeLabel_ Nothing
              dNodeID_1 dNodeID_2 ginfo
       Data.Foldable.forM_ err putStr
       return nMap
@@ -372,27 +372,27 @@ getSubSuperSingle g showSuper newGr name =
         _ -> gr
     insPredecessorAndEdge :: ClassGraph -> ClassGraph -> LEdge String
                           -> ClassGraph
-    insPredecessorAndEdge oldGr newGr' (fromNode, toNode, edgeLabel) =
+    insPredecessorAndEdge oldGr newGr' (fromNode, toNode, edgeLabel_) =
       case fst $ match fromNode oldGr of
         Nothing -> newGr'
         Just (_, _, nodeLabel1, _) ->
            case match fromNode newGr' of
              (Nothing, _) ->
-                 ([], fromNode, nodeLabel1, [(edgeLabel, toNode)]) & newGr'
+                 ([], fromNode, nodeLabel1, [(edgeLabel_, toNode)]) & newGr'
              (Just (p, fromNodeID, nodeLabel2, s), newGr2) ->
-                 (p, fromNodeID, nodeLabel2, (edgeLabel, toNode) : s) & newGr2
+                 (p, fromNodeID, nodeLabel2, (edgeLabel_, toNode) : s) & newGr2
     insSuccessorAndEdge :: ClassGraph -> ClassGraph -> LEdge String
                         -> ClassGraph
-    insSuccessorAndEdge oldGr newGr' (fromNode, toNode, edgeLabel) =
+    insSuccessorAndEdge oldGr newGr' (fromNode, toNode, edgeLabel_) =
       case fst $ match toNode oldGr of
         Nothing -> newGr'
         Just (_, _, (nodeLabel1, _, _), _) ->
            case match toNode newGr' of
              (Nothing, _) ->
-              ([(edgeLabel, fromNode)], toNode, (nodeLabel1, "", OntoClass), [])
+              ([(edgeLabel_, fromNode)], toNode, (nodeLabel1, "", OntoClass), [])
               & newGr'
              (Just (p, toNodeID, nodeLabel2, s), newGr2) ->
-                 ((edgeLabel, fromNode) : p, toNodeID, nodeLabel2, s) & newGr2
+                 ((edgeLabel_, fromNode) : p, toNodeID, nodeLabel2, s) & newGr2
 
 getSubSuperClosure :: ClassGraph -> Bool -> ClassGraph -> String -> ClassGraph
 getSubSuperClosure g showSuper newGr name =

--- a/Temporal/Logic_Temporal.hs
+++ b/Temporal/Logic_Temporal.hs
@@ -15,7 +15,7 @@ Instance of class Logic for temporal logic
 
 module Temporal.Logic_Temporal where
 
-import Data.Monoid
+import Data.Monoid ()
 
 import Logic.Logic
 

--- a/TopHybrid/AS_TopHybrid.der.hs
+++ b/TopHybrid/AS_TopHybrid.der.hs
@@ -1,5 +1,6 @@
-{-# LANGUAGE ExistentialQuantification, DeriveDataTypeable
-  , OverlappingInstances #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE MonoLocalBinds #-}
 {- |
 Module      :  ./TopHybrid/AS_TopHybrid.der.hs
 License     :  GPLv2 or higher, see LICENSE.txt
@@ -26,7 +27,7 @@ import Logic.Logic
 import Unsafe.Coerce
 
 import Data.Data
-import Data.Monoid
+import Data.Monoid ()
 
 import Text.XML.Light
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -24,6 +24,7 @@
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
 resolver: lts-14.27
+# resolver: lts-16.31
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/utils/DrIFT-src/ParseLib2.hs
+++ b/utils/DrIFT-src/ParseLib2.hs
@@ -71,7 +71,6 @@ instance Monad Parser where
    -- >>=         :: Parser a -> (a -> Parser b) -> Parser b
    (P p) >>= f = P (\ pos inp -> concat [papply (f v) pos out
                                                 | (v, out) <- p pos inp])
-   fail _ = P (\ _ _ -> [])
 
 instance Alternative Parser where
    (<|>) = mplus


### PR DESCRIPTION
Remove majority of warnings appearing during Hets compilation. Warnings about deprecated imports of `network` package will be fixed in #2067. Motivated by https://github.com/spechub/Hets/issues/2065#issuecomment-1178183691. Works both with and without stack.

`Non-exhaustive pattern match` warning in file `Static/PrintDevGraph.hs` was handled by stub `_ -> Doc.empty`. Can be fixed later.