### PR TITLE
2131 for the python api have a uniform datatype for sentences

### DIFF
--- a/ATC/Sml_cats.hs
+++ b/ATC/Sml_cats.hs
@@ -1189,7 +1189,7 @@ instance ATermConvertibleSML SPEC where
         case aterm of
             (ShAAppl "basic" [ aa ] _) ->
                 let
-                aa' = from_sml_ShATerm (getATermByIndex1 aa att)
+                aa' = from_sml_ShATerm (getATermByIndex1 aa att) :: CASLBasicSpec
                 aa'' = G_basic_spec CASL aa'
                 in group (Syntax.AS_Structured.Basic_spec aa''
                           nullRange) group_flag

--- a/Common/InjMap.hs
+++ b/Common/InjMap.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveDataTypeable, DeriveGeneric #-}
 {- |
 Module      :  ./Common/InjMap.hs
 Description :  injective maps
@@ -32,11 +32,13 @@ module Common.InjMap
 import Data.Data
 import qualified Data.Map as Map
 
+import GHC.Generics (Generic)
+
 -- | the data type of injective maps
 data InjMap a b = InjMap
     { getAToB :: Map.Map a b -- ^ the actual injective map
     , getBToA :: Map.Map b a -- ^ the inverse map
-    } deriving (Show, Eq, Ord, Typeable, Data)
+    } deriving (Show, Eq, Ord, Typeable, Data, Generic)
 
 -- | for serialization only
 unsafeConstructInjMap :: Map.Map a b -> Map.Map b a -> InjMap a b

--- a/Common/Json/ConvInstances.hs
+++ b/Common/Json/ConvInstances.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE StandaloneDeriving, DeriveGeneric, FlexibleInstances, UndecidableInstances #-}
+module Common.Json.ConvInstances where
+    
+import Data.Aeson
+import GHC.Generics
+import Common.Lib.SizedList as SizedList
+import Common.Json.Instances()
+import qualified Common.Lib.Rel as Rel
+import qualified Common.Lib.MapSet as MapSet
+import qualified Common.InjMap as InjMap
+import qualified Data.Relation as DRel
+import qualified Data.Relation.Internal as DRelInt
+import System.Time
+
+deriving instance Generic ClockTime
+deriving instance (Generic a, Generic b) => Generic (DRelInt.Relation a b)
+
+instance ToJSON a => ToJSON (SizedList.SizedList a)
+instance (Ord a, ToJSON a, Ord b, ToJSON b, ToJSONKey a, ToJSONKey b) => ToJSON (InjMap.InjMap a b) where
+instance (Ord a, ToJSON a, Ord b, ToJSON b, ToJSONKey a) => ToJSON (MapSet.MapSet a b) where
+instance (Ord a, ToJSON a, ToJSONKey a) => ToJSON (Rel.Rel a) where
+instance (Ord a, Ord b, Generic a, Generic b, ToJSON a, ToJSON b, ToJSONKey a, ToJSONKey b) => ToJSON (DRel.Relation a b) where
+instance ToJSON ClockTime where
+
+instance FromJSON a => FromJSON (SizedList.SizedList a)
+instance (Ord a, FromJSON a, Ord b, FromJSON b, FromJSONKey a, FromJSONKey b) => FromJSON (InjMap.InjMap a b) where
+instance (Ord a, FromJSON a, Ord b, FromJSON b, FromJSONKey a) => FromJSON (MapSet.MapSet a b) where
+instance (Ord a, FromJSON a, FromJSONKey a) => FromJSON (Rel.Rel a) where
+instance (Ord a, Ord b, Generic a, Generic b, FromJSON a, FromJSON b, FromJSONKey a, FromJSONKey b) => FromJSON (DRel.Relation a b) where
+instance FromJSON ClockTime where

--- a/Common/Json/Instances.hs
+++ b/Common/Json/Instances.hs
@@ -1,0 +1,8 @@
+{-# LANGUAGE StandaloneDeriving, DeriveGeneric, FlexibleInstances, UndecidableInstances #-}
+module Common.Json.Instances () where
+
+import GHC.Generics
+import Data.Aeson
+
+instance {-# OVERLAPS #-} (Generic a, ToJSON a) => ToJSONKey a where
+instance {-# OVERLAPS #-} (Generic a, FromJSON a) => FromJSONKey a where

--- a/Common/Json/Instances.hs
+++ b/Common/Json/Instances.hs
@@ -4,5 +4,8 @@ module Common.Json.Instances () where
 import GHC.Generics
 import Data.Aeson
 
+instance {-# OVERLAPS #-} (Generic a, GToJSON Zero (Rep a)) => ToJSON a where
+instance {-# OVERLAPS #-} (Generic a, GFromJSON Zero (Rep a)) => FromJSON a where
+
 instance {-# OVERLAPS #-} (Generic a, ToJSON a) => ToJSONKey a where
 instance {-# OVERLAPS #-} (Generic a, FromJSON a) => FromJSONKey a where

--- a/Common/Lib/MapSet.hs
+++ b/Common/Lib/MapSet.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveDataTypeable, DeriveGeneric #-}
 {- |
 Module      :  ./Common/Lib/MapSet.hs
 Description :  Maps of sets
@@ -66,6 +66,8 @@ import qualified Data.Map as Map
 import qualified Data.Set as Set
 import qualified Data.List as List
 
+import GHC.Generics (Generic)
+
 -- * functions directly working over unwrapped maps of sets
 
 -- | remove empty elements from the map
@@ -124,7 +126,7 @@ imageSet m = Set.fromList . imageList m
 
 -- | a map to non-empty sets
 newtype MapSet a b = MapSet { toMap :: Map.Map a (Set.Set b) }
-  deriving (Eq, Ord, Typeable, Data)
+  deriving (Eq, Ord, Typeable, Data, Generic)
 
 instance (Show a, Show b) => Show (MapSet a b) where
     show = show . toMap

--- a/Common/Lib/Rel.hs
+++ b/Common/Lib/Rel.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveDataTypeable, DeriveGeneric #-}
 {- |
 Module      :  ./Common/Lib/Rel.hs
 Description :  Relations, based on maps
@@ -54,11 +54,13 @@ import qualified Data.Map as Map
 import qualified Data.Set as Set
 import qualified Data.List as List
 
+import GHC.Generics (Generic)
+
 import qualified Common.Lib.MapSet as MapSet
 
 -- | no invariant is ensured for relations!
 newtype Rel a = Rel { toMap :: Map.Map a (Set.Set a) }
-  deriving (Eq, Ord, Typeable, Data)
+  deriving (Eq, Ord, Typeable, Data, Generic)
 
 instance Show a => Show (Rel a) where
     show = show . toMap

--- a/Common/Lib/SizedList.hs
+++ b/Common/Lib/SizedList.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveDataTypeable, DeriveGeneric #-}
 {- |
 Module      :  ./Common/Lib/SizedList.hs
 Description :  lists with their size similar to Data.Edison.Seq.SizedSeq
@@ -36,7 +36,9 @@ import Prelude hiding (null, head, tail, reverse, take, drop, map)
 import Data.Data
 import qualified Data.List as List
 
-data SizedList a = N !Int [a] deriving (Show, Eq, Ord, Typeable, Data)
+import GHC.Generics (Generic)
+
+data SizedList a = N !Int [a] deriving (Show, Eq, Ord, Typeable, Data, Generic)
 
 fromList :: [a] -> SizedList a
 fromList xs = N (length xs) xs

--- a/DMU/Logic_DMU.hs
+++ b/DMU/Logic_DMU.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE MultiParamTypeClasses, FlexibleInstances, DeriveDataTypeable
-  , GeneralizedNewtypeDeriving #-}
+  , GeneralizedNewtypeDeriving, DeriveGeneric #-}
 {- |
 Module      :  ./DMU/Logic_DMU.hs
 Description :  Instance of class Logic for DMU
@@ -34,6 +34,7 @@ import Data.Monoid ()
 import qualified Data.Map as Map
 import qualified Data.Set as Set
 import Data.Typeable
+import GHC.Generics
 
 data DMU = DMU deriving Show
 
@@ -41,7 +42,7 @@ instance Language DMU where
   description _ = "a logic to wrap output of the CAD tool Catia"
 
 newtype Text = Text { fromText :: String }
-  deriving (Show, Eq, Ord, GetRange, Typeable, ShATermConvertible)
+  deriving (Show, Eq, Ord, GetRange, Typeable, ShATermConvertible, Generic)
 
 instance Pretty Text where
   pretty (Text s) = text s

--- a/Logic/Logic.hs
+++ b/Logic/Logic.hs
@@ -162,6 +162,8 @@ import Data.Typeable
 import Control.Monad (unless)
 import qualified Control.Monad.Fail as Fail
 
+import Data.Aeson (FromJSON, ToJSON)
+
 -- | Stability of logic implementations
 data Stability = Stable | Testing | Unstable | Experimental
      deriving (Eq, Show)
@@ -171,8 +173,8 @@ class ShATermConvertible a => Convertible a
 instance ShATermConvertible a => Convertible a
 
 -- | shortcut for class constraints
-class (Pretty a, Convertible a) => PrintTypeConv a
-instance (Pretty a, Convertible a) => PrintTypeConv a
+class (Pretty a, Convertible a, ToJSON a, FromJSON a) => PrintTypeConv a
+instance (Pretty a, Convertible a, ToJSON a, FromJSON a) => PrintTypeConv a
 
 -- | shortcut for class constraints with equality
 class (Eq a, PrintTypeConv a) => EqPrintTypeConv a

--- a/Logic/Morphism.hs
+++ b/Logic/Morphism.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE ExistentialQuantification #-}
@@ -43,6 +44,8 @@ import Common.AS_Annotation
 import Common.Id
 import Common.Json
 import Common.ToXml
+
+import GHC.Generics (Generic)
 
 class (Language cid,
        Logic lid1 sublogics1
@@ -191,7 +194,7 @@ instance (Morphism cid
 -- default is ok
 
 newtype S2 s = S2 { sentence2 :: s }
-  deriving (Eq, Ord, Show, Typeable, ShATermConvertible, Pretty, GetRange, Data)
+  deriving (Eq, Ord, Show, Typeable, ShATermConvertible, Pretty, GetRange, Data, Generic)
 
 deriving instance {-# OVERLAPPING #-} Data a => ToJson (S2 a)
 deriving instance {-# OVERLAPPING #-} Data a => ToXml (S2 a)

--- a/Makefile
+++ b/Makefile
@@ -352,13 +352,13 @@ FreeCAD_files = FreeCAD/As.hs
 
 OWL2_files = OWL2/AS.hs OWL2/Symbols.hs OWL2/Sign.hs \
   OWL2/Morphism.hs OWL2/ProfilesAndSublogics.hs OWL2/Sublogic.hs \
-  OWL2/Profiles.hs Common/IRI.hs
+  OWL2/Profiles.hs
 
 NeSyPatterns_files = NeSyPatterns/AS.hs NeSyPatterns/Symbol.hs \
   NeSyPatterns/Sign.hs NeSyPatterns/Morphism.hs
 
-RDF_files = RDF/AS.hs OWL2/AS.hs RDF/Symbols.hs RDF/Sign.hs RDF/Morphism.hs \
-  RDF/Sublogic.hs Common/IRI.hs
+RDF_files = RDF/AS.hs RDF/Symbols.hs RDF/Sign.hs RDF/Morphism.hs \
+  RDF/Sublogic.hs
 
 CSMOF_files = CSMOF/As.hs CSMOF/Sign.hs
 
@@ -459,7 +459,7 @@ FreeCAD/ATC_FreeCAD.der.hs: $(FreeCAD_files) $(GENRULES)
 	$(GENRULECALL) -i Common.ATerm.ConvInstances -i Common.Json.ConvInstances -o $@ $(FreeCAD_files)
 
 OWL2/ATC_OWL2.der.hs: $(OWL2_files) $(GENRULES)
-	$(GENRULECALL) -i ATC.Result -o $@ $(OWL2_files)
+	$(GENRULECALL) -i ATC.Result -i ATC.IRI -o $@ $(OWL2_files)
 
 NeSyPatterns/ATC_NeSyPatterns.der.hs: $(NeSyPatterns_files) $(GENRULES)
 	$(GENRULECALL) -i ATC.Result -i NeSyPatterns.ATC_Relation \

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,8 @@ GENITCORRECTIONS_deps = utils/itcor/GenItCorrections.hs
 
 PERL = perl
 GENRULES = utils/genRules
-GENRULECALL = $(GENRULES) -r ShATermConvertible \
+GENRULECALL = $(GENRULES) -r ShATermConvertible -r Json \
+	-i "GHC.Generics(Generic)" -i "Data.Aeson(ToJSON, FromJSON)" \
     -i ATerm.Lib
 
 GENRULECALL2 = $(GENRULES) -r ShATermLG \
@@ -246,16 +247,16 @@ ATC/ProofTree.der.hs: Common/ProofTree.hs $(GENRULES)
 	$(GENRULECALL) -o $@ $<
 
 ATC/AS_Annotation.der.hs: Common/AS_Annotation.der.hs $(GENRULES)
-	$(GENRULECALL) -i ATC.IRI -i Common.ATerm.ConvInstances -o $@ $<
+	$(GENRULECALL) -i ATC.IRI -i Common.ATerm.ConvInstances -i Common.Json.ConvInstances -o $@ $<
 
 ATC/Consistency.der.hs: Common/Consistency.hs $(GENRULES)
 	$(GENRULECALL) -x Common.Consistency.ConservativityChecker -o $@ $<
 
 ATC/LibName.der.hs: Common/LibName.hs $(GENRULES)
-	$(GENRULECALL) -i ATC.IRI -i Common.ATerm.ConvInstances -o $@ $<
+	$(GENRULECALL) -i ATC.IRI -i Common.ATerm.ConvInstances -i Common.Json.ConvInstances -o $@ $<
 
 ATC/ExtSign.der.hs: Common/ExtSign.hs $(GENRULES)
-	$(GENRULECALL) -i Common.ATerm.ConvInstances -o $@ $<
+	$(GENRULECALL) -i Common.ATerm.ConvInstances -i Common.Json.ConvInstances -o $@ $<
 
 ATC/DefaultMorphism.der.hs: Common/DefaultMorphism.hs $(GENRULES)
 	$(GENRULECALL) -o $@ $<
@@ -349,7 +350,7 @@ THF_files = THF/As.hs THF/Cons.hs THF/Sign.hs THF/Sublogic.hs
 
 FreeCAD_files = FreeCAD/As.hs
 
-OWL2_files = OWL2/AS.hs OWL2/Symbols.hs OWL2/Sign.hs OWL2/MS.hs \
+OWL2_files = OWL2/AS.hs OWL2/Symbols.hs OWL2/Sign.hs \
   OWL2/Morphism.hs OWL2/ProfilesAndSublogics.hs OWL2/Sublogic.hs \
   OWL2/Profiles.hs Common/IRI.hs
 
@@ -455,7 +456,7 @@ THF/ATC_THF.der.hs: $(THF_files) $(GENRULES)
 	$(GENRULECALL) -i ATC.Id -i ATC.GlobalAnnotations -o $@ $(THF_files)
 
 FreeCAD/ATC_FreeCAD.der.hs: $(FreeCAD_files) $(GENRULES)
-	$(GENRULECALL) -i Common.ATerm.ConvInstances -o $@ $(FreeCAD_files)
+	$(GENRULECALL) -i Common.ATerm.ConvInstances -i Common.Json.ConvInstances -o $@ $(FreeCAD_files)
 
 OWL2/ATC_OWL2.der.hs: $(OWL2_files) $(GENRULES)
 	$(GENRULECALL) -i ATC.Result -o $@ $(OWL2_files)
@@ -468,10 +469,10 @@ RDF/ATC_RDF.der.hs: $(RDF_files) $(GENRULES)
 	$(GENRULECALL) -i ATC.Result -o $@ $(RDF_files)
 
 CSMOF/ATC_CSMOF.der.hs: $(CSMOF_files) $(GENRULES)
-	$(GENRULECALL) -i Common.ATerm.ConvInstances -o $@ $(CSMOF_files)
+	$(GENRULECALL) -i Common.ATerm.ConvInstances -i Common.Json.ConvInstances -o $@ $(CSMOF_files)
 
 QVTR/ATC_QVTR.der.hs: $(QVTR_files) CSMOF/ATC_CSMOF.hs $(GENRULES)
-	$(GENRULECALL) -i CSMOF.ATC_CSMOF -i Common.ATerm.ConvInstances \
+	$(GENRULECALL) -i CSMOF.ATC_CSMOF -i Common.ATerm.ConvInstances -i Common.Json.ConvInstances \
  -o $@ $(QVTR_files)
 
 TPTP/ATC_TPTP.der.hs: $(TPTP_files) $(GENRULES)

--- a/OWL2/AS.hs
+++ b/OWL2/AS.hs
@@ -1106,7 +1106,7 @@ data OntologySyntaxType = MS | AS | XML
 data OntologyMetadata = OntologyMetadata {
   syntaxType :: OntologySyntaxType
   -- might be extended 
-} deriving  (Show, Eq, Ord, Data, Typeable)
+  } deriving  (Show, Eq, Ord, Data, Typeable)
 
 changeSyntax :: OntologySyntaxType -> OntologyDocument -> OntologyDocument
 changeSyntax t o@(OntologyDocument m _ _) = o {
@@ -1117,7 +1117,7 @@ data OntologyDocument = OntologyDocument {
     ontologyMetadata :: OntologyMetadata 
   , prefixDeclaration :: GA.PrefixMap
   , ontology :: Ontology
-}
+  }
   deriving  (Show, Eq, Ord, Data, Typeable)
 
 data PrefixDeclaration = PrefixDeclaration PrefixName IRI
@@ -1133,5 +1133,5 @@ data Ontology = Ontology {
   , importsDocuments :: DirectlyImportsDocuments
   , ontologyAnnotation:: OntologyAnnotations
   , axioms :: [Axiom]
-}
+  }
   deriving  (Show, Eq, Ord, Data)

--- a/OWL2/Logic_OWL2.hs
+++ b/OWL2/Logic_OWL2.hs
@@ -16,6 +16,7 @@ Here is the place where the class Logic is instantiated for OWL2.
 module OWL2.Logic_OWL2 where
 
 import ATC.ProofTree ()
+import OWL2.ATC_OWL2 ()
 
 import Common.AS_Annotation as Anno
 import Common.Consistency
@@ -65,14 +66,6 @@ import ATerm.Conversion
 
 data OWL2 = OWL2
 
-instance ShATermConvertible SymbItems
-instance ShATermConvertible SymbMapItems
-instance ShATermConvertible Sign
-instance ShATermConvertible Axiom
-instance ShATermConvertible OntologyDocument
-instance ShATermConvertible OWLMorphism
-instance ShATermConvertible Entity
-instance ShATermConvertible ProfSub
 
 instance Show OWL2 where
   show _ = "OWL"

--- a/OWL2/Profiles.hs
+++ b/OWL2/Profiles.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveDataTypeable, DeriveGeneric #-}
 {- |
 Module      :  ./OWL2/Profiles.hs
 Copyright   :  (c) Felix Gabriel Mance
@@ -33,11 +33,13 @@ import qualified Data.Set as Set
 
 import Common.IRI(setPrefix, mkIRI)
 
+import GHC.Generics (Generic)
+
 data Profiles = Profiles
     { outsideEL :: Bool
     , outsideQL :: Bool
     , outsideRL :: Bool
-    } deriving (Show, Eq, Ord, Typeable, Data)
+    } deriving (Show, Eq, Ord, Typeable, Data, Generic)
 
 allProfiles :: [[Profiles]]
 allProfiles = [[bottomProfile]

--- a/OWL2/Profiles.hs
+++ b/OWL2/Profiles.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveDataTypeable, DeriveGeneric #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 {- |
 Module      :  ./OWL2/Profiles.hs
 Copyright   :  (c) Felix Gabriel Mance
@@ -14,7 +14,7 @@ References  :  <http://www.w3.org/TR/owl2-profiles/>
 -}
 
 module OWL2.Profiles
-    ( Profiles
+    ( Profiles(..)
     , bottomProfile
     , topProfile
     , allProfiles
@@ -33,13 +33,11 @@ import qualified Data.Set as Set
 
 import Common.IRI(setPrefix, mkIRI)
 
-import GHC.Generics (Generic)
-
 data Profiles = Profiles
     { outsideEL :: Bool
     , outsideQL :: Bool
     , outsideRL :: Bool
-    } deriving (Show, Eq, Ord, Typeable, Data, Generic)
+    } deriving (Show, Eq, Ord, Typeable, Data)
 
 allProfiles :: [[Profiles]]
 allProfiles = [[bottomProfile]

--- a/PGIP/GraphQL/Resolver/OMS.hs
+++ b/PGIP/GraphQL/Resolver/OMS.hs
@@ -22,7 +22,7 @@ import Persistence.Utils
 import Database.Esqueleto
 
 import Control.Monad.IO.Class (MonadIO (..))
-import Control.Monad.Fail
+import Control.Monad.Fail ()
 
 resolve :: HetcatsOpts -> Cache -> String -> IO (Maybe GraphQLResult.Result)
 resolve opts _ locIdVar =

--- a/PGIP/GraphQL/Resolver/SignatureMorphism.hs
+++ b/PGIP/GraphQL/Resolver/SignatureMorphism.hs
@@ -20,7 +20,7 @@ import Persistence.Schema as DatabaseSchema
 import Database.Esqueleto
 
 import Control.Monad.IO.Class (MonadIO (..))
-import Control.Monad.Fail
+import Control.Monad.Fail ()
 
 resolve :: HetcatsOpts -> Cache -> Int -> IO (Maybe GraphQLResult.Result)
 resolve opts _ idVar =

--- a/RDF/AS.hs
+++ b/RDF/AS.hs
@@ -21,6 +21,7 @@ module RDF.AS where
 import Common.Id
 import Common.IRI
 import qualified OWL2.AS as AS
+import OWL2.ATC_OWL2 ()
 
 import Data.Data
 import Data.List

--- a/RDF/Logic_RDF.hs
+++ b/RDF/Logic_RDF.hs
@@ -40,16 +40,9 @@ import RDF.Morphism
 import RDF.Sublogic
 import RDF.StaticAnalysis
 import ATerm.Conversion
+import RDF.ATC_RDF ()
 
 data RDF = RDF deriving Show
-
-instance ShATermConvertible SymbItems
-instance ShATermConvertible SymbMapItems
-instance ShATermConvertible Sign
-instance ShATermConvertible Axiom
-instance ShATermConvertible TurtleDocument
-instance ShATermConvertible RDFMorphism
-instance ShATermConvertible RDFEntity
 
 instance Language RDF where
   language_name _ = "RDF"

--- a/TopHybrid/StatAna.hs
+++ b/TopHybrid/StatAna.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE ExistentialQuantification, OverloadedStrings #-}
 {- |
 Module      :  ./TopHybrid/StatAna.hs
 License     :  GPLv2 or higher, see LICENSE.txt
@@ -31,6 +31,7 @@ import Data.List
 import Data.Set
 import Unsafe.Coerce
 import ATerm.Lib
+import Data.Aeson(FromJSON, ToJSON, parseJSON, toJSON, object, (.=), Value(Null))
 
 bimap :: (t1 -> t2) -> (s1 -> s2) -> (t1, s1) -> (t2, s2)
 bimap f g (a, b) = (f a, g b)
@@ -235,3 +236,21 @@ instance ShATermConvertible Spc_Wrap where
 instance ShATermConvertible Frm_Wrap where
         toShATermAux att (Frm_Wrap _ f) = toShATermAux att f
         fromShATermAux _ _ = error "I entered here"
+
+
+
+instance ToJSON Sgn_Wrap where
+  toJSON (Sgn_Wrap _ s) = toJSON s
+  toJSON EmptySign = Null
+instance FromJSON Sgn_Wrap where
+  parseJSON = error "fromJSON not implemented for Sgn_Wrap"
+
+instance ToJSON Spc_Wrap where
+  toJSON (Spc_Wrap _ spec sen) = object ["spec" .= spec, "sen" .= sen]
+instance FromJSON Spc_Wrap where
+  parseJSON = error "fromJSON not implemented for Spc_Wrap"
+
+instance ToJSON Frm_Wrap where
+  toJSON (Frm_Wrap _ f) = toJSON f
+instance FromJSON Frm_Wrap where
+  parseJSON = error "fromJSON not implemented for Frm_Wrap"

--- a/utils/DrIFT-src/ParseLib2.hs
+++ b/utils/DrIFT-src/ParseLib2.hs
@@ -45,7 +45,7 @@ module ParseLib2
 import Data.Char
 import Control.Applicative
 import Control.Monad
-import Control.Monad.Fail
+import Control.Monad.Fail()
 
 infixr 5 +++
 

--- a/utils/DrIFT-src/RuleUtils.hs
+++ b/utils/DrIFT-src/RuleUtils.hs
@@ -75,8 +75,6 @@ commentBlock x = text "{-" <+> x <+> text "-}"
 
 -- Instances
 
-strippedName :: Data -> String
-strippedName = reverse . takeWhile (/= '.') . reverse . name
 
 -- instance header, handling class constraints etc.
 simpleInstance :: Class -> Data -> Doc
@@ -84,7 +82,7 @@ simpleInstance s d = hsep [text "instance"
                 , opt1 constr (\ x -> parenList x <+> text "=>")
                        ( \ x -> x <+> text "=>")
                 , text s
-                , opt1 (texts (strippedName d : vars d)) parenSpace id]
+                , opt1 (texts (name d : vars d)) parenSpace id]
    where
    constr = map (\ v -> text "Ord" <+> text v)
             (concatMap getSetVars . concatMap types $ body d)

--- a/utils/DrIFT-src/UserRulesHetCATS.hs
+++ b/utils/DrIFT-src/UserRulesHetCATS.hs
@@ -260,7 +260,7 @@ makeSpanFn b =
 
 binaryfn :: Bool -> Data -> Doc
 binaryfn forLG dat =
-  let dn = strippedName dat
+  let dn = name dat
       cs = body dat
       moreCs = length cs > 1
       u = text "u"
@@ -297,7 +297,7 @@ makeGetBinary forLG moreCs b i =
 -- begin of ShATermConvertible derivation
 shatermfn :: Bool -> Data -> Doc
 shatermfn forLG dat =
-  let dn = strippedName dat
+  let dn = name dat
       cs = body dat
       u = text "u"
   in instanceSkeleton (if forLG then "ShATermLG" else "ShATermConvertible")
@@ -359,7 +359,7 @@ makeFromShATerm forLG b =
 typeablefn :: Data -> Doc
 typeablefn dat =
     let vs = vars dat
-        dn = strippedName dat
+        dn = name dat
         ntext str = str ++ if null vs then "" else show $ length vs
         stext = text ("deriving instance Typeable " ++ dn)
     in if null vs then stext else
@@ -371,7 +371,7 @@ typeablefn dat =
 jsonfn :: Data ->Doc
 jsonfn dat =
     let vs = vars dat
-        dn = strippedName dat
+        dn = name dat
         typ = if null vs then text dn else parens . hsep . fmap text $ (dn : vs)
         gen = text "deriving instance GHC.Generics.Generic" <+> typ
 

--- a/utils/GenerateRules/GenerateRules.hs
+++ b/utils/GenerateRules/GenerateRules.hs
@@ -64,8 +64,8 @@ genRules flags files =
        if null ds then Fail.fail "no data types left" else
            writeFile outf . unlines $
              "{-# OPTIONS -w -O0 #-}"
-             : [ "{-# LANGUAGE CPP, StandaloneDeriving, DeriveDataTypeable #-}"
-               | elem "Typeable" rules ]
+             : [ "{-# LANGUAGE CPP, StandaloneDeriving, DeriveDataTypeable, DeriveGeneric #-}"
+               |  not . null $ rules \\ ["Typeable", "Json"] ]
              ++ ["{- |"
              , "Module      :  " ++ outf
              , "Description :  generated " ++ rule ++ " instances"
@@ -93,7 +93,7 @@ genRules flags files =
              , "module " ++ toModule outf ++ " () where"
              , "" ]
              ++ map ("import " ++)
-                     (Set.toList . Set.fromList $ imports ++ is)
+                     (Set.toList . Set.fromList $ imports ++ is ++ [ "Common.Json.Instances" | "Json" `elem` rules])
              ++ concatMap (\ r -> "" :
                 map (\ d -> "{-! for " ++ d ++ " derive : " ++ r ++ " !-}") ds
                           ) rules

--- a/utils/GenerateRules/GenerateRules.hs
+++ b/utils/GenerateRules/GenerateRules.hs
@@ -93,7 +93,10 @@ genRules flags files =
              , "module " ++ toModule outf ++ " () where"
              , "" ]
              ++ map ("import " ++)
-                     (Set.toList . Set.fromList $ imports ++ is ++ [ "Common.Json.Instances" | "Json" `elem` rules])
+                     (Set.toList . Set.fromList $
+                        [i |  i <- imports, not (toModule outf `isPrefixOf` i)]
+                        ++ is
+                        ++ [ "Common.Json.Instances" | "Json" `elem` rules])
              ++ concatMap (\ r -> "" :
                 map (\ d -> "{-! for " ++ d ++ " derive : " ++ r ++ " !-}") ds
                           ) rules


### PR DESCRIPTION
Closes #2131

Adds rules for deriving `GHC.Generic`, `Data.Aeson`s `FromJSON`, `ToJSON`, `FromJSONKey`, and `ToJSONKey` instances for all datatypes that are also convertible to ATerms.

With these changes, JSON can be used as interchange format between the python api and the haskell api.