### PR TITLE
fix errors while compiling dtdtohaskell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -675,7 +675,6 @@ distclean: clean_stack realclean clean_genRules
 		utils/appendHaskellPreludeString \
 		utils/DrIFT utils/genRules \
 		$(DTD2HS) \
-		utils/DtdToHaskell-src/DtdToHaskell \
 		utils/genItCorrections pretty/LaTeX_maps.hs pretty/words.pl.log \
 		docs
 

--- a/utils/DrIFT-src/ParseLib2.hs
+++ b/utils/DrIFT-src/ParseLib2.hs
@@ -45,7 +45,7 @@ module ParseLib2
 import Data.Char
 import Control.Applicative
 import Control.Monad
--- import Control.Monad.Fail
+import Control.Monad.Fail
 
 infixr 5 +++
 

--- a/utils/DtdToHaskell-src/DtdToHaskell/Instance.hs
+++ b/utils/DtdToHaskell-src/DtdToHaskell/Instance.hs
@@ -7,8 +7,6 @@ import Data.List (intersperse)
 import DtdToHaskell.TypeDef
 import Text.PrettyPrint.HughesPJ as PP
 
-import Debug.Trace
-
 {- | Convert typedef to appropriate instance declaration, either @XmlContent@,
 @XmlAttributes@, or @XmlAttrType@. -}
 mkInstance :: TypeDef -> Doc
@@ -20,7 +18,7 @@ mkInstance (DataDef _ n fs []) =
         topatval = if null fs then ppHName n else topat
     in
     text "instance HTypeable" <+> ppHName n <+> text "where" $$
-    nest 4 ( trace "-- HERE!" $ text "toHType _ = Defined \"" PP.<> ppXName n
+    nest 4 (text "toHType _ = Defined \"" PP.<> ppXName n
              PP.<> text "\" [] []" )
     $$
     text "instance XmlContent" <+> ppHName n <+> text "where" $$


### PR DESCRIPTION
Problems compiling Hets on master. Next sequence of commands fails:

1. `make distclean`
2. `make utils/DtdToHaskell` or `make Isabelle/IsaExport.hs`

This PR intends to fix it.