### PR TITLE
isInfixOf import

### DIFF
--- a/Persistence/Database.hs
+++ b/Persistence/Database.hs
@@ -17,7 +17,7 @@ import Control.Monad.Trans.Reader
 import Control.Monad.Logger
 import Control.Monad.IO.Unlift
 
-import Data.List (intercalate)
+import Data.List (intercalate, isInfixOf)
 import Data.Text (Text, pack)
 
 import Database.Persist.Sql


### PR DESCRIPTION
Accidentally remove import of `isInfixOf` function. Preprocessor remove one of `#ifdef` branches that's why I got warning `function not used` but it is needed indeed.