### PR TITLE
Corrections to nesypatterns printer

### DIFF
--- a/NeSyPatterns/Print.hs
+++ b/NeSyPatterns/Print.hs
@@ -23,11 +23,7 @@ instance Pretty Node where
     pretty = printNode
 
 printNode :: Node -> Doc
-printNode (Node mot mid _) =
-  let
-    ot = maybe empty pretty mot
-    id' = maybe empty (brackets . pretty) mid
-  in ot <> id'
+printNode (Node mot _ _) = maybe empty pretty mot
 
 printBasicSpec :: BASIC_SPEC -> Doc
 printBasicSpec (Basic_spec l) = vsep $ map (printAnnoted pretty) l

--- a/NeSyPatterns/Sign.hs
+++ b/NeSyPatterns/Sign.hs
@@ -100,13 +100,18 @@ isLegalSignature s =
   Rel.dom (edges s) `Set.isSubsetOf` nodes s
   && Rel.ran (edges s) `Set.isSubsetOf` nodes s
 
+-- | pretty printin for edge e.g. tuple (ResolvedNode, ResolvedNode)
+printEdge :: (ResolvedNode, ResolvedNode) -> Doc
+printEdge (node1, node2) =
+  fsep . punctuate (text " ->") $ map pretty [node1, node2]
+
 -- | pretty printing for Signatures
 printSign :: Sign -> Doc
-printSign s = 
+printSign s =
     hsep [sepBySemis $ map pretty $ Set.toList $ owlClasses s,
           sepBySemis $ map pretty $ Rel.toList $ owlTaxonomy s,
           sepBySemis $ map pretty $ Set.toList $ nodes s,
-          sepBySemis $ map pretty $ Rel.toList $ edges s,
+          sepBySemis $ map printEdge $ Rel.toList $ edges s,
           sepBySemis $ map pretty $ Map.toList $ idMap s]
 
 -- | Adds a node to the signature


### PR DESCRIPTION
Actually the only function from `NeSyPatterns/Print.hs` that is invoked is `printNode`. It is done when in `NeSyPatterns/Sign.hs` function `printSign` print edges. The signature of example has empty list of nodes, but `Rel.toList $ edges s` retuns next list of ResolvedNodes:
```haskell
[(ResolvedNode {resolvedOTerm = Model, resolvedNeSyId = __genid2, resolvedNodeRange = nullRange},ResolvedNode {resolvedOTerm = Symbol, resolvedNeSyId = __genid0, resolvedNodeRange = nullRange}),(ResolvedNode {resolvedOTerm = Symbol, resolvedNeSyId = __genid0, resolvedNodeRange = nullRange},ResolvedNode {resolvedOTerm = Training, resolvedNeSyId = __genid1, resolvedNodeRange = nullRange}),(ResolvedNode {resolvedOTerm = Training, resolvedNeSyId = __genid1, resolvedNodeRange = nullRange},ResolvedNode {resolvedOTerm = Model, resolvedNeSyId = __genid2, resolvedNodeRange = nullRange})]
```

I added function `printEdge` to `NeSyPatterns/Sign.hs`  and not to `NeSyPatterns/Print.hs` as edges are not part of abstract syntax.

Is that the solution we are looking for? Is it OK that signature of example has empty list of nodes?